### PR TITLE
Add .swarm file format for shareable dashboard import/export

### DIFF
--- a/backend/apps/dashboards/dashboards.py
+++ b/backend/apps/dashboards/dashboards.py
@@ -15,11 +15,12 @@ from backend.apps.dashboards.models import (
     ViewCardPosition,
     BrowserCardPosition,
 )
-from fastapi import HTTPException
+from fastapi import HTTPException, UploadFile, File
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
-from backend.config.paths import DASHBOARDS_DIR as DATA_DIR, SESSIONS_DIR, DASHBOARD_LAYOUT_DIR as OLD_LAYOUT_DIR
+from backend.config.paths import DASHBOARDS_DIR as DATA_DIR, SESSIONS_DIR, OUTPUTS_DIR, DASHBOARD_LAYOUT_DIR as OLD_LAYOUT_DIR
 
 OLD_LAYOUT_FILE = os.path.join(OLD_LAYOUT_DIR, "layout.json")
 
@@ -267,3 +268,110 @@ async def duplicate_dashboard(dashboard_id: str):
         json.dump(new_dashboard, f, indent=2)
 
     return new_dashboard
+
+
+SWARM_FORMAT_VERSION = 1
+
+
+@dashboards.router.get("/{dashboard_id}/export")
+async def export_dashboard(dashboard_id: str):
+    """Export a dashboard as a .swarm file (JSON with layout + referenced outputs)."""
+    dashboard = _load(dashboard_id)
+    data = dashboard.model_dump(mode="json")
+
+    # Collect referenced outputs for view cards
+    outputs = {}
+    view_cards = data.get("layout", {}).get("view_cards", {})
+    for vc in view_cards.values():
+        output_id = vc.get("output_id")
+        if output_id:
+            output_path = os.path.join(OUTPUTS_DIR, f"{output_id}.json")
+            if os.path.exists(output_path):
+                with open(output_path) as f:
+                    output_data = json.load(f)
+                # Strip thumbnails to keep file size down
+                output_data.pop("thumbnail", None)
+                outputs[output_id] = output_data
+
+    swarm = {
+        "swarm_version": SWARM_FORMAT_VERSION,
+        "dashboard": {
+            "name": data["name"],
+            "layout": data["layout"],
+        },
+        "outputs": outputs,
+    }
+
+    # Strip thumbnails from dashboard too
+    swarm["dashboard"].pop("thumbnail", None)
+
+    return JSONResponse(
+        content=swarm,
+        headers={
+            "Content-Disposition": f'attachment; filename="{data["name"]}.swarm"',
+        },
+    )
+
+
+@dashboards.router.post("/import")
+async def import_dashboard(file: UploadFile = File(...)):
+    """Import a .swarm file and create a new dashboard with remapped IDs."""
+    content = await file.read()
+    try:
+        swarm = json.loads(content)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid .swarm file: not valid JSON")
+
+    version = swarm.get("swarm_version")
+    if not version or version > SWARM_FORMAT_VERSION:
+        raise HTTPException(status_code=400, detail="Unsupported .swarm file version")
+
+    dash_data = swarm.get("dashboard")
+    if not dash_data:
+        raise HTTPException(status_code=400, detail="Invalid .swarm file: missing dashboard data")
+
+    # Remap output IDs so imports don't collide with existing outputs
+    output_id_map = {}  # old_id -> new_id
+    imported_outputs = swarm.get("outputs", {})
+    os.makedirs(OUTPUTS_DIR, exist_ok=True)
+    for old_id, output_data in imported_outputs.items():
+        new_id = uuid4().hex
+        output_id_map[old_id] = new_id
+        output_data["id"] = new_id
+        now = datetime.now().isoformat()
+        output_data["created_at"] = now
+        output_data["updated_at"] = now
+        with open(os.path.join(OUTPUTS_DIR, f"{new_id}.json"), "w") as f:
+            json.dump(output_data, f, indent=2)
+
+    # Rebuild layout with remapped IDs
+    layout_data = dash_data.get("layout", {})
+
+    # Remap view_cards output IDs
+    new_view_cards = {}
+    for key, vc in layout_data.get("view_cards", {}).items():
+        old_output_id = vc.get("output_id", "")
+        new_output_id = output_id_map.get(old_output_id, old_output_id)
+        vc["output_id"] = new_output_id
+        new_view_cards[new_output_id] = vc
+    layout_data["view_cards"] = new_view_cards
+
+    # Clear agent cards (sessions are not portable)
+    layout_data["cards"] = {}
+    layout_data["expanded_session_ids"] = []
+
+    # Remap browser card IDs
+    new_browser_cards = {}
+    for _key, bc in layout_data.get("browser_cards", {}).items():
+        new_browser_id = uuid4().hex
+        bc["browser_id"] = new_browser_id
+        new_browser_cards[new_browser_id] = bc
+    layout_data["browser_cards"] = new_browser_cards
+
+    dashboard = Dashboard(
+        name=f"{dash_data.get('name', 'Imported Dashboard')} (imported)",
+        layout=DashboardLayout(**layout_data),
+    )
+    _save(dashboard)
+
+    return dashboard.model_dump(mode="json")

--- a/frontend/src/app/pages/DashboardSelection/DashboardSelection.tsx
+++ b/frontend/src/app/pages/DashboardSelection/DashboardSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -17,6 +17,8 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EditIcon from '@mui/icons-material/Edit';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import SearchIcon from '@mui/icons-material/Search';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 import {
   fetchDashboards,
@@ -24,6 +26,8 @@ import {
   deleteDashboard,
   duplicateDashboard,
   renameDashboard,
+  exportDashboard,
+  importDashboard,
   Dashboard,
 } from '@/shared/state/dashboardsSlice';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
@@ -52,6 +56,7 @@ const DashboardSelection: React.FC = () => {
   const [menuDashboard, setMenuDashboard] = useState<Dashboard | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     dispatch(fetchDashboards());
@@ -113,6 +118,26 @@ const DashboardSelection: React.FC = () => {
     setRenamingId(null);
   };
 
+  const handleExport = () => {
+    if (menuDashboard) dispatch(exportDashboard(menuDashboard.id));
+    handleCloseMenu();
+  };
+
+  const handleImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const result = await dispatch(importDashboard(file));
+    if (importDashboard.fulfilled.match(result)) {
+      navigate(`/dashboard/${result.payload.id}`);
+    }
+    // Reset input so the same file can be re-imported
+    e.target.value = '';
+  };
+
   return (
     <Box sx={{ height: '100%', overflow: 'auto', p: 4 }}>
       <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
@@ -132,21 +157,46 @@ const DashboardSelection: React.FC = () => {
               Monitor and manage your agents from a single workspace.
             </Typography>
           </Box>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={handleCreate}
-            sx={{
-              bgcolor: c.accent.primary,
-              borderRadius: 2,
-              textTransform: 'none',
-              fontWeight: 500,
-              px: 2.5,
-              '&:hover': { bgcolor: c.accent.hover },
-            }}
-          >
-            New dashboard
-          </Button>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".swarm"
+              style={{ display: 'none' }}
+              onChange={handleFileSelected}
+            />
+            <Button
+              variant="outlined"
+              startIcon={<FileUploadIcon />}
+              onClick={handleImport}
+              sx={{
+                borderColor: c.border.medium,
+                color: c.text.secondary,
+                borderRadius: 2,
+                textTransform: 'none',
+                fontWeight: 500,
+                px: 2.5,
+                '&:hover': { borderColor: c.accent.primary, color: c.accent.primary },
+              }}
+            >
+              Import .swarm
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleCreate}
+              sx={{
+                bgcolor: c.accent.primary,
+                borderRadius: 2,
+                textTransform: 'none',
+                fontWeight: 500,
+                px: 2.5,
+                '&:hover': { bgcolor: c.accent.hover },
+              }}
+            >
+              New dashboard
+            </Button>
+          </Box>
         </Box>
 
         <Box sx={{ mb: 3 }}>
@@ -340,6 +390,10 @@ const DashboardSelection: React.FC = () => {
         <MenuItem onClick={handleDuplicate}>
           <ListItemIcon><ContentCopyIcon sx={{ fontSize: 18 }} /></ListItemIcon>
           <ListItemText>Duplicate</ListItemText>
+        </MenuItem>
+        <MenuItem onClick={handleExport}>
+          <ListItemIcon><FileDownloadIcon sx={{ fontSize: 18 }} /></ListItemIcon>
+          <ListItemText>Export as .swarm</ListItemText>
         </MenuItem>
         <MenuItem onClick={handleDelete} sx={{ color: c.status.error }}>
           <ListItemIcon><DeleteOutlineIcon sx={{ fontSize: 18, color: c.status.error }} /></ListItemIcon>

--- a/frontend/src/shared/state/dashboardsSlice.ts
+++ b/frontend/src/shared/state/dashboardsSlice.ts
@@ -82,6 +82,43 @@ export const updateDashboardThumbnail = createAsyncThunk(
   },
 );
 
+export const exportDashboard = createAsyncThunk(
+  'dashboards/export',
+  async (id: string) => {
+    const res = await fetch(`${DASHBOARDS_API}/${id}/export`);
+    if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+    const data = await res.json();
+    const name = data.dashboard?.name || 'dashboard';
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${name}.swarm`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    return id;
+  },
+);
+
+export const importDashboard = createAsyncThunk(
+  'dashboards/import',
+  async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch(`${DASHBOARDS_API}/import`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: 'Import failed' }));
+      throw new Error(err.detail || `Import failed: ${res.status}`);
+    }
+    return (await res.json()) as Dashboard;
+  },
+);
+
 export const generateDashboardName = createAsyncThunk(
   'dashboards/generateName',
   async (dashboardId: string) => {
@@ -139,6 +176,9 @@ const dashboardsSlice = createSlice({
           state.items[id].name = name;
           state.items[id].auto_named = auto_named;
         }
+      })
+      .addCase(importDashboard.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
       })
       .addCase(updateDashboardThumbnail.fulfilled, (state, action) => {
         const { id, thumbnail, updated_at } = action.payload;


### PR DESCRIPTION
## Summary

This PR introduces a `.swarm` file format that allows OpenSwarm users to **export and import dashboards** as portable files. This makes it easy to share workflows, workspace layouts, and view configurations across different OpenSwarm instances — no manual recreation needed.

### Why this matters

Right now, dashboards live locally and can't be shared between users or machines. If someone builds a useful monitoring layout with custom views and browser cards, there's no way to hand that to a teammate. The `.swarm` file format solves this by packaging everything needed to recreate a dashboard into a single file.

**Use cases:**
- Share a pre-built agent monitoring dashboard with your team
- Distribute template workspaces for common workflows (e.g. data analysis, code review)
- Back up and restore dashboard configurations across machines
- Build a community library of reusable OpenSwarm dashboard templates

### What's in a `.swarm` file

A `.swarm` file is JSON with a `.swarm` extension containing:

```json
{
  "swarm_version": 1,
  "dashboard": {
    "name": "My Dashboard",
    "layout": {
      "cards": {},
      "view_cards": { ... },
      "browser_cards": { ... }
    }
  },
  "outputs": {
    "output_id": {
      "name": "Chart View",
      "files": { "index.html": "...", "style.css": "..." },
      ...
    }
  }
}
```

- **Dashboard layout** — Card positions, sizes, and spatial arrangement on the canvas
- **View card outputs** — Full HTML/CSS/JS code for custom views, bundled inline
- **Browser cards** — URLs, tabs, and tab configuration
- **Version field** — `swarm_version: 1` for forward compatibility

**What's intentionally excluded:**
- Agent chat sessions (ephemeral, user-specific conversations)
- Thumbnails (auto-generated on use, keeps file size small)

### How it works

**Export:** Click the three-dot menu on any dashboard → "Export as .swarm" → downloads a `.swarm` file.

**Import:** Click "Import .swarm" on the Dashboards page → select a `.swarm` file → a new dashboard is created with all views and browser cards intact.

On import, all internal IDs (outputs, browser cards) are **remapped to new UUIDs** so there are never collisions with existing data. Agent cards are cleared since chat sessions aren't portable.

### Changes made

This is a minimal, additive change — **no existing logic was modified**, only new endpoints and UI were added:

| File | Lines | Change |
|------|-------|--------|
| `backend/apps/dashboards/dashboards.py` | +112 | `GET /{id}/export` and `POST /import` endpoints |
| `frontend/src/shared/state/dashboardsSlice.ts` | +40 | `exportDashboard` and `importDashboard` async thunks |
| `frontend/src/app/pages/DashboardSelection/DashboardSelection.tsx` | +68 | "Import .swarm" button + "Export as .swarm" context menu item |

**3 files changed, ~220 lines added, 0 files created.**

## Test plan

- [ ] Export a dashboard with view cards and browser cards — verify `.swarm` file downloads with correct JSON structure
- [ ] Import the exported `.swarm` file — verify a new dashboard is created with "(imported)" suffix
- [ ] Verify imported view cards render correctly with their HTML/CSS/JS
- [ ] Verify imported browser cards retain their URLs and tab configuration
- [ ] Verify agent cards are cleared on import (not portable)
- [ ] Import the same `.swarm` file twice — verify no ID collisions (all IDs remapped)
- [ ] Import a file with invalid JSON — verify 400 error is returned
- [ ] Import a file with unsupported `swarm_version` — verify 400 error
- [ ] Export an empty dashboard — verify minimal valid `.swarm` file is produced