### PR TITLE
Cross-platform Windows/Linux dev-mode support

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -826,9 +826,8 @@ class AgentManager:
                 "disallowed_tools": effective_disallowed,
                 "include_partial_messages": True,
             }
-            if not global_settings.anthropic_api_key:
-                raise ValueError("Anthropic API key not configured. Set it in Settings.")
-            options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
+            if global_settings.anthropic_api_key:
+                options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
             if mcp_servers:
                 options_kwargs["mcp_servers"] = mcp_servers
             if composed_prompt:

--- a/backend/apps/tools_lib/tools_lib.py
+++ b/backend/apps/tools_lib/tools_lib.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import re
+import sys
 import logging
 import shutil
 import time
@@ -235,7 +236,8 @@ def _sync_external_config(tool: ToolDefinition):
             config["ct0"] = ct0
             with open(_XBIRD_CONFIG_PATH, "w") as f:
                 json.dump(config, f, indent=2)
-            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
             logger.info("Synced xbird credentials to %s", _XBIRD_CONFIG_PATH)
     elif tool.name == "xbird" and not tool.credentials:
         if os.path.exists(_XBIRD_CONFIG_PATH):
@@ -290,6 +292,24 @@ def _sanitize_server_name(name: str) -> str:
 def _extra_bin_dirs() -> list[str]:
     """Well-known user-local bin directories that may not be on PATH in packaged apps."""
     home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
     dirs = [
         os.path.join(home, ".bun", "bin"),
         os.path.join(home, ".cargo", "bin"),

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -10,29 +10,71 @@ const backendDir = __dirname;
 const isWindows = process.platform === 'win32';
 
 // --- Locate Python ---
+function getPythonVersion(cmd, args = ['--version']) {
+  try {
+    const output = execFileSync(cmd, args, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Extract version number from "Python X.Y.Z"
+    const match = output.match(/Python (\d+)\.(\d+)/);
+    if (match) {
+      return { cmd, args: args.length > 1 ? args.slice(0, -1) : [], major: parseInt(match[1]), minor: parseInt(match[2]), output };
+    }
+  } catch {
+    // not found
+  }
+  return null;
+}
+
 function findPython() {
+  const found = [];
+
+  if (isWindows) {
+    // Windows py launcher — try specific compatible versions first
+    for (const ver of ['3.13', '3.12', '3.11']) {
+      const result = getPythonVersion('py', [`-${ver}`, '--version']);
+      if (result) {
+        found.push({ cmd: 'py', args: [`-${ver}`], ...result });
+      }
+    }
+  }
+
+  // Generic commands
   const candidates = isWindows
     ? ['python', 'python3']
     : ['python3', 'python'];
   for (const cmd of candidates) {
-    try {
-      const version = execFileSync(cmd, ['--version'], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      console.log(`Found ${version} (${cmd})`);
-      return cmd;
-    } catch {
-      // not found, try next
+    const result = getPythonVersion(cmd);
+    if (result) {
+      found.push({ cmd, args: [], ...result });
     }
   }
+
+  // Prefer 3.11-3.13 (known compatible), then any 3.11+
+  const compatible = found.filter(p => p.major === 3 && p.minor >= 11 && p.minor <= 13);
+  const selected = compatible[0] || found.find(p => p.major === 3 && p.minor >= 11);
+
+  if (selected) {
+    const fullCmd = selected.args.length ? `${selected.cmd} ${selected.args.join(' ')}` : selected.cmd;
+    console.log(`Found ${selected.output} (${fullCmd})`);
+    return { cmd: selected.cmd, args: selected.args };
+  }
+
+  if (found.length > 0) {
+    const p = found[0];
+    console.warn(`Warning: Found Python ${p.major}.${p.minor} but 3.11-3.13 is recommended.`);
+    console.warn('Some dependencies may not have pre-built wheels for this version.');
+    return { cmd: p.cmd, args: p.args };
+  }
+
   console.error(
-    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+    'Error: Python not found. Install Python 3.11-3.13 and ensure it is on your PATH.'
   );
   process.exit(1);
 }
 
-const pythonCmd = findPython();
+const python = findPython();
 
 // --- Venv setup ---
 const venvDir = join(backendDir, '.venv');
@@ -51,6 +93,8 @@ const env = {
   ...process.env,
   PATH: venvBin + delimiter + (process.env.PATH || ''),
   VIRTUAL_ENV: venvDir,
+  // Force UTF-8 on Windows so open() without encoding= matches macOS/Linux behavior
+  ...(isWindows ? { PYTHONUTF8: '1' } : {}),
 };
 
 function run(cmd, args, options = {}) {
@@ -73,7 +117,7 @@ try {
   // --- Create virtual environment if needed ---
   if (!existsSync(venvDir)) {
     console.log('Creating virtual environment...');
-    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+    await run(python.cmd, [...python.args, '-m', 'venv', venvDir], { env: process.env });
   }
 
   // --- Install debugger module if not installed ---

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -1,0 +1,111 @@
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
+++ b/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
@@ -1,0 +1,853 @@
+# Windows & Linux Dev-Mode Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make OpenSwarm runnable in dev mode on Windows and Linux via cross-platform Node.js orchestration scripts and targeted platform fixes.
+
+**Architecture:** Three new `.mjs` scripts (`run.mjs`, `backend/run.mjs`, `frontend/run.mjs`) replace the Bash `.sh` scripts with cross-platform Node.js equivalents. Existing `.sh` files are untouched. Platform-specific code in `electron/main.js` and `backend/apps/tools_lib/tools_lib.py` is patched to handle Windows paths and conventions.
+
+**Tech Stack:** Node.js (ESM), child_process, http module, Python venv
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/run.mjs` | npm install + npm run dev |
+| Create | `backend/run.mjs` | venv setup, pip install, uvicorn start |
+| Create | `run.mjs` | Orchestrate backend, frontend, Electron; health checks; shutdown |
+| Modify | `electron/main.js` | Windows Python path, cross-platform PATH delimiters |
+| Modify | `electron/package.json` | Cross-platform dev/postinstall scripts |
+| Modify | `backend/apps/tools_lib/tools_lib.py` | Windows bin dirs, chmod guard |
+| Modify | `frontend/package.json` | Cross-platform clean script |
+
+---
+
+### Task 1: Create `frontend/run.mjs`
+
+The simplest script — good place to establish the pattern.
+
+**Files:**
+- Create: `frontend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify it works**
+
+Run from the project root:
+```bash
+node frontend/run.mjs
+```
+Expected: npm install runs, then webpack dev server starts on `http://localhost:3000`. Ctrl+C stops it cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/run.mjs
+git commit -m "feat: add cross-platform frontend/run.mjs"
+```
+
+---
+
+### Task 2: Create `backend/run.mjs`
+
+Handles Python venv creation, activation (via PATH manipulation), pip install, and uvicorn startup.
+
+**Files:**
+- Create: `backend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify venv creation and uvicorn start**
+
+Run from the project root:
+```bash
+node backend/run.mjs
+```
+Expected: Creates `.venv` if missing, installs deps, starts uvicorn on port 8324. Ctrl+C stops it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/run.mjs
+git commit -m "feat: add cross-platform backend/run.mjs"
+```
+
+---
+
+### Task 3: Create `run.mjs` (root orchestrator)
+
+Spawns backend and frontend, health-checks both, launches Electron, handles graceful shutdown.
+
+**Files:**
+- Create: `run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}
+```
+
+- [ ] **Step 2: Verify full orchestration**
+
+Run from the project root:
+```bash
+node run.mjs
+```
+Expected: Backend starts and becomes healthy, frontend starts and becomes healthy, Electron launches. Ctrl+C gracefully shuts down all three. On unexpected exit of any service, the others are torn down.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add run.mjs
+git commit -m "feat: add cross-platform run.mjs orchestrator"
+```
+
+---
+
+### Task 4: Fix `electron/main.js` for Windows paths
+
+**Files:**
+- Modify: `electron/main.js:93` (PATH split)
+- Modify: `electron/main.js:98` (PATH join)
+- Modify: `electron/main.js:108-115` (getPythonPath)
+- Modify: `electron/main.js:164` (PYTHONPATH join)
+- Modify: `electron/main.js:289-300` (killBackend)
+
+- [ ] **Step 1: Fix `getPythonPath()` to use Windows paths**
+
+Change lines 108-115 from:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return path.join(envPath, 'bin', 'python3');
+  }
+  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+  return venvPython;
+}
+```
+
+To:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
+  }
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+}
+```
+
+- [ ] **Step 2: Fix PATH separator on line 93**
+
+Change line 93 from:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+```
+
+To:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
+```
+
+- [ ] **Step 3: Fix PATH join on line 98**
+
+Change line 98 from:
+
+```javascript
+  return dirs.join(':');
+```
+
+To:
+
+```javascript
+  return dirs.join(path.delimiter);
+```
+
+- [ ] **Step 4: Fix PYTHONPATH join on line 164**
+
+Change line 164 from:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+```
+
+To:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
+```
+
+- [ ] **Step 5: Fix `killBackend()` for Windows**
+
+Change lines 289-300 from:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    backendProcess.kill('SIGTERM');
+    setTimeout(() => {
+      if (backendProcess && !backendProcess.killed) {
+        backendProcess.kill('SIGKILL');
+      }
+    }, 3000);
+    backendProcess = null;
+  }
+}
+```
+
+To:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    if (process.platform === 'win32') {
+      try {
+        // PID is a numeric value from Node child_process — safe to pass as argument
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
+    backendProcess = null;
+  }
+}
+```
+
+Note: change the import on line 5 from `const { spawn, execFileSync } = require('child_process');` — `execFileSync` is already imported.
+
+- [ ] **Step 6: Verify Electron launches in dev mode**
+
+With backend and frontend already running (via `node backend/run.mjs` and `node frontend/run.mjs` in separate terminals):
+```bash
+cd electron && npx cross-env ELECTRON_DEV=1 npx electron .
+```
+Expected: Electron window opens, loads `http://localhost:3000`, no errors in console about Python paths.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/main.js
+git commit -m "fix: make electron main.js cross-platform (Windows paths, delimiters, process kill)"
+```
+
+---
+
+### Task 5: Fix `electron/package.json` scripts
+
+**Files:**
+- Modify: `electron/package.json`
+- Create: `electron/scripts/postinstall.mjs`
+
+- [ ] **Step 1: Install cross-env as a dev dependency**
+
+```bash
+cd electron && npm install --save-dev cross-env
+```
+
+- [ ] **Step 2: Update the `dev` and `postinstall` scripts**
+
+Change the `"scripts"` section from:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "ELECTRON_DEV=1 electron .",
+    "postinstall": "bash scripts/sign-vmp.sh",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+To:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+- [ ] **Step 3: Create `electron/scripts/postinstall.mjs`**
+
+```javascript
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}
+```
+
+- [ ] **Step 4: Verify npm install works without error**
+
+```bash
+cd electron && npm install
+```
+Expected: On Windows/Linux, prints `[postinstall] Skipping VMP signing (macOS only)` and succeeds. On macOS, runs the existing sign-vmp.sh.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/package.json electron/scripts/postinstall.mjs
+git commit -m "fix: make electron package.json scripts cross-platform"
+```
+
+---
+
+### Task 6: Fix `backend/apps/tools_lib/tools_lib.py` for Windows
+
+**Files:**
+- Modify: `backend/apps/tools_lib/tools_lib.py:4` (add `sys` import)
+- Modify: `backend/apps/tools_lib/tools_lib.py:291-314` (`_extra_bin_dirs`)
+- Modify: `backend/apps/tools_lib/tools_lib.py:238` (`os.chmod`)
+
+- [ ] **Step 1: Add `sys` import**
+
+Add `import sys` after `import re` on line 4, so lines 3-5 become:
+
+```python
+import os
+import re
+import sys
+import logging
+```
+
+- [ ] **Step 2: Fix `_extra_bin_dirs()` for Windows**
+
+Change the `_extra_bin_dirs()` function (lines 291-314) from:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+To:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+- [ ] **Step 3: Guard `os.chmod()` call**
+
+Change line 238 from:
+
+```python
+            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+To:
+
+```python
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+- [ ] **Step 4: Verify the backend starts without errors**
+
+```bash
+node backend/run.mjs
+```
+Expected: uvicorn starts, no import errors or platform-related crashes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/apps/tools_lib/tools_lib.py
+git commit -m "fix: make tools_lib bin dirs and chmod cross-platform"
+```
+
+---
+
+### Task 7: Fix `frontend/package.json` clean script
+
+**Files:**
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Replace Unix-only `rm -rf` with cross-platform alternative**
+
+Change the `"clean"` script from:
+
+```json
+    "clean": "rm -rf dist"
+```
+
+To:
+
+```json
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
+```
+
+- [ ] **Step 2: Verify clean works**
+
+```bash
+cd frontend && npm run clean
+```
+Expected: No error, `dist/` removed if it exists, no-op if it doesn't.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/package.json
+git commit -m "fix: make frontend clean script cross-platform"
+```
+
+---
+
+### Task 8: End-to-end verification
+
+- [ ] **Step 1: Full startup test**
+
+From the project root:
+```bash
+node run.mjs
+```
+
+Verify:
+1. Backend venv is created (if first run)
+2. Backend dependencies install
+3. Backend server starts on port 8324
+4. Frontend dependencies install
+5. Frontend dev server starts on port 3000
+6. Electron window opens and loads the app
+7. Ctrl+C gracefully stops all three processes
+
+- [ ] **Step 2: Restart test**
+
+Run `node run.mjs` again after Ctrl+C. Verify it starts cleanly (venv already exists, deps already installed, should be faster).
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any fixes were needed during testing, commit them:
+```bash
+git add -A
+git commit -m "fix: address issues found during cross-platform dev-mode testing"
+```

--- a/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
+++ b/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
@@ -1,0 +1,81 @@
+# Windows (& Linux) Dev-Mode Support
+
+**Date:** 2026-04-09
+**Scope:** Development mode only — no packaged app builds
+
+## Goal
+
+Make OpenSwarm runnable in dev mode on Windows and Linux by replacing the Bash orchestration scripts with cross-platform Node.js equivalents and fixing platform-specific code paths in the Electron main process and Python backend.
+
+## Approach
+
+Add three new `.mjs` scripts that mirror the existing `.sh` scripts but work on all platforms. Existing `.sh` files are untouched — zero risk to current macOS users.
+
+## New Files
+
+### `run.mjs` (root orchestrator)
+
+Replaces `run.sh`. Responsibilities:
+
+- Spawns `node backend/run.mjs` and `node frontend/run.mjs` as child processes
+- Prefixes stdout with colored `[backend]` / `[frontend]` / `[electron]` tags using ANSI codes (no dependencies)
+- Health-checks `http://localhost:8324` and `http://localhost:3000` via `http.get()` polling
+- Once both healthy, launches Electron with `ELECTRON_DEV=1` env var
+- Graceful shutdown on SIGINT/SIGTERM: sends SIGTERM on Unix, `taskkill /T /F /PID` on Windows
+- Monitors child PIDs — if any exit unexpectedly, tears down all others
+
+### `backend/run.mjs`
+
+Replaces `backend/run.sh`. Responsibilities:
+
+- Creates Python venv if `.venv` doesn't exist: `python -m venv .venv`
+- Activates venv by prepending the correct bin dir to PATH (`.venv/Scripts` on Windows, `.venv/bin` on Unix) — no `source activate` needed
+- Installs debugger module (`pip install -e .`) if not already installed
+- Installs Python dependencies (`pip install -r requirements.txt`)
+- Starts uvicorn: `python -m uvicorn backend.main:app --host 0.0.0.0 --port 8324 --reload`
+
+### `frontend/run.mjs`
+
+Replaces `frontend/run.sh`. Responsibilities:
+
+- Runs `npm install` in frontend directory
+- Runs `npm run dev`
+
+## Modified Files
+
+### `electron/main.js`
+
+- `getPythonPath()`: Return `.venv\Scripts\python.exe` on `win32`, `.venv/bin/python3` on Unix
+- Line 93/98: Change hardcoded `':'` PATH separator to `path.delimiter`
+- Line 164: Change `PYTHONPATH` join separator from `':'` to `path.delimiter`
+
+### `backend/apps/tools_lib/tools_lib.py`
+
+- `_extra_bin_dirs()`: On `win32`, return Windows-appropriate paths (`~\AppData\Roaming\npm`, `~\.cargo\bin`, `~\scoop\shims`) instead of Unix-only paths (`/opt/homebrew/bin`, `/usr/local/bin`, etc.)
+- `os.chmod(_XBIRD_CONFIG_PATH, 0o600)`: Wrap in `if sys.platform != 'win32'` guard — Windows doesn't support Unix permissions; files are already user-private by default
+
+### `electron/package.json`
+
+- `"dev"` script: Either use `cross-env` for env var setting or rely on `run.mjs` setting `ELECTRON_DEV=1` (making the npm script moot in the cross-platform workflow)
+- `"postinstall"`: Guard VMP signing script with platform check so it doesn't fail on Windows/Linux
+
+## Error Handling
+
+- **Python not found**: `backend/run.mjs` checks for `python`/`python3` on PATH at startup, exits with clear error
+- **Port conflicts**: Preserved existing behavior — uvicorn/webpack error naturally
+- **Windows long paths**: Not expected for dev mode; users can enable `git config --system core.longpaths true` if needed
+- **Line endings**: Node.js handles natively — no `sed` stripping needed
+
+## Out of Scope
+
+- Existing `.sh` files (untouched)
+- Build/publish scripts (`scripts/build-app.sh`, `scripts/build-python-env.sh`, `publish.sh`)
+- Packaged Windows/Linux Electron builds (`.exe`, `.deb`, etc.)
+- CI/CD pipeline
+- Backend Python application code (already cross-platform except the two fixes above)
+- Frontend React code (already platform-agnostic)
+
+## Testing
+
+- Manual testing on Windows, ideally verified on macOS/Linux too
+- Verify: venv creation, pip install, uvicorn starts, frontend starts, Electron launches, Ctrl+C clean shutdown

--- a/electron/main.js
+++ b/electron/main.js
@@ -90,12 +90,12 @@ function getShellPath() {
 
   const seen = new Set();
   const dirs = [];
-  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
     if (!d || seen.has(d)) continue;
     seen.add(d);
     try { if (fs.statSync(d).isDirectory()) dirs.push(d); } catch { /* skip */ }
   }
-  return dirs.join(':');
+  return dirs.join(path.delimiter);
 }
 
 function getResourcePath(...segments) {
@@ -108,10 +108,13 @@ function getResourcePath(...segments) {
 function getPythonPath() {
   if (isPackaged) {
     const envPath = path.join(process.resourcesPath, 'python-env');
-    return path.join(envPath, 'bin', 'python3');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
   }
-  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
-  return venvPython;
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
 }
 
 function waitForBackend(port, timeoutMs = 60000) {
@@ -161,7 +164,7 @@ async function startBackend() {
       'python3.13', 'site-packages'
     );
     const debuggerDir = getResourcePath('debugger');
-    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
   }
 
   console.log(`Starting backend: ${pythonPath} on port ${backendPort}`);
@@ -289,12 +292,18 @@ function setupAutoUpdater() {
 function killBackend() {
   if (backendProcess) {
     console.log('Killing backend process...');
-    backendProcess.kill('SIGTERM');
-    setTimeout(() => {
-      if (backendProcess && !backendProcess.killed) {
-        backendProcess.kill('SIGKILL');
-      }
-    }, 3000);
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
     backendProcess = null;
   }
 }

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
+        "cross-env": "^10.1.0",
         "electron": "castlabs/electron-releases#v33.4.11+wvcus",
         "electron-builder": "^25.1.0"
       }
@@ -363,6 +364,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -816,6 +824,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1013,7 +1022,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1033,7 +1041,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1056,7 +1063,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1072,8 +1078,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1081,7 +1086,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1709,7 +1713,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1834,7 +1837,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1848,13 +1850,30 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -2062,6 +2081,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -2256,7 +2276,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -2270,7 +2289,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2286,7 +2304,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2300,7 +2317,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2754,8 +2770,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3360,8 +3375,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3496,7 +3510,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3510,7 +3523,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3526,8 +3538,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3535,7 +3546,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3552,16 +3562,14 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3574,8 +3582,7 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3589,16 +3596,14 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4070,7 +4075,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4318,8 +4322,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4420,7 +4423,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4430,8 +4432,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4439,7 +4440,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4450,7 +4450,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4952,7 +4951,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5336,7 +5334,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -5352,7 +5349,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dev": "ELECTRON_DEV=1 electron .",
-    "postinstall": "bash scripts/sign-vmp.sh",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
     "sign-vmp": "bash scripts/sign-vmp.sh",
     "dist": "electron-builder --mac --publish never",
     "dist:publish": "electron-builder --mac --publish always",
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
+    "cross-env": "^10.1.0",
     "electron": "castlabs/electron-releases#v33.4.11+wvcus",
     "electron-builder": "^25.1.0"
   },

--- a/electron/scripts/postinstall.mjs
+++ b/electron/scripts/postinstall.mjs
@@ -1,0 +1,19 @@
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "build": "webpack --mode=production",
     "build:watch": "webpack --mode=development --watch",
     "dev": "webpack serve --mode=development",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.4.11",

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -1,0 +1,33 @@
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -12,6 +12,7 @@ function run(cmd, args) {
     const child = spawn(cmd, args, {
       cwd: __dirname,
       stdio: 'inherit',
+      shell: isWindows,
     });
     child.on('error', reject);
     child.on('exit', (code) => {

--- a/run.mjs
+++ b/run.mjs
@@ -66,7 +66,6 @@ function cleanup() {
 
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
-process.on('exit', cleanup);
 
 // --- Spawn with prefixed output ---
 function spawnService(name, color, cmd, args, options = {}) {

--- a/run.mjs
+++ b/run.mjs
@@ -73,6 +73,8 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
+    // .cmd files on Windows require shell: true
+    shell: isWindows,
     ...options,
   });
   children.push(child);

--- a/run.mjs
+++ b/run.mjs
@@ -73,8 +73,6 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
-    // .cmd files on Windows require shell: true
-    shell: isWindows,
     ...options,
   });
   children.push(child);
@@ -132,7 +130,7 @@ try {
 
   // Wait for backend health
   console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
-  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  await waitForHealth('http://localhost:8324/api/health/check', 'Backend', 120000);
   console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
 
   // Start frontend
@@ -157,6 +155,7 @@ try {
   const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
     cwd: join(__dirname, 'electron'),
     env: { ...process.env, ELECTRON_DEV: '1' },
+    shell: isWindows,
   });
 
   electron.on('exit', (code) => {

--- a/run.mjs
+++ b/run.mjs
@@ -1,0 +1,177 @@
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}


### PR DESCRIPTION
## Summary
- Adds cross-platform `run.mjs` orchestrators (root, backend, frontend) replacing bash-only scripts
- Makes Electron main process, package scripts, and tools_lib work on Windows (paths, process management, chmod)
- Fixes health check URL, exit handler re-entrancy, and makes Anthropic API key optional for agent spawning
- Includes design spec and implementation plan docs

## Commits (14)
Full cross-platform runtime support enabling OpenSwarm to run on Windows alongside Linux/macOS.

## Test plan
- [ ] `node run.mjs` starts all 3 services on Windows
- [ ] `node run.mjs` still works on macOS/Linux
- [ ] Electron app launches and connects to backend
- [ ] Agent spawning works without API key configured (CLI fallback)