### PR TITLE
Refactor: LLM router with API/CLI dual-path + browser tools MCP

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -1334,22 +1334,18 @@ class AgentManager:
 
         title = first_prompt[:40].strip()
         try:
-            import anthropic
-            global_settings = load_settings()
-            if not global_settings.anthropic_api_key:
-                raise ValueError("API key not configured")
-            client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
-            resp = await client.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=30,
+            from backend.apps.settings.llm_router import llm_call
+            generated = await llm_call(
                 system="Generate a concise 3-6 word title for a chat that starts with this message. Return only the title, nothing else.",
-                messages=[{"role": "user", "content": first_prompt}],
+                user_message=first_prompt,
+                model="haiku",
+                max_tokens=30,
             )
-            generated = resp.content[0].text.strip().strip('"\'')
+            generated = generated.strip('"\'')
             if generated:
                 title = generated
         except Exception as e:
-            logger.warning(f"Title generation failed, using fallback: {e}")
+            logger.debug(f"Title generation failed, using fallback: {e}")
 
         session.name = title
         await ws_manager.send_to_session(session_id, "agent:name_updated", {
@@ -1378,11 +1374,8 @@ class AgentManager:
         svg = ""
 
         try:
-            import anthropic, json as _json
-            global_settings = load_settings()
-            if not global_settings.anthropic_api_key:
-                raise ValueError("API key not configured")
-            client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
+            import json as _json
+            from backend.apps.settings.llm_router import llm_call
 
             tool_desc = "\n".join(
                 f"- {tc.get('tool', '?')}: {tc.get('input_summary', '')}" for tc in tool_calls
@@ -1406,14 +1399,12 @@ class AgentManager:
                 "- Max 400 characters for the svg string"
             )
 
-            resp = await client.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=300,
+            raw = await llm_call(
                 system=system,
-                messages=[{"role": "user", "content": user_content}],
+                user_message=user_content,
+                model="haiku",
+                max_tokens=300,
             )
-
-            raw = resp.content[0].text.strip()
             if raw.startswith("```"):
                 raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             parsed = _json.loads(raw)
@@ -1422,7 +1413,7 @@ class AgentManager:
             if parsed.get("svg"):
                 svg = parsed["svg"].strip()
         except Exception as e:
-            logger.warning(f"Group meta generation failed, using fallback: {e}")
+            logger.debug(f"Group meta generation failed, using fallback: {e}")
 
         meta = ToolGroupMeta(id=group_id, name=name, svg=svg, is_refined=is_refinement)
         session.tool_group_meta[group_id] = meta

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -826,9 +826,8 @@ class AgentManager:
                 "disallowed_tools": effective_disallowed,
                 "include_partial_messages": True,
             }
-            if not global_settings.anthropic_api_key:
-                raise ValueError("Anthropic API key not configured. Set it in Settings.")
-            options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
+            if global_settings.anthropic_api_key:
+                options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
             if mcp_servers:
                 options_kwargs["mcp_servers"] = mcp_servers
             if composed_prompt:

--- a/backend/apps/agents/browser_agent.py
+++ b/backend/apps/agents/browser_agent.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 
@@ -274,25 +275,17 @@ async def _request_browser_approval(
     return decision
 
 
-async def run_browser_agent(
+async def _setup_browser_session(
     task: str,
     browser_id: str,
     model: str,
-    api_key: str,
-    dashboard_id: str | None = None,
-    tab_id: str = "",
-    pre_selected: bool = False,
-    initial_url: str | None = None,
-    parent_session_id: str | None = None,
-) -> dict:
-    """Run a browser sub-agent loop for a single browser card.
-
-    Creates a visible AgentSession, streams progress via WebSocket,
-    and returns the full action log + summary + final screenshot.
-    """
+    dashboard_id: str | None,
+    tab_id: str,
+    initial_url: str | None,
+    parent_session_id: str | None,
+) -> tuple:
+    """Common setup for browser agent sessions (API and CLI paths)."""
     from backend.apps.agents.agent_manager import agent_manager
-
-    _browser_perms = load_builtin_permissions()
 
     session_id = uuid4().hex
     cancel_event = asyncio.Event()
@@ -322,13 +315,6 @@ async def run_browser_agent(
         )
         logger.info(f"Browser agent {session_id}: navigated to {initial_url}: {nav_result.get('text', nav_result.get('error', ''))}")
 
-    api_model = MODEL_MAP.get(model, model)
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-
-    messages: list[dict] = [{"role": "user", "content": task}]
-    action_log: list[dict] = []
-    final_screenshot: str | None = None
-
     user_msg = Message(role="user", content=task)
     session.messages.append(user_msg)
     await ws_manager.send_to_session(session_id, "agent:message", {
@@ -336,74 +322,154 @@ async def run_browser_agent(
         "message": user_msg.model_dump(mode="json"),
     })
 
-    try:
-        for turn in range(MAX_TURNS):
-            if cancel_event.is_set():
-                break
+    return session_id, session, cancel_event
 
-            response = await client.messages.create(
-                model=api_model,
-                max_tokens=4096,
-                system=SYSTEM_PROMPT,
-                tools=BROWSER_TOOLS_SCHEMA,
-                messages=messages,
+
+async def _finalize_browser_session(
+    session_id: str,
+    session: AgentSession,
+    browser_id: str,
+    tab_id: str,
+    summary: str,
+    action_log: list[dict],
+    final_screenshot: str | None,
+    status: str = "completed",
+) -> dict:
+    """Common finalization for browser agent sessions."""
+    if not final_screenshot and status == "completed":
+        try:
+            ss_result = await execute_browser_tool(
+                "BrowserScreenshot", {}, browser_id, tab_id,
             )
+            if ss_result.get("image"):
+                final_screenshot = ss_result["image"]
+        except Exception:
+            pass
 
-            assistant_content = []
-            text_parts = []
-            tool_uses = []
+    session.status = status
+    await ws_manager.send_to_session(session_id, "agent:status", {
+        "session_id": session_id,
+        "status": status,
+        "session": session.model_dump(mode="json"),
+    })
 
-            for block in response.content:
-                if block.type == "text":
-                    text_parts.append(block.text)
-                    assistant_content.append({"type": "text", "text": block.text})
-                elif block.type == "tool_use":
-                    tool_uses.append(block)
-                    assistant_content.append({
-                        "type": "tool_use",
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
-                    })
+    return {
+        "session_id": session_id,
+        "browser_id": browser_id,
+        "summary": summary,
+        "action_log": action_log,
+        "final_screenshot": final_screenshot,
+    }
 
-            if text_parts:
-                asst_msg = Message(
-                    role="assistant",
-                    content="\n".join(text_parts),
-                )
-                session.messages.append(asst_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": asst_msg.model_dump(mode="json"),
+
+async def _run_browser_agent_api(
+    task: str,
+    session_id: str,
+    session: AgentSession,
+    cancel_event: asyncio.Event,
+    browser_id: str,
+    model: str,
+    api_key: str,
+    tab_id: str,
+) -> dict:
+    """Run browser agent using direct Anthropic API (when API key is available)."""
+    _browser_perms = load_builtin_permissions()
+    api_model = MODEL_MAP.get(model, model)
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    messages: list[dict] = [{"role": "user", "content": task}]
+    action_log: list[dict] = []
+    final_screenshot: str | None = None
+
+    for turn in range(MAX_TURNS):
+        if cancel_event.is_set():
+            break
+
+        response = await client.messages.create(
+            model=api_model,
+            max_tokens=4096,
+            system=SYSTEM_PROMPT,
+            tools=BROWSER_TOOLS_SCHEMA,
+            messages=messages,
+        )
+
+        assistant_content = []
+        text_parts = []
+        tool_uses = []
+
+        for block in response.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+                assistant_content.append({"type": "text", "text": block.text})
+            elif block.type == "tool_use":
+                tool_uses.append(block)
+                assistant_content.append({
+                    "type": "tool_use",
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
                 })
 
-            for tu in tool_uses:
-                tool_msg = Message(
-                    role="tool_call",
-                    content={"id": tu.id, "tool": tu.name, "input": tu.input},
-                )
-                session.messages.append(tool_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": tool_msg.model_dump(mode="json"),
-                })
+        if text_parts:
+            asst_msg = Message(
+                role="assistant",
+                content="\n".join(text_parts),
+            )
+            session.messages.append(asst_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
+                "session_id": session_id,
+                "message": asst_msg.model_dump(mode="json"),
+            })
 
-            messages.append({"role": "assistant", "content": assistant_content})
+        for tu in tool_uses:
+            tool_msg = Message(
+                role="tool_call",
+                content={"id": tu.id, "tool": tu.name, "input": tu.input},
+            )
+            session.messages.append(tool_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
+                "session_id": session_id,
+                "message": tool_msg.model_dump(mode="json"),
+            })
 
-            if response.stop_reason != "tool_use":
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        if response.stop_reason != "tool_use":
+            break
+
+        tool_results = []
+        cancelled = False
+        for tu in tool_uses:
+            if cancel_event.is_set():
+                cancelled = True
                 break
 
-            tool_results = []
-            cancelled = False
-            for tu in tool_uses:
-                if cancel_event.is_set():
-                    cancelled = True
-                    break
+            policy = _browser_perms.get(tu.name, "always_allow")
 
-                policy = _browser_perms.get(tu.name, "always_allow")
+            if policy == "deny":
+                denied_text = f"Tool {tu.name} is denied by permission policy."
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu.id,
+                    "content": [{"type": "text", "text": denied_text}],
+                })
+                result_msg = Message(
+                    role="tool_result",
+                    content={"text": denied_text, "tool_name": tu.name, "elapsed_ms": 0},
+                )
+                session.messages.append(result_msg)
+                await ws_manager.send_to_session(session_id, "agent:message", {
+                    "session_id": session_id,
+                    "message": result_msg.model_dump(mode="json"),
+                })
+                continue
 
-                if policy == "deny":
-                    denied_text = f"Tool {tu.name} is denied by permission policy."
+            if policy == "ask":
+                decision = await _request_browser_approval(
+                    session, tu.name, tu.input,
+                )
+                if decision.get("behavior") == "deny":
+                    denied_text = decision.get("message") or f"Tool {tu.name} denied by user."
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": tu.id,
@@ -420,110 +486,185 @@ async def run_browser_agent(
                     })
                     continue
 
-                if policy == "ask":
-                    decision = await _request_browser_approval(
-                        session, tu.name, tu.input,
-                    )
-                    if decision.get("behavior") == "deny":
-                        denied_text = decision.get("message") or f"Tool {tu.name} denied by user."
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tu.id,
-                            "content": [{"type": "text", "text": denied_text}],
-                        })
-                        result_msg = Message(
-                            role="tool_result",
-                            content={"text": denied_text, "tool_name": tu.name, "elapsed_ms": 0},
-                        )
-                        session.messages.append(result_msg)
-                        await ws_manager.send_to_session(session_id, "agent:message", {
-                            "session_id": session_id,
-                            "message": result_msg.model_dump(mode="json"),
-                        })
-                        continue
+            start = time.time()
+            result = await execute_browser_tool(
+                tu.name, tu.input, browser_id, tab_id,
+            )
+            elapsed_ms = int((time.time() - start) * 1000)
 
-                start = time.time()
-                result = await execute_browser_tool(
-                    tu.name, tu.input, browser_id, tab_id,
-                )
-                elapsed_ms = int((time.time() - start) * 1000)
-
-                action_log.append({
-                    "tool": tu.name,
-                    "input": tu.input,
-                    "result_summary": result.get("text", result.get("error", ""))[:200],
-                    "elapsed_ms": elapsed_ms,
-                })
-
-                if tu.name == "BrowserScreenshot" and result.get("image"):
-                    final_screenshot = result["image"]
-
-                content_blocks = _format_tool_result(result, tu.name)
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": tu.id,
-                    "content": content_blocks,
-                })
-
-                result_text = result.get("text", result.get("error", ""))
-                result_msg = Message(
-                    role="tool_result",
-                    content={"text": result_text, "tool_name": tu.name, "elapsed_ms": elapsed_ms},
-                )
-                session.messages.append(result_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": result_msg.model_dump(mode="json"),
-                })
-
-            messages.append({"role": "user", "content": tool_results})
-
-            if cancelled:
-                break
-
-        if cancel_event.is_set():
-            session.status = "stopped"
-            await ws_manager.send_to_session(session_id, "agent:status", {
-                "session_id": session_id,
-                "status": "stopped",
-                "session": session.model_dump(mode="json"),
+            action_log.append({
+                "tool": tu.name,
+                "input": tu.input,
+                "result_summary": result.get("text", result.get("error", ""))[:200],
+                "elapsed_ms": elapsed_ms,
             })
-            return {
+
+            if tu.name == "BrowserScreenshot" and result.get("image"):
+                final_screenshot = result["image"]
+
+            content_blocks = _format_tool_result(result, tu.name)
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tu.id,
+                "content": content_blocks,
+            })
+
+            result_text = result.get("text", result.get("error", ""))
+            result_msg = Message(
+                role="tool_result",
+                content={"text": result_text, "tool_name": tu.name, "elapsed_ms": elapsed_ms},
+            )
+            session.messages.append(result_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
                 "session_id": session_id,
-                "browser_id": browser_id,
-                "summary": "Agent was stopped.",
-                "action_log": action_log,
-                "final_screenshot": final_screenshot,
-            }
+                "message": result_msg.model_dump(mode="json"),
+            })
 
-        summary_parts = text_parts if text_parts else ["Task completed."]
-        summary = "\n".join(summary_parts)
+        messages.append({"role": "user", "content": tool_results})
 
-        if not final_screenshot:
-            try:
-                ss_result = await execute_browser_tool(
-                    "BrowserScreenshot", {}, browser_id, tab_id,
-                )
-                if ss_result.get("image"):
-                    final_screenshot = ss_result["image"]
-            except Exception:
-                pass
+        if cancelled:
+            break
 
-        session.status = "completed"
-        await ws_manager.send_to_session(session_id, "agent:status", {
-            "session_id": session_id,
-            "status": "completed",
-            "session": session.model_dump(mode="json"),
-        })
+    if cancel_event.is_set():
+        return await _finalize_browser_session(
+            session_id, session, browser_id, tab_id,
+            "Agent was stopped.", action_log, final_screenshot, "stopped",
+        )
 
-        return {
-            "session_id": session_id,
-            "browser_id": browser_id,
-            "summary": summary,
-            "action_log": action_log,
-            "final_screenshot": final_screenshot,
-        }
+    summary = "\n".join(text_parts) if text_parts else "Task completed."
+    return await _finalize_browser_session(
+        session_id, session, browser_id, tab_id,
+        summary, action_log, final_screenshot,
+    )
 
+
+async def _run_browser_agent_cli(
+    task: str,
+    session_id: str,
+    session: AgentSession,
+    cancel_event: asyncio.Event,
+    browser_id: str,
+    model: str,
+    tab_id: str,
+) -> dict:
+    """Run browser agent using Claude Code CLI (when no API key is available)."""
+    import os as _os
+    import sys as _sys
+    from claude_agent_sdk import query, ClaudeAgentOptions
+    from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+
+    action_log: list[dict] = []
+    final_screenshot: str | None = None
+    text_parts: list[str] = []
+
+    browser_tools_server = _os.path.join(
+        _os.path.dirname(__file__), "browser_tools_mcp_server.py",
+    )
+    backend_port = _os.environ.get("OPENSWARM_PORT", "8324")
+
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=SYSTEM_PROMPT,
+        max_turns=MAX_TURNS,
+        permission_mode="bypassPermissions",
+        mcp_servers={
+            "browser-tools": {
+                "command": _sys.executable,
+                "args": [browser_tools_server],
+                "env": {
+                    "OPENSWARM_PORT": backend_port,
+                    "OPENSWARM_BROWSER_ID": browser_id,
+                },
+                "type": "stdio",
+            },
+        },
+        stderr=lambda line: None,
+    )
+
+    async for message in query(prompt=task, options=options):
+        if cancel_event.is_set():
+            break
+
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text_parts.append(block.text)
+                    asst_msg = Message(role="assistant", content=block.text)
+                    session.messages.append(asst_msg)
+                    await ws_manager.send_to_session(session_id, "agent:message", {
+                        "session_id": session_id,
+                        "message": asst_msg.model_dump(mode="json"),
+                    })
+                elif isinstance(block, ToolUseBlock):
+                    tool_name = block.name
+                    # Strip MCP prefix if present (e.g. mcp__browser-tools__BrowserClick → BrowserClick)
+                    if "__" in tool_name:
+                        tool_name = tool_name.split("__")[-1]
+
+                    tool_msg = Message(
+                        role="tool_call",
+                        content={"id": block.id, "tool": tool_name, "input": block.input},
+                    )
+                    session.messages.append(tool_msg)
+                    await ws_manager.send_to_session(session_id, "agent:message", {
+                        "session_id": session_id,
+                        "message": tool_msg.model_dump(mode="json"),
+                    })
+
+                    action_log.append({
+                        "tool": tool_name,
+                        "input": block.input,
+                        "result_summary": "",
+                        "elapsed_ms": 0,
+                    })
+
+    if cancel_event.is_set():
+        return await _finalize_browser_session(
+            session_id, session, browser_id, tab_id,
+            "Agent was stopped.", action_log, final_screenshot, "stopped",
+        )
+
+    summary = "\n".join(text_parts) if text_parts else "Task completed."
+    return await _finalize_browser_session(
+        session_id, session, browser_id, tab_id,
+        summary, action_log, final_screenshot,
+    )
+
+
+async def run_browser_agent(
+    task: str,
+    browser_id: str,
+    model: str,
+    api_key: str | None = None,
+    dashboard_id: str | None = None,
+    tab_id: str = "",
+    pre_selected: bool = False,
+    initial_url: str | None = None,
+    parent_session_id: str | None = None,
+) -> dict:
+    """Run a browser sub-agent loop for a single browser card.
+
+    Creates a visible AgentSession, streams progress via WebSocket,
+    and returns the full action log + summary + final screenshot.
+
+    Routes through direct Anthropic API when api_key is provided,
+    or through Claude Code CLI when it's not.
+    """
+    session_id, session, cancel_event = await _setup_browser_session(
+        task, browser_id, model, dashboard_id, tab_id, initial_url, parent_session_id,
+    )
+
+    try:
+        if api_key:
+            return await _run_browser_agent_api(
+                task, session_id, session, cancel_event,
+                browser_id, model, api_key, tab_id,
+            )
+        else:
+            return await _run_browser_agent_cli(
+                task, session_id, session, cancel_event,
+                browser_id, model, tab_id,
+            )
     except Exception as e:
         logger.exception(f"Browser agent {session_id} error: {e}")
         session.status = "error"
@@ -543,7 +684,7 @@ async def run_browser_agent(
             "session_id": session_id,
             "browser_id": browser_id,
             "summary": f"Error: {str(e)}",
-            "action_log": action_log,
+            "action_log": [],
             "final_screenshot": None,
         }
 
@@ -582,7 +723,7 @@ async def _create_browser_card(dashboard_id: str, url: str, parent_session_id: s
 async def run_browser_agents(
     tasks: list[dict],
     model: str,
-    api_key: str,
+    api_key: str | None = None,
     dashboard_id: str | None = None,
     pre_selected_browser_ids: list[str] | None = None,
     parent_session_id: str | None = None,
@@ -591,6 +732,7 @@ async def run_browser_agents(
 
     Each task dict has: { browser_id (optional), task, url (optional) }
     Returns a list of result dicts, one per task.
+    Uses direct API when api_key is provided, CLI otherwise.
     """
     pre_selected = set(pre_selected_browser_ids or [])
 

--- a/backend/apps/agents/browser_tools_mcp_server.py
+++ b/backend/apps/agents/browser_tools_mcp_server.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Stdio MCP server that exposes the 9 low-level browser tools as MCP tools.
+
+Used by claude_agent_sdk when running browser agents through CLI (no API key).
+Each tool call proxies to the backend's /api/browser/command HTTP endpoint,
+which forwards the command to the frontend browser card via WebSocket.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+BACKEND_PORT = os.environ.get("OPENSWARM_PORT", "8324")
+BROWSER_ID = os.environ.get("OPENSWARM_BROWSER_ID", "")
+COMMAND_URL = f"http://127.0.0.1:{BACKEND_PORT}/api/browser/command"
+
+TOOLS = [
+    {
+        "name": "BrowserScreenshot",
+        "description": (
+            "Capture a screenshot of the browser page. Returns the screenshot as a "
+            "base64-encoded PNG image. Use this to see what is currently displayed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserGetText",
+        "description": (
+            "Get the visible text content of the browser page. Returns up to 15000 characters."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserNavigate",
+        "description": "Navigate the browser to a specific URL.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to navigate to.",
+                },
+            },
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "BrowserClick",
+        "description": (
+            "Click an element on the page identified by a CSS selector. "
+            "Use BrowserGetElements first to find valid selectors."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector for the element to click.",
+                },
+            },
+            "required": ["selector"],
+        },
+    },
+    {
+        "name": "BrowserType",
+        "description": (
+            "Type text into an input element identified by a CSS selector. "
+            "Optionally clear existing content first."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector for the input element.",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "The text to type.",
+                },
+                "clear": {
+                    "type": "boolean",
+                    "description": "Clear existing content before typing. Defaults to true.",
+                },
+            },
+            "required": ["selector", "text"],
+        },
+    },
+    {
+        "name": "BrowserEvaluate",
+        "description": (
+            "Execute JavaScript code in the browser page and return the result. "
+            "The last expression value is returned as a string."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "JavaScript code to execute in the page context.",
+                },
+            },
+            "required": ["expression"],
+        },
+    },
+    {
+        "name": "BrowserGetElements",
+        "description": (
+            "Query DOM elements matching a CSS selector. Returns tag name, text, "
+            "attributes, and bounding box for each match (up to 50 elements)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector to query elements.",
+                },
+            },
+            "required": ["selector"],
+        },
+    },
+    {
+        "name": "BrowserScroll",
+        "description": (
+            "Scroll the browser page. Can scroll up, down, or to a specific element. "
+            "Returns scroll position info including whether you're at the top or bottom."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "enum": ["up", "down"],
+                    "description": "Direction to scroll. Ignored if 'selector' is provided.",
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector of element to scroll into view.",
+                },
+                "amount": {
+                    "type": "number",
+                    "description": "Pixels to scroll. Defaults to one viewport height.",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserWait",
+        "description": (
+            "Wait for a specified duration. Use after navigation or actions that "
+            "trigger page loads. Min 100ms, max 10000ms."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "milliseconds": {
+                    "type": "number",
+                    "description": "Duration to wait in milliseconds. Defaults to 1000.",
+                },
+            },
+            "required": [],
+        },
+    },
+]
+
+# Map tool names to backend action names (matches browser_agent.py ACTION_MAP)
+ACTION_MAP = {
+    "BrowserScreenshot": "screenshot",
+    "BrowserGetText": "get_text",
+    "BrowserNavigate": "navigate",
+    "BrowserClick": "click",
+    "BrowserType": "type",
+    "BrowserEvaluate": "evaluate",
+    "BrowserGetElements": "get_elements",
+    "BrowserScroll": "scroll",
+    "BrowserWait": "wait",
+}
+
+
+def send_response(id_, result=None, error=None):
+    msg = {"jsonrpc": "2.0", "id": id_}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = result
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+def call_browser_command(action: str, params: dict) -> dict:
+    """Send a browser command to the backend HTTP endpoint."""
+    payload = json.dumps({
+        "action": action,
+        "browser_id": BROWSER_ID,
+        "params": params,
+    }).encode()
+    req = urllib.request.Request(
+        COMMAND_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else str(e)
+        return {"error": f"HTTP {e.code}: {body}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def handle_tool_call(tool_name: str, arguments: dict) -> dict:
+    action = ACTION_MAP.get(tool_name)
+    if not action:
+        return {"content": [{"type": "text", "text": f"Unknown tool: {tool_name}"}], "isError": True}
+
+    result = call_browser_command(action, arguments)
+
+    if "error" in result:
+        return {"content": [{"type": "text", "text": f"Error: {result['error']}"}], "isError": True}
+
+    # Handle screenshot results — return as image content block
+    if tool_name == "BrowserScreenshot" and result.get("image"):
+        content = [
+            {"type": "image", "data": result["image"], "mimeType": "image/png"},
+            {"type": "text", "text": f"Screenshot captured. URL: {result.get('url', 'unknown')}"},
+        ]
+        return {"content": content}
+
+    # All other results — return as text
+    text = result.get("text", json.dumps(result))
+    return {"content": [{"type": "text", "text": str(text)}]}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method")
+        id_ = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            send_response(id_, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {
+                    "name": "openswarm-browser-tools",
+                    "version": "1.0.0",
+                },
+            })
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send_response(id_, {"tools": TOOLS})
+        elif method == "tools/call":
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+            result = handle_tool_call(tool_name, arguments)
+            send_response(id_, result)
+        elif method == "ping":
+            send_response(id_, {})
+        elif id_ is not None:
+            send_response(id_, error={"code": -32601, "message": f"Method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/apps/agents/models.py
+++ b/backend/apps/agents/models.py
@@ -74,3 +74,4 @@ class AgentSession(BaseModel):
     dashboard_id: Optional[str] = None
     browser_id: Optional[str] = None
     parent_session_id: Optional[str] = None
+    schedule_id: Optional[str] = None

--- a/backend/apps/dashboards/dashboards.py
+++ b/backend/apps/dashboards/dashboards.py
@@ -151,13 +151,7 @@ async def generate_name(dashboard_id: str):
 
     fallback = prompts[0][:40]
     try:
-        import anthropic
-        from backend.apps.settings.settings import load_settings
-        global_settings = load_settings()
-        if not global_settings.anthropic_api_key:
-            raise ValueError("API key not configured")
-
-        client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
+        from backend.apps.settings.llm_router import llm_call
 
         if len(prompts) == 1:
             system = (
@@ -172,17 +166,17 @@ async def generate_name(dashboard_id: str):
             )
             user_content = "\n".join(f"- {p}" for p in prompts)
 
-        resp = await client.messages.create(
-            model="claude-haiku-4-5-20251001",
-            max_tokens=30,
+        generated = await llm_call(
             system=system,
-            messages=[{"role": "user", "content": user_content}],
+            user_message=user_content,
+            model="haiku",
+            max_tokens=30,
         )
-        generated = resp.content[0].text.strip().strip('"\'')
+        generated = generated.strip('"\'')
         if generated:
             fallback = generated
     except Exception as e:
-        logger.warning(f"Dashboard name generation failed, using fallback: {e}")
+        logger.debug(f"Dashboard name generation failed, using fallback: {e}")
 
     dashboard.name = fallback
     dashboard.auto_named = True
@@ -215,6 +209,10 @@ async def update_dashboard(dashboard_id: str, body: DashboardUpdate):
 @dashboards.router.delete("/{dashboard_id}")
 async def delete_dashboard(dashboard_id: str):
     _load(dashboard_id)
+
+    # Delete schedules tied to this dashboard
+    from backend.apps.schedules.schedules import delete_schedules_for_dashboard
+    delete_schedules_for_dashboard(dashboard_id)
 
     if os.path.exists(SESSIONS_DIR):
         for fname in os.listdir(SESSIONS_DIR):

--- a/backend/apps/outputs/outputs.py
+++ b/backend/apps/outputs/outputs.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 
@@ -31,14 +32,10 @@ def _resolve_model(short_name: str) -> str:
     return MODEL_MAP.get(short_name, short_name)
 
 
-def _get_anthropic_client():
-    """Create an AsyncAnthropic client using the API key from app settings."""
-    import anthropic
-
-    settings = load_settings()
-    if not settings.anthropic_api_key:
-        raise ValueError("Anthropic API key not configured. Set it in Settings.")
-    return anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+async def _llm_call(system: str, user_message: str, model: str = "sonnet", max_tokens: int = 4000) -> str:
+    """Route view builder LLM calls through API or CLI."""
+    from backend.apps.settings.llm_router import llm_call
+    return await llm_call(system=system, user_message=user_message, model=model, max_tokens=max_tokens)
 
 
 def _validate_against_schema(data: dict, schema: dict) -> str | None:
@@ -378,15 +375,13 @@ async def vibe_code(body: VibeCodeRequest):
     if context_parts:
         user_message = "\n\n".join(context_parts) + "\n\nUser request: " + body.prompt
 
-    client = _get_anthropic_client()
     try:
-        resp = await client.messages.create(
-            model="claude-sonnet-4-20250514",
-            max_tokens=8000,
+        raw = await _llm_call(
             system=VIBE_CODE_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_message}],
+            user_message=user_message,
+            model="sonnet",
+            max_tokens=8000,
         )
-        raw = resp.content[0].text.strip()
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
             if raw.endswith("```"):
@@ -429,24 +424,16 @@ Every required field must be present. Use realistic, meaningful data.\
 @outputs.router.post("/auto-run")
 async def auto_run_output(body: AutoRunRequest):
     """Use an LLM to generate input data matching the schema, then optionally execute backend code."""
-    try:
-        import anthropic
-    except ImportError:
-        return {"error": "anthropic SDK not installed", "input_data": None, "backend_result": None}
-
     schema_str = json.dumps(body.input_schema, indent=2)
     user_message = f"Schema:\n```json\n{schema_str}\n```\n\nGenerate data for: {body.prompt}"
 
-    api_model = _resolve_model(body.model)
-    client = _get_anthropic_client()
     try:
-        resp = await client.messages.create(
-            model=api_model,
-            max_tokens=4000,
+        raw = await _llm_call(
             system=AUTO_RUN_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_message}],
+            user_message=user_message,
+            model=body.model,
+            max_tokens=4000,
         )
-        raw = resp.content[0].text.strip()
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
             if raw.endswith("```"):

--- a/backend/apps/schedules/executor.py
+++ b/backend/apps/schedules/executor.py
@@ -1,0 +1,68 @@
+import logging
+from backend.apps.schedules.models import Schedule
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_schedule(schedule: Schedule):
+    """Fire a schedule: create a new session or message an existing one."""
+    if schedule.action_type == "new_session":
+        await _create_new_session(schedule)
+    elif schedule.action_type == "message_existing":
+        await _message_existing(schedule)
+    else:
+        raise ValueError(f"Unknown action_type: {schedule.action_type}")
+
+
+async def _create_new_session(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+    from backend.apps.agents.models import AgentConfig
+
+    config_kwargs: dict = {
+        "dashboard_id": schedule.dashboard_id,
+    }
+
+    if schedule.template_id:
+        try:
+            from backend.apps.templates.templates import _load as load_template
+            template = load_template(schedule.template_id)
+            if template.mode:
+                config_kwargs["mode"] = template.mode
+        except Exception:
+            logger.warning(f"Template {schedule.template_id} not found, using defaults")
+
+    if schedule.model:
+        config_kwargs["model"] = schedule.model
+    if schedule.mode:
+        config_kwargs["mode"] = schedule.mode
+    if schedule.system_prompt:
+        config_kwargs["system_prompt"] = schedule.system_prompt
+
+    config = AgentConfig(**config_kwargs)
+    session = await agent_manager.launch_agent(config)
+
+    await agent_manager.send_message(
+        session.id,
+        schedule.prompt,
+        mode=config_kwargs.get("mode"),
+        model=config_kwargs.get("model"),
+    )
+
+    logger.info(f"Schedule {schedule.id} created session {session.id}")
+
+
+async def _message_existing(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+
+    if not schedule.target_session_id:
+        raise ValueError("target_session_id required for message_existing action")
+
+    if schedule.target_session_id not in agent_manager.sessions:
+        raise ValueError(f"Session {schedule.target_session_id} not found or not active")
+
+    await agent_manager.send_message(
+        schedule.target_session_id,
+        schedule.prompt,
+    )
+
+    logger.info(f"Schedule {schedule.id} sent message to session {schedule.target_session_id}")

--- a/backend/apps/schedules/executor.py
+++ b/backend/apps/schedules/executor.py
@@ -19,6 +19,7 @@ async def _create_new_session(schedule: Schedule):
     from backend.apps.agents.models import AgentConfig
 
     config_kwargs: dict = {
+        "name": schedule.name,
         "dashboard_id": schedule.dashboard_id,
     }
 
@@ -40,6 +41,7 @@ async def _create_new_session(schedule: Schedule):
 
     config = AgentConfig(**config_kwargs)
     session = await agent_manager.launch_agent(config)
+    session.schedule_id = schedule.id
 
     await agent_manager.send_message(
         session.id,

--- a/backend/apps/schedules/models.py
+++ b/backend/apps/schedules/models.py
@@ -1,0 +1,70 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+from uuid import uuid4
+
+
+class Schedule(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    name: str = "Untitled Schedule"
+    enabled: bool = True
+    dashboard_id: str
+
+    # Trigger
+    trigger_type: str  # "cron" | "interval" | "once"
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+
+    # Action
+    action_type: str  # "new_session" | "message_existing"
+    prompt: str
+    target_session_id: Optional[str] = None
+
+    # Agent config (new_session only)
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+    # State
+    last_run_at: Optional[datetime] = None
+    next_run_at: Optional[datetime] = None
+    run_count: int = 0
+    last_error: Optional[str] = None
+
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class ScheduleCreate(BaseModel):
+    name: str = "Untitled Schedule"
+    dashboard_id: str
+    trigger_type: str
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: str
+    prompt: str
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+
+class ScheduleUpdate(BaseModel):
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    dashboard_id: Optional[str] = None
+    trigger_type: Optional[str] = None
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: Optional[str] = None
+    prompt: Optional[str] = None
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None

--- a/backend/apps/schedules/scheduler.py
+++ b/backend/apps/schedules/scheduler.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+_scheduler_task: asyncio.Task | None = None
+TICK_INTERVAL = 30
+
+
+async def _tick():
+    """One evaluation cycle: check all enabled schedules, fire due ones."""
+    from backend.apps.schedules.schedules import _load_all, _save
+    from backend.apps.schedules.executor import execute_schedule
+
+    now = datetime.now()
+    for schedule in _load_all():
+        if not schedule.enabled:
+            continue
+        if schedule.next_run_at is None:
+            continue
+        if schedule.next_run_at > now:
+            continue
+
+        try:
+            await execute_schedule(schedule)
+            schedule.last_run_at = now
+            schedule.run_count += 1
+            schedule.last_error = None
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_complete", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+            })
+        except Exception as e:
+            logger.exception(f"Schedule {schedule.id} ({schedule.name}) failed")
+            schedule.last_error = str(e)
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_failed", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+                "error": str(e),
+            })
+
+        schedule.next_run_at = _compute_next_run(schedule, now)
+
+        if schedule.trigger_type == "once":
+            schedule.enabled = False
+
+        schedule.updated_at = now
+        _save(schedule)
+
+
+def _compute_next_run(schedule, after: datetime) -> datetime | None:
+    """Compute the next run time based on trigger type."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, after).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return after + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once":
+        return None
+    return None
+
+
+def compute_initial_next_run(schedule) -> datetime | None:
+    """Compute the first next_run_at when a schedule is created."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, datetime.now()).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return datetime.now() + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once" and schedule.run_at:
+        return schedule.run_at
+    return None
+
+
+async def _run_loop():
+    """Main scheduler loop — ticks every TICK_INTERVAL seconds."""
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.exception("Scheduler tick failed")
+        await asyncio.sleep(TICK_INTERVAL)
+
+
+def start_scheduler():
+    """Start the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task is None or _scheduler_task.done():
+        loop = asyncio.get_event_loop()
+        _scheduler_task = loop.create_task(_run_loop())
+        logger.info("Scheduler started (tick interval: %ds)", TICK_INTERVAL)
+
+
+def stop_scheduler():
+    """Stop the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task and not _scheduler_task.done():
+        _scheduler_task.cancel()
+        _scheduler_task = None
+        logger.info("Scheduler stopped")

--- a/backend/apps/schedules/scheduler.py
+++ b/backend/apps/schedules/scheduler.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 logger = logging.getLogger(__name__)
 
 _scheduler_task: asyncio.Task | None = None
-TICK_INTERVAL = 30
+TICK_INTERVAL = 5
 
 
 async def _tick():
@@ -44,7 +44,9 @@ async def _tick():
                 "error": str(e),
             })
 
-        schedule.next_run_at = _compute_next_run(schedule, now)
+        # Compute next_run_at relative to current time (after execution),
+        # not the stale `now` from tick start, to avoid stacking missed runs
+        schedule.next_run_at = _compute_next_run(schedule, datetime.now())
 
         if schedule.trigger_type == "once":
             schedule.enabled = False

--- a/backend/apps/schedules/schedules.py
+++ b/backend/apps/schedules/schedules.py
@@ -1,0 +1,139 @@
+import json
+import os
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime
+
+from backend.config.Apps import SubApp
+from backend.apps.schedules.models import Schedule, ScheduleCreate, ScheduleUpdate
+from backend.apps.schedules.scheduler import start_scheduler, stop_scheduler, compute_initial_next_run
+from backend.config.paths import SCHEDULES_DIR as DATA_DIR
+from fastapi import HTTPException, Query
+
+logger = logging.getLogger(__name__)
+
+
+def _load_all() -> list[Schedule]:
+    result = []
+    if not os.path.exists(DATA_DIR):
+        return result
+    for fname in os.listdir(DATA_DIR):
+        if fname.endswith(".json"):
+            with open(os.path.join(DATA_DIR, fname)) as f:
+                result.append(Schedule(**json.load(f)))
+    return result
+
+
+def _save(schedule: Schedule):
+    with open(os.path.join(DATA_DIR, f"{schedule.id}.json"), "w") as f:
+        json.dump(schedule.model_dump(mode="json"), f, indent=2)
+
+
+def _load(schedule_id: str) -> Schedule:
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    with open(path) as f:
+        return Schedule(**json.load(f))
+
+
+def _delete(schedule_id: str):
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def delete_schedules_for_dashboard(dashboard_id: str):
+    """Remove all schedules tied to a dashboard. Called during dashboard deletion."""
+    for schedule in _load_all():
+        if schedule.dashboard_id == dashboard_id:
+            _delete(schedule.id)
+            logger.info(f"Deleted schedule {schedule.id} (dashboard {dashboard_id} deleted)")
+
+
+@asynccontextmanager
+async def schedules_lifespan():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    start_scheduler()
+    try:
+        yield
+    finally:
+        stop_scheduler()
+
+
+schedules = SubApp("schedules", schedules_lifespan)
+
+
+@schedules.router.get("/list")
+async def list_schedules(dashboard_id: str | None = Query(None)):
+    all_schedules = _load_all()
+    if dashboard_id:
+        all_schedules = [s for s in all_schedules if s.dashboard_id == dashboard_id]
+    all_schedules.sort(key=lambda s: s.updated_at or s.created_at, reverse=True)
+    return {"schedules": [s.model_dump(mode="json") for s in all_schedules]}
+
+
+@schedules.router.post("/create")
+async def create_schedule(body: ScheduleCreate):
+    schedule = Schedule(
+        name=body.name,
+        dashboard_id=body.dashboard_id,
+        trigger_type=body.trigger_type,
+        cron_expression=body.cron_expression,
+        interval_seconds=body.interval_seconds,
+        run_at=body.run_at,
+        action_type=body.action_type,
+        prompt=body.prompt,
+        target_session_id=body.target_session_id,
+        template_id=body.template_id,
+        model=body.model,
+        mode=body.mode,
+        system_prompt=body.system_prompt,
+    )
+    schedule.next_run_at = compute_initial_next_run(schedule)
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.get("/{schedule_id}")
+async def get_schedule(schedule_id: str):
+    return _load(schedule_id).model_dump(mode="json")
+
+
+@schedules.router.put("/{schedule_id}")
+async def update_schedule(schedule_id: str, body: ScheduleUpdate):
+    schedule = _load(schedule_id)
+    trigger_changed = False
+
+    for field_name in body.model_fields_set:
+        value = getattr(body, field_name)
+        setattr(schedule, field_name, value)
+        if field_name in ("trigger_type", "cron_expression", "interval_seconds", "run_at"):
+            trigger_changed = True
+
+    if trigger_changed:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.delete("/{schedule_id}")
+async def delete_schedule_endpoint(schedule_id: str):
+    _load(schedule_id)  # 404 if not found
+    _delete(schedule_id)
+    return {"ok": True}
+
+
+@schedules.router.post("/{schedule_id}/toggle")
+async def toggle_schedule(schedule_id: str):
+    schedule = _load(schedule_id)
+    schedule.enabled = not schedule.enabled
+
+    if schedule.enabled and schedule.next_run_at is None:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")

--- a/backend/apps/settings/llm_router.py
+++ b/backend/apps/settings/llm_router.py
@@ -1,0 +1,91 @@
+"""
+LLM Router — routes LLM calls through direct Anthropic API or Claude Code CLI.
+
+When an API key is configured, uses direct API calls (faster, lower latency).
+When no API key is set, falls back to Claude Code CLI via claude_agent_sdk,
+which uses the user's existing CLI authentication.
+"""
+
+import logging
+import sys
+
+from backend.apps.settings.settings import load_settings
+
+logger = logging.getLogger(__name__)
+
+MODEL_MAP = {
+    "sonnet": "claude-sonnet-4-20250514",
+    "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
+
+def _resolve_model(short_name: str) -> str:
+    return MODEL_MAP.get(short_name, short_name)
+
+
+async def llm_call(
+    system: str,
+    user_message: str,
+    model: str = "haiku",
+    max_tokens: int = 100,
+) -> str:
+    """Make a one-shot LLM call, routing through API or CLI as appropriate.
+
+    Returns the text response from the model.
+    Raises on failure (callers should wrap in try/except if they have fallbacks).
+    """
+    settings = load_settings()
+    if settings.anthropic_api_key:
+        return await _api_call(settings.anthropic_api_key, system, user_message, model, max_tokens)
+    return await _cli_call(system, user_message, model, max_tokens)
+
+
+async def _api_call(
+    api_key: str,
+    system: str,
+    user_message: str,
+    model: str,
+    max_tokens: int,
+) -> str:
+    import anthropic
+
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+    resp = await client.messages.create(
+        model=_resolve_model(model),
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    return resp.content[0].text.strip()
+
+
+async def _cli_call(
+    system: str,
+    user_message: str,
+    model: str,
+    max_tokens: int,
+) -> str:
+    from claude_agent_sdk import query, ClaudeAgentOptions
+    from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=system,
+        max_turns=1,
+        permission_mode="plan",  # no tool use, just text generation
+        stderr=lambda line: None,  # suppress CLI startup noise
+    )
+
+    text_parts: list[str] = []
+    async for message in query(prompt=user_message, options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text_parts.append(block.text)
+
+    result = "".join(text_parts).strip()
+    if not result:
+        raise ValueError("CLI returned empty response")
+    return result

--- a/backend/apps/tools_lib/tools_lib.py
+++ b/backend/apps/tools_lib/tools_lib.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import re
+import sys
 import logging
 import shutil
 import time
@@ -235,7 +236,8 @@ def _sync_external_config(tool: ToolDefinition):
             config["ct0"] = ct0
             with open(_XBIRD_CONFIG_PATH, "w") as f:
                 json.dump(config, f, indent=2)
-            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
             logger.info("Synced xbird credentials to %s", _XBIRD_CONFIG_PATH)
     elif tool.name == "xbird" and not tool.credentials:
         if os.path.exists(_XBIRD_CONFIG_PATH):
@@ -290,6 +292,24 @@ def _sanitize_server_name(name: str) -> str:
 def _extra_bin_dirs() -> list[str]:
     """Well-known user-local bin directories that may not be on PATH in packaged apps."""
     home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
     dirs = [
         os.path.join(home, ".bun", "bin"),
         os.path.join(home, ".cargo", "bin"),

--- a/backend/config/paths.py
+++ b/backend/config/paths.py
@@ -34,6 +34,7 @@ OUTPUTS_DIR = os.path.join(DATA_ROOT, "outputs")
 OUTPUTS_WORKSPACE_DIR = os.path.join(DATA_ROOT, "outputs_workspace")
 SKILLS_WORKSPACE_DIR = os.path.join(DATA_ROOT, "skills_workspace")
 DASHBOARD_LAYOUT_DIR = os.path.join(DATA_ROOT, "dashboard_layout")
+SCHEDULES_DIR = os.path.join(DATA_ROOT, "schedules")
 BUILTIN_PERMISSIONS_PATH = os.path.join(DATA_ROOT, "builtin_permissions.json")
 
 BACKEND_DIR = _BACKEND_DIR

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,11 +19,12 @@ from backend.apps.mcp_registry.mcp_registry import mcp_registry
 from backend.apps.skill_registry.skill_registry import skill_registry
 from backend.apps.outputs.outputs import outputs
 from backend.apps.dashboards.dashboards import dashboards
+from backend.apps.schedules.schedules import schedules
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import WebSocket, WebSocketDisconnect
 import json
 
-main_app = MainApp([health, agents, templates, skills, tools_lib, modes, settings, mcp_registry, skill_registry, outputs, dashboards])
+main_app = MainApp([health, agents, templates, skills, tools_lib, modes, settings, mcp_registry, skill_registry, outputs, dashboards, schedules])
 app = main_app.app
 
 app.add_middleware(
@@ -135,13 +136,11 @@ async def browser_agent_run(request: Request):
         return JSONResponse({"error": "tasks array is required"}, status_code=400)
 
     settings = load_settings()
-    if not settings.anthropic_api_key:
-        return JSONResponse({"error": "Anthropic API key not configured"}, status_code=400)
 
     results = await run_browser_agents(
         tasks=tasks,
         model=model,
-        api_key=settings.anthropic_api_key,
+        api_key=settings.anthropic_api_key or None,
         dashboard_id=dashboard_id or None,
         pre_selected_browser_ids=pre_selected_browser_ids,
         parent_session_id=parent_session_id or None,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ pytest-asyncio==0.25.2
 typeguard==4.4.2
 python-dotenv==1.1.1
 Pillow
+croniter

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -10,29 +10,71 @@ const backendDir = __dirname;
 const isWindows = process.platform === 'win32';
 
 // --- Locate Python ---
+function getPythonVersion(cmd, args = ['--version']) {
+  try {
+    const output = execFileSync(cmd, args, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Extract version number from "Python X.Y.Z"
+    const match = output.match(/Python (\d+)\.(\d+)/);
+    if (match) {
+      return { cmd, args: args.length > 1 ? args.slice(0, -1) : [], major: parseInt(match[1]), minor: parseInt(match[2]), output };
+    }
+  } catch {
+    // not found
+  }
+  return null;
+}
+
 function findPython() {
+  const found = [];
+
+  if (isWindows) {
+    // Windows py launcher — try specific compatible versions first
+    for (const ver of ['3.13', '3.12', '3.11']) {
+      const result = getPythonVersion('py', [`-${ver}`, '--version']);
+      if (result) {
+        found.push({ cmd: 'py', args: [`-${ver}`], ...result });
+      }
+    }
+  }
+
+  // Generic commands
   const candidates = isWindows
     ? ['python', 'python3']
     : ['python3', 'python'];
   for (const cmd of candidates) {
-    try {
-      const version = execFileSync(cmd, ['--version'], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      console.log(`Found ${version} (${cmd})`);
-      return cmd;
-    } catch {
-      // not found, try next
+    const result = getPythonVersion(cmd);
+    if (result) {
+      found.push({ cmd, args: [], ...result });
     }
   }
+
+  // Prefer 3.11-3.13 (known compatible), then any 3.11+
+  const compatible = found.filter(p => p.major === 3 && p.minor >= 11 && p.minor <= 13);
+  const selected = compatible[0] || found.find(p => p.major === 3 && p.minor >= 11);
+
+  if (selected) {
+    const fullCmd = selected.args.length ? `${selected.cmd} ${selected.args.join(' ')}` : selected.cmd;
+    console.log(`Found ${selected.output} (${fullCmd})`);
+    return { cmd: selected.cmd, args: selected.args };
+  }
+
+  if (found.length > 0) {
+    const p = found[0];
+    console.warn(`Warning: Found Python ${p.major}.${p.minor} but 3.11-3.13 is recommended.`);
+    console.warn('Some dependencies may not have pre-built wheels for this version.');
+    return { cmd: p.cmd, args: p.args };
+  }
+
   console.error(
-    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+    'Error: Python not found. Install Python 3.11-3.13 and ensure it is on your PATH.'
   );
   process.exit(1);
 }
 
-const pythonCmd = findPython();
+const python = findPython();
 
 // --- Venv setup ---
 const venvDir = join(backendDir, '.venv');
@@ -51,6 +93,8 @@ const env = {
   ...process.env,
   PATH: venvBin + delimiter + (process.env.PATH || ''),
   VIRTUAL_ENV: venvDir,
+  // Force UTF-8 on Windows so open() without encoding= matches macOS/Linux behavior
+  ...(isWindows ? { PYTHONUTF8: '1' } : {}),
 };
 
 function run(cmd, args, options = {}) {
@@ -73,7 +117,7 @@ try {
   // --- Create virtual environment if needed ---
   if (!existsSync(venvDir)) {
     console.log('Creating virtual environment...');
-    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+    await run(python.cmd, [...python.args, '-m', 'venv', venvDir], { env: process.env });
   }
 
   // --- Install debugger module if not installed ---

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -1,0 +1,111 @@
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -144,6 +144,11 @@ try {
       '--host', '0.0.0.0',
       '--port', '8324',
       '--reload',
+      // On Windows, uvicorn's default loop factory picks SelectorEventLoop when
+      // --reload is active, which cannot spawn subprocesses (needed by claude_agent_sdk).
+      // '--loop none' tells uvicorn to skip its factory and use Python's default event
+      // loop (ProactorEventLoop on Windows), which supports subprocesses.
+      ...(isWindows ? ['--loop', 'none'] : []),
       '--reload-dir', backendDir,
       '--reload-exclude', '*.pyc',
     ],

--- a/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
+++ b/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
@@ -1,0 +1,853 @@
+# Windows & Linux Dev-Mode Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make OpenSwarm runnable in dev mode on Windows and Linux via cross-platform Node.js orchestration scripts and targeted platform fixes.
+
+**Architecture:** Three new `.mjs` scripts (`run.mjs`, `backend/run.mjs`, `frontend/run.mjs`) replace the Bash `.sh` scripts with cross-platform Node.js equivalents. Existing `.sh` files are untouched. Platform-specific code in `electron/main.js` and `backend/apps/tools_lib/tools_lib.py` is patched to handle Windows paths and conventions.
+
+**Tech Stack:** Node.js (ESM), child_process, http module, Python venv
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/run.mjs` | npm install + npm run dev |
+| Create | `backend/run.mjs` | venv setup, pip install, uvicorn start |
+| Create | `run.mjs` | Orchestrate backend, frontend, Electron; health checks; shutdown |
+| Modify | `electron/main.js` | Windows Python path, cross-platform PATH delimiters |
+| Modify | `electron/package.json` | Cross-platform dev/postinstall scripts |
+| Modify | `backend/apps/tools_lib/tools_lib.py` | Windows bin dirs, chmod guard |
+| Modify | `frontend/package.json` | Cross-platform clean script |
+
+---
+
+### Task 1: Create `frontend/run.mjs`
+
+The simplest script — good place to establish the pattern.
+
+**Files:**
+- Create: `frontend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify it works**
+
+Run from the project root:
+```bash
+node frontend/run.mjs
+```
+Expected: npm install runs, then webpack dev server starts on `http://localhost:3000`. Ctrl+C stops it cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/run.mjs
+git commit -m "feat: add cross-platform frontend/run.mjs"
+```
+
+---
+
+### Task 2: Create `backend/run.mjs`
+
+Handles Python venv creation, activation (via PATH manipulation), pip install, and uvicorn startup.
+
+**Files:**
+- Create: `backend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify venv creation and uvicorn start**
+
+Run from the project root:
+```bash
+node backend/run.mjs
+```
+Expected: Creates `.venv` if missing, installs deps, starts uvicorn on port 8324. Ctrl+C stops it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/run.mjs
+git commit -m "feat: add cross-platform backend/run.mjs"
+```
+
+---
+
+### Task 3: Create `run.mjs` (root orchestrator)
+
+Spawns backend and frontend, health-checks both, launches Electron, handles graceful shutdown.
+
+**Files:**
+- Create: `run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}
+```
+
+- [ ] **Step 2: Verify full orchestration**
+
+Run from the project root:
+```bash
+node run.mjs
+```
+Expected: Backend starts and becomes healthy, frontend starts and becomes healthy, Electron launches. Ctrl+C gracefully shuts down all three. On unexpected exit of any service, the others are torn down.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add run.mjs
+git commit -m "feat: add cross-platform run.mjs orchestrator"
+```
+
+---
+
+### Task 4: Fix `electron/main.js` for Windows paths
+
+**Files:**
+- Modify: `electron/main.js:93` (PATH split)
+- Modify: `electron/main.js:98` (PATH join)
+- Modify: `electron/main.js:108-115` (getPythonPath)
+- Modify: `electron/main.js:164` (PYTHONPATH join)
+- Modify: `electron/main.js:289-300` (killBackend)
+
+- [ ] **Step 1: Fix `getPythonPath()` to use Windows paths**
+
+Change lines 108-115 from:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return path.join(envPath, 'bin', 'python3');
+  }
+  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+  return venvPython;
+}
+```
+
+To:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
+  }
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+}
+```
+
+- [ ] **Step 2: Fix PATH separator on line 93**
+
+Change line 93 from:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+```
+
+To:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
+```
+
+- [ ] **Step 3: Fix PATH join on line 98**
+
+Change line 98 from:
+
+```javascript
+  return dirs.join(':');
+```
+
+To:
+
+```javascript
+  return dirs.join(path.delimiter);
+```
+
+- [ ] **Step 4: Fix PYTHONPATH join on line 164**
+
+Change line 164 from:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+```
+
+To:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
+```
+
+- [ ] **Step 5: Fix `killBackend()` for Windows**
+
+Change lines 289-300 from:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    backendProcess.kill('SIGTERM');
+    setTimeout(() => {
+      if (backendProcess && !backendProcess.killed) {
+        backendProcess.kill('SIGKILL');
+      }
+    }, 3000);
+    backendProcess = null;
+  }
+}
+```
+
+To:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    if (process.platform === 'win32') {
+      try {
+        // PID is a numeric value from Node child_process — safe to pass as argument
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
+    backendProcess = null;
+  }
+}
+```
+
+Note: change the import on line 5 from `const { spawn, execFileSync } = require('child_process');` — `execFileSync` is already imported.
+
+- [ ] **Step 6: Verify Electron launches in dev mode**
+
+With backend and frontend already running (via `node backend/run.mjs` and `node frontend/run.mjs` in separate terminals):
+```bash
+cd electron && npx cross-env ELECTRON_DEV=1 npx electron .
+```
+Expected: Electron window opens, loads `http://localhost:3000`, no errors in console about Python paths.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/main.js
+git commit -m "fix: make electron main.js cross-platform (Windows paths, delimiters, process kill)"
+```
+
+---
+
+### Task 5: Fix `electron/package.json` scripts
+
+**Files:**
+- Modify: `electron/package.json`
+- Create: `electron/scripts/postinstall.mjs`
+
+- [ ] **Step 1: Install cross-env as a dev dependency**
+
+```bash
+cd electron && npm install --save-dev cross-env
+```
+
+- [ ] **Step 2: Update the `dev` and `postinstall` scripts**
+
+Change the `"scripts"` section from:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "ELECTRON_DEV=1 electron .",
+    "postinstall": "bash scripts/sign-vmp.sh",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+To:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+- [ ] **Step 3: Create `electron/scripts/postinstall.mjs`**
+
+```javascript
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}
+```
+
+- [ ] **Step 4: Verify npm install works without error**
+
+```bash
+cd electron && npm install
+```
+Expected: On Windows/Linux, prints `[postinstall] Skipping VMP signing (macOS only)` and succeeds. On macOS, runs the existing sign-vmp.sh.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/package.json electron/scripts/postinstall.mjs
+git commit -m "fix: make electron package.json scripts cross-platform"
+```
+
+---
+
+### Task 6: Fix `backend/apps/tools_lib/tools_lib.py` for Windows
+
+**Files:**
+- Modify: `backend/apps/tools_lib/tools_lib.py:4` (add `sys` import)
+- Modify: `backend/apps/tools_lib/tools_lib.py:291-314` (`_extra_bin_dirs`)
+- Modify: `backend/apps/tools_lib/tools_lib.py:238` (`os.chmod`)
+
+- [ ] **Step 1: Add `sys` import**
+
+Add `import sys` after `import re` on line 4, so lines 3-5 become:
+
+```python
+import os
+import re
+import sys
+import logging
+```
+
+- [ ] **Step 2: Fix `_extra_bin_dirs()` for Windows**
+
+Change the `_extra_bin_dirs()` function (lines 291-314) from:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+To:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+- [ ] **Step 3: Guard `os.chmod()` call**
+
+Change line 238 from:
+
+```python
+            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+To:
+
+```python
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+- [ ] **Step 4: Verify the backend starts without errors**
+
+```bash
+node backend/run.mjs
+```
+Expected: uvicorn starts, no import errors or platform-related crashes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/apps/tools_lib/tools_lib.py
+git commit -m "fix: make tools_lib bin dirs and chmod cross-platform"
+```
+
+---
+
+### Task 7: Fix `frontend/package.json` clean script
+
+**Files:**
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Replace Unix-only `rm -rf` with cross-platform alternative**
+
+Change the `"clean"` script from:
+
+```json
+    "clean": "rm -rf dist"
+```
+
+To:
+
+```json
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
+```
+
+- [ ] **Step 2: Verify clean works**
+
+```bash
+cd frontend && npm run clean
+```
+Expected: No error, `dist/` removed if it exists, no-op if it doesn't.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/package.json
+git commit -m "fix: make frontend clean script cross-platform"
+```
+
+---
+
+### Task 8: End-to-end verification
+
+- [ ] **Step 1: Full startup test**
+
+From the project root:
+```bash
+node run.mjs
+```
+
+Verify:
+1. Backend venv is created (if first run)
+2. Backend dependencies install
+3. Backend server starts on port 8324
+4. Frontend dependencies install
+5. Frontend dev server starts on port 3000
+6. Electron window opens and loads the app
+7. Ctrl+C gracefully stops all three processes
+
+- [ ] **Step 2: Restart test**
+
+Run `node run.mjs` again after Ctrl+C. Verify it starts cleanly (venv already exists, deps already installed, should be faster).
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any fixes were needed during testing, commit them:
+```bash
+git add -A
+git commit -m "fix: address issues found during cross-platform dev-mode testing"
+```

--- a/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
+++ b/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
@@ -1,0 +1,81 @@
+# Windows (& Linux) Dev-Mode Support
+
+**Date:** 2026-04-09
+**Scope:** Development mode only — no packaged app builds
+
+## Goal
+
+Make OpenSwarm runnable in dev mode on Windows and Linux by replacing the Bash orchestration scripts with cross-platform Node.js equivalents and fixing platform-specific code paths in the Electron main process and Python backend.
+
+## Approach
+
+Add three new `.mjs` scripts that mirror the existing `.sh` scripts but work on all platforms. Existing `.sh` files are untouched — zero risk to current macOS users.
+
+## New Files
+
+### `run.mjs` (root orchestrator)
+
+Replaces `run.sh`. Responsibilities:
+
+- Spawns `node backend/run.mjs` and `node frontend/run.mjs` as child processes
+- Prefixes stdout with colored `[backend]` / `[frontend]` / `[electron]` tags using ANSI codes (no dependencies)
+- Health-checks `http://localhost:8324` and `http://localhost:3000` via `http.get()` polling
+- Once both healthy, launches Electron with `ELECTRON_DEV=1` env var
+- Graceful shutdown on SIGINT/SIGTERM: sends SIGTERM on Unix, `taskkill /T /F /PID` on Windows
+- Monitors child PIDs — if any exit unexpectedly, tears down all others
+
+### `backend/run.mjs`
+
+Replaces `backend/run.sh`. Responsibilities:
+
+- Creates Python venv if `.venv` doesn't exist: `python -m venv .venv`
+- Activates venv by prepending the correct bin dir to PATH (`.venv/Scripts` on Windows, `.venv/bin` on Unix) — no `source activate` needed
+- Installs debugger module (`pip install -e .`) if not already installed
+- Installs Python dependencies (`pip install -r requirements.txt`)
+- Starts uvicorn: `python -m uvicorn backend.main:app --host 0.0.0.0 --port 8324 --reload`
+
+### `frontend/run.mjs`
+
+Replaces `frontend/run.sh`. Responsibilities:
+
+- Runs `npm install` in frontend directory
+- Runs `npm run dev`
+
+## Modified Files
+
+### `electron/main.js`
+
+- `getPythonPath()`: Return `.venv\Scripts\python.exe` on `win32`, `.venv/bin/python3` on Unix
+- Line 93/98: Change hardcoded `':'` PATH separator to `path.delimiter`
+- Line 164: Change `PYTHONPATH` join separator from `':'` to `path.delimiter`
+
+### `backend/apps/tools_lib/tools_lib.py`
+
+- `_extra_bin_dirs()`: On `win32`, return Windows-appropriate paths (`~\AppData\Roaming\npm`, `~\.cargo\bin`, `~\scoop\shims`) instead of Unix-only paths (`/opt/homebrew/bin`, `/usr/local/bin`, etc.)
+- `os.chmod(_XBIRD_CONFIG_PATH, 0o600)`: Wrap in `if sys.platform != 'win32'` guard — Windows doesn't support Unix permissions; files are already user-private by default
+
+### `electron/package.json`
+
+- `"dev"` script: Either use `cross-env` for env var setting or rely on `run.mjs` setting `ELECTRON_DEV=1` (making the npm script moot in the cross-platform workflow)
+- `"postinstall"`: Guard VMP signing script with platform check so it doesn't fail on Windows/Linux
+
+## Error Handling
+
+- **Python not found**: `backend/run.mjs` checks for `python`/`python3` on PATH at startup, exits with clear error
+- **Port conflicts**: Preserved existing behavior — uvicorn/webpack error naturally
+- **Windows long paths**: Not expected for dev mode; users can enable `git config --system core.longpaths true` if needed
+- **Line endings**: Node.js handles natively — no `sed` stripping needed
+
+## Out of Scope
+
+- Existing `.sh` files (untouched)
+- Build/publish scripts (`scripts/build-app.sh`, `scripts/build-python-env.sh`, `publish.sh`)
+- Packaged Windows/Linux Electron builds (`.exe`, `.deb`, etc.)
+- CI/CD pipeline
+- Backend Python application code (already cross-platform except the two fixes above)
+- Frontend React code (already platform-agnostic)
+
+## Testing
+
+- Manual testing on Windows, ideally verified on macOS/Linux too
+- Verify: venv creation, pip install, uvicorn starts, frontend starts, Electron launches, Ctrl+C clean shutdown

--- a/electron/main.js
+++ b/electron/main.js
@@ -90,12 +90,12 @@ function getShellPath() {
 
   const seen = new Set();
   const dirs = [];
-  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
     if (!d || seen.has(d)) continue;
     seen.add(d);
     try { if (fs.statSync(d).isDirectory()) dirs.push(d); } catch { /* skip */ }
   }
-  return dirs.join(':');
+  return dirs.join(path.delimiter);
 }
 
 function getResourcePath(...segments) {
@@ -108,10 +108,13 @@ function getResourcePath(...segments) {
 function getPythonPath() {
   if (isPackaged) {
     const envPath = path.join(process.resourcesPath, 'python-env');
-    return path.join(envPath, 'bin', 'python3');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
   }
-  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
-  return venvPython;
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
 }
 
 function waitForBackend(port, timeoutMs = 60000) {
@@ -161,7 +164,7 @@ async function startBackend() {
       'python3.13', 'site-packages'
     );
     const debuggerDir = getResourcePath('debugger');
-    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
   }
 
   console.log(`Starting backend: ${pythonPath} on port ${backendPort}`);
@@ -289,12 +292,18 @@ function setupAutoUpdater() {
 function killBackend() {
   if (backendProcess) {
     console.log('Killing backend process...');
-    backendProcess.kill('SIGTERM');
-    setTimeout(() => {
-      if (backendProcess && !backendProcess.killed) {
-        backendProcess.kill('SIGKILL');
-      }
-    }, 3000);
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
     backendProcess = null;
   }
 }

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
+        "cross-env": "^10.1.0",
         "electron": "castlabs/electron-releases#v33.4.11+wvcus",
         "electron-builder": "^25.1.0"
       }
@@ -363,6 +364,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -816,6 +824,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1013,7 +1022,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1033,7 +1041,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1056,7 +1063,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1072,8 +1078,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1081,7 +1086,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1709,7 +1713,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1834,7 +1837,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1848,13 +1850,30 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -2062,6 +2081,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -2256,7 +2276,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -2270,7 +2289,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2286,7 +2304,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2300,7 +2317,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2754,8 +2770,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3360,8 +3375,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3496,7 +3510,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3510,7 +3523,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3526,8 +3538,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3535,7 +3546,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3552,16 +3562,14 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3574,8 +3582,7 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3589,16 +3596,14 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4070,7 +4075,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4318,8 +4322,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4420,7 +4423,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4430,8 +4432,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4439,7 +4440,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4450,7 +4450,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4952,7 +4951,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5336,7 +5334,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -5352,7 +5349,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dev": "ELECTRON_DEV=1 electron .",
-    "postinstall": "bash scripts/sign-vmp.sh",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
     "sign-vmp": "bash scripts/sign-vmp.sh",
     "dist": "electron-builder --mac --publish never",
     "dist:publish": "electron-builder --mac --publish always",
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
+    "cross-env": "^10.1.0",
     "electron": "castlabs/electron-releases#v33.4.11+wvcus",
     "electron-builder": "^25.1.0"
   },

--- a/electron/scripts/postinstall.mjs
+++ b/electron/scripts/postinstall.mjs
@@ -1,0 +1,19 @@
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "build": "webpack --mode=production",
     "build:watch": "webpack --mode=development --watch",
     "dev": "webpack serve --mode=development",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.4.11",

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -1,0 +1,33 @@
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -12,6 +12,7 @@ function run(cmd, args) {
     const child = spawn(cmd, args, {
       cwd: __dirname,
       stdio: 'inherit',
+      shell: isWindows,
     });
     child.on('error', reject);
     child.on('exit', (code) => {

--- a/frontend/src/app/Main.tsx
+++ b/frontend/src/app/Main.tsx
@@ -22,6 +22,7 @@ import Tools from './pages/Tools/Tools';
 import Modes from './pages/Modes/Modes';
 import Views from './pages/Views/Views';
 import Customization from './pages/Customization/Customization';
+import Schedules from './pages/Schedules/Schedules';
 import { useKeyboardShortcuts } from '@/shared/hooks/useKeyboardShortcuts';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
 import { ThemeProvider, useThemeMode, useClaudeTokens } from '@/shared/styles/ThemeContext';
@@ -228,6 +229,7 @@ const ThemedApp: React.FC = () => {
                   <Route path="/modes" element={<Modes />} />
                   <Route path="/apps" element={<Views />} />
                   <Route path="/apps/:id" element={<Views />} />
+                  <Route path="/schedules" element={<Schedules />} />
                 </Route>
               </Routes>
             </UpdateListener>

--- a/frontend/src/app/components/Layout/AppShell.tsx
+++ b/frontend/src/app/components/Layout/AppShell.tsx
@@ -29,6 +29,8 @@ import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import CloseIcon from '@mui/icons-material/Close';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import Badge from '@mui/material/Badge';
 import LinearProgress from '@mui/material/LinearProgress';
 import Settings from '@/app/pages/Settings/Settings';
 import DynamicIsland from '@/app/components/DynamicIsland';
@@ -39,6 +41,7 @@ import { setPendingBrowserUrl } from '@/shared/state/tempStateSlice';
 import { fetchOutputs } from '@/shared/state/outputsSlice';
 import { findBrowserByWebContentsId } from '@/shared/browserRegistry';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import { dashboardWs } from '@/shared/ws/WebSocketManager';
 
 const SIDEBAR_MIN = 160;
 const SIDEBAR_MAX = 400;
@@ -51,6 +54,7 @@ const CUSTOMIZATION_ITEMS = [
   { label: 'Skills', path: '/skills', icon: <PsychologyIcon /> },
   { label: 'Actions', path: '/actions', icon: <BuildIcon /> },
   { label: 'Modes', path: '/modes', icon: <TuneIcon /> },
+  { label: 'Schedules', path: '/schedules', icon: <ScheduleIcon /> },
 ];
 
 const CUSTOMIZATION_PATHS = new Set(CUSTOMIZATION_ITEMS.map((i) => i.path));
@@ -83,11 +87,13 @@ const AppShell: React.FC = () => {
   const updateStatus = useAppSelector((state) => state.update.status);
   const availableVersion = useAppSelector((state) => state.update.availableVersion);
   const downloadPercent = useAppSelector((state) => state.update.downloadPercent);
+  const scheduleUnread = useAppSelector((s) => s.schedules.unreadCount);
 
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(() => {
     try { return localStorage.getItem(UPDATE_DISMISS_KEY); } catch { return null; }
   });
   const [snackbarDismissed, setSnackbarDismissed] = useState(false);
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   const bannerDismissedForVersion = availableVersion != null && dismissedVersion === availableVersion;
   const isUpdateActionable = updateStatus === 'available' || updateStatus === 'downloaded' || updateStatus === 'downloading';
@@ -109,6 +115,13 @@ const AppShell: React.FC = () => {
 
   const handleInstallUpdate = useCallback(() => {
     (window as any).openswarm?.installUpdate();
+  }, []);
+
+  useEffect(() => {
+    const unsub = dashboardWs.on('schedule:run_failed', (data: any) => {
+      setScheduleError(`Schedule "${data.name}" failed: ${data.error}`);
+    });
+    return unsub;
   }, []);
 
   const dashboardItems = useAppSelector((state) => state.dashboards.items);
@@ -705,20 +718,39 @@ const AppShell: React.FC = () => {
                           transition: 'background-color 0.12s, border-color 0.12s',
                         }}
                       >
-                        <Typography
-                          sx={{
-                            color: isActive ? c.text.secondary : c.text.ghost,
-                            fontSize: '0.78rem',
-                            fontWeight: isActive ? 500 : 400,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            flex: 1,
-                            minWidth: 0,
-                          }}
-                        >
-                          {item.label}
-                        </Typography>
+                        {item.label === 'Schedules' ? (
+                          <Badge badgeContent={scheduleUnread} color="error" max={99} sx={{ flex: 1, minWidth: 0, '& .MuiBadge-badge': { right: -8, top: 6 } }}>
+                            <Typography
+                              sx={{
+                                color: isActive ? c.text.secondary : c.text.ghost,
+                                fontSize: '0.78rem',
+                                fontWeight: isActive ? 500 : 400,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                flex: 1,
+                                minWidth: 0,
+                              }}
+                            >
+                              {item.label}
+                            </Typography>
+                          </Badge>
+                        ) : (
+                          <Typography
+                            sx={{
+                              color: isActive ? c.text.secondary : c.text.ghost,
+                              fontSize: '0.78rem',
+                              fontWeight: isActive ? 500 : 400,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              flex: 1,
+                              minWidth: 0,
+                            }}
+                          >
+                            {item.label}
+                          </Typography>
+                        )}
                       </Box>
                     )}
                   </NavLink>
@@ -997,6 +1029,15 @@ const AppShell: React.FC = () => {
           {updateStatus === 'available' && `OpenSwarm ${availableVersion} is available`}
           {updateStatus === 'downloaded' && `OpenSwarm ${availableVersion} downloaded — restart to update`}
         </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={!!scheduleError}
+        autoHideDuration={6000}
+        onClose={() => setScheduleError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert severity="error" onClose={() => setScheduleError(null)}>{scheduleError}</Alert>
       </Snackbar>
     </Box>
   );

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -753,7 +753,7 @@ const AgentCard: React.FC<Props> = ({
               <Tooltip title="View Schedule">
                 <IconButton
                   size="small"
-                  onClick={() => onEditSchedule?.(session.schedule_id!)}
+                  onClick={(e) => { e.stopPropagation(); onEditSchedule?.(session.schedule_id!); }}
                   onMouseDown={(e) => e.stopPropagation()}
                   sx={{
                     color: c.accent.primary,

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -188,6 +188,7 @@ interface Props {
   autoFocusInput?: boolean;
   cardZOrder?: number;
   onBringToFront?: (id: string, type: 'agent' | 'view' | 'browser') => void;
+  onEditSchedule?: (scheduleId: string) => void;
 }
 
 const MIN_W = 480;
@@ -204,7 +205,7 @@ const SNAP_THRESHOLD = 60;
 const AgentCard: React.FC<Props> = ({
   session, expanded, cardX, cardY, cardWidth, cardHeight, zoom = 1, spawnFrom, exitTarget,
   isSelected = false, isHighlighted = false, multiDragDelta, onCardSelect, onDragStart, onDragMove, onDragEnd,
-  onBranch, onMeasuredHeight, snapColumn, autoFocusInput, cardZOrder = 0, onBringToFront,
+  onBranch, onMeasuredHeight, snapColumn, autoFocusInput, cardZOrder = 0, onBringToFront, onEditSchedule,
 }) => {
   const c = useClaudeTokens();
   const dispatch = useAppDispatch();
@@ -752,7 +753,7 @@ const AgentCard: React.FC<Props> = ({
               <Tooltip title="View Schedule">
                 <IconButton
                   size="small"
-                  onClick={() => { window.location.hash = `/schedules?edit=${session.schedule_id}`; }}
+                  onClick={() => onEditSchedule?.(session.schedule_id!)}
                   onMouseDown={(e) => e.stopPropagation()}
                   sx={{
                     color: c.accent.primary,

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -12,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import ScheduleIcon from '@mui/icons-material/Schedule';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import { motion } from 'framer-motion';
 import {
   AgentSession,
@@ -72,6 +73,13 @@ const GoogleServiceIcon: React.FC<{ service: string; size?: number }> = ({ servi
   }
   return null;
 };
+
+function truncatePath(p: string): string {
+  const sep = p.includes('\\') ? '\\' : '/';
+  const parts = p.split(sep).filter(Boolean);
+  if (parts.length <= 3) return p;
+  return parts[0] + sep + '...' + sep + parts.slice(-2).join(sep);
+}
 
 function formatDuration(createdAt: string): string {
   const seconds = Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000);
@@ -804,6 +812,18 @@ const AgentCard: React.FC<Props> = ({
             </Typography>
           )}
         </Box>
+
+        {/* Working directory */}
+        {session.cwd && (
+          <Tooltip title={session.cwd}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25, flexShrink: 0, overflow: 'hidden' }}>
+              <FolderOutlinedIcon sx={{ fontSize: 13, color: c.text.ghost, flexShrink: 0 }} />
+              <Typography variant="caption" sx={{ color: c.text.ghost, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.7rem' }}>
+                {truncatePath(session.cwd)}
+              </Typography>
+            </Box>
+          </Tooltip>
+        )}
       </Box>
 
       {/* Expanded: inline chat fills remaining space */}

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -11,6 +11,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import TerminalIcon from '@mui/icons-material/Terminal';
+import ScheduleIcon from '@mui/icons-material/Schedule';
 import { motion } from 'framer-motion';
 import {
   AgentSession,
@@ -747,6 +748,22 @@ const AgentCard: React.FC<Props> = ({
             onPointerDown={(e) => e.stopPropagation()}
             sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0, ml: 0.5 }}
           >
+            {session.schedule_id && (
+              <Tooltip title="View Schedule">
+                <IconButton
+                  size="small"
+                  onClick={() => { window.location.hash = `/schedules?edit=${session.schedule_id}`; }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  sx={{
+                    color: c.accent.primary,
+                    p: 0.5,
+                    '&:hover': { bgcolor: `${c.accent.primary}22` },
+                  }}
+                >
+                  <ScheduleIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title={isDraft ? 'Remove' : 'Close chat'}>
               <IconButton
                 size="small"

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -54,6 +54,7 @@ import DashboardViewCard from './DashboardViewCard';
 import BrowserCard from './BrowserCard';
 import CanvasControls from './CanvasControls';
 import DashboardToolbar from './DashboardToolbar';
+import ScheduleEditor from '@/app/pages/Schedules/ScheduleEditor';
 import { captureDashboardThumbnail } from './captureDashboardThumbnail';
 import { useCanvasControls } from './useCanvasControls';
 import { useDashboardSelection } from './useDashboardSelection';
@@ -118,6 +119,7 @@ const DashboardInner: React.FC = () => {
 
   const [toolbarOpen, setToolbarOpen] = useState(false);
   const [highlightedCardId, setHighlightedCardId] = useState<string | null>(null);
+  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [autoFocusSessionId, setAutoFocusSessionId] = useState<string | null>(null);
   const [pendingSelectSessionId, setPendingSelectSessionId] = useState<string | null>(null);
@@ -1378,6 +1380,7 @@ const DashboardInner: React.FC = () => {
                   snapColumn={snapColumn}
                   autoFocusInput={autoFocusSessionId === session.id}
                   onBringToFront={handleBringToFront}
+                  onEditSchedule={setEditingScheduleId}
                 />
               );
             })}
@@ -1471,6 +1474,11 @@ const DashboardInner: React.FC = () => {
         <CanvasControls zoom={canvas.zoom} actions={canvas.actions} onTidy={handleTidy} />
       </Box>
     </Box>
+    <ScheduleEditor
+      open={editingScheduleId !== null}
+      scheduleId={editingScheduleId}
+      onClose={() => setEditingScheduleId(null)}
+    />
     </>
   );
 };

--- a/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
+++ b/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
@@ -1,0 +1,269 @@
+import React, { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import { createSchedule, updateSchedule, fetchSchedules } from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+
+interface Props {
+  open: boolean;
+  scheduleId: string | null;
+  onClose: () => void;
+}
+
+const TRIGGER_TYPES = [
+  { value: 'cron', label: 'Cron Expression' },
+  { value: 'interval', label: 'Interval' },
+  { value: 'once', label: 'One-shot' },
+];
+
+const ACTION_TYPES = [
+  { value: 'new_session', label: 'Create New Session' },
+  { value: 'message_existing', label: 'Message Existing Session' },
+];
+
+const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const existing = useAppSelector((s) => scheduleId ? s.schedules.items[scheduleId] : null);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const templates = useAppSelector((s) => s.templates.items);
+  const dashboardList = Object.values(dashboards);
+  const templateList = Object.values(templates);
+
+  const [name, setName] = useState('');
+  const [dashboardId, setDashboardId] = useState('');
+  const [triggerType, setTriggerType] = useState('cron');
+  const [cronExpression, setCronExpression] = useState('');
+  const [intervalSeconds, setIntervalSeconds] = useState(3600);
+  const [runAt, setRunAt] = useState('');
+  const [actionType, setActionType] = useState('new_session');
+  const [prompt, setPrompt] = useState('');
+  const [targetSessionId, setTargetSessionId] = useState('');
+  const [templateId, setTemplateId] = useState('');
+  const [model, setModel] = useState('sonnet');
+  const [mode, setMode] = useState('agent');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [configSource, setConfigSource] = useState<'template' | 'inline'>('inline');
+
+  useEffect(() => {
+    if (existing) {
+      setName(existing.name);
+      setDashboardId(existing.dashboard_id);
+      setTriggerType(existing.trigger_type);
+      setCronExpression(existing.cron_expression || '');
+      setIntervalSeconds(existing.interval_seconds || 3600);
+      setRunAt(existing.run_at || '');
+      setActionType(existing.action_type);
+      setPrompt(existing.prompt);
+      setTargetSessionId(existing.target_session_id || '');
+      setTemplateId(existing.template_id || '');
+      setModel(existing.model || 'sonnet');
+      setMode(existing.mode || 'agent');
+      setSystemPrompt(existing.system_prompt || '');
+      setConfigSource(existing.template_id ? 'template' : 'inline');
+    } else {
+      setName('');
+      setDashboardId(dashboardList[0]?.id || '');
+      setTriggerType('cron');
+      setCronExpression('');
+      setIntervalSeconds(3600);
+      setRunAt('');
+      setActionType('new_session');
+      setPrompt('');
+      setTargetSessionId('');
+      setTemplateId('');
+      setModel('sonnet');
+      setMode('agent');
+      setSystemPrompt('');
+      setConfigSource('inline');
+    }
+  }, [existing, open]);
+
+  const inputSx = {
+    '& .MuiOutlinedInput-root': {
+      color: c.text.primary,
+      '& fieldset': { borderColor: c.border.strong },
+      '&:hover fieldset': { borderColor: c.text.tertiary },
+      '&.Mui-focused fieldset': { borderColor: c.accent.primary },
+    },
+    '& .MuiInputLabel-root': { color: c.text.tertiary },
+    '& .MuiInputLabel-root.Mui-focused': { color: c.accent.primary },
+  };
+
+  const handleSave = async () => {
+    const body: any = {
+      name: name || 'Untitled Schedule',
+      dashboard_id: dashboardId,
+      trigger_type: triggerType,
+      action_type: actionType,
+      prompt,
+    };
+
+    if (triggerType === 'cron') body.cron_expression = cronExpression;
+    if (triggerType === 'interval') body.interval_seconds = intervalSeconds;
+    if (triggerType === 'once') body.run_at = runAt;
+
+    if (actionType === 'message_existing') {
+      body.target_session_id = targetSessionId;
+    } else if (configSource === 'template') {
+      body.template_id = templateId;
+    } else {
+      body.model = model;
+      body.mode = mode;
+      if (systemPrompt) body.system_prompt = systemPrompt;
+    }
+
+    if (scheduleId) {
+      await dispatch(updateSchedule({ id: scheduleId, ...body }));
+    } else {
+      await dispatch(createSchedule(body));
+    }
+
+    dispatch(fetchSchedules());
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { bgcolor: c.bg.surface, borderRadius: 4, border: `1px solid ${c.border.subtle}` } }}
+    >
+      <DialogTitle sx={{ color: c.text.primary, fontWeight: 700 }}>
+        {scheduleId ? 'Edit Schedule' : 'New Schedule'}
+      </DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} fullWidth size="small" sx={inputSx} />
+
+        <TextField
+          select label="Dashboard" value={dashboardId}
+          onChange={(e) => setDashboardId(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {dashboardList.map((d) => <MenuItem key={d.id} value={d.id}>{d.name}</MenuItem>)}
+        </TextField>
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Trigger</Typography>
+
+        <TextField
+          select label="Type" value={triggerType}
+          onChange={(e) => setTriggerType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {TRIGGER_TYPES.map((t) => <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>)}
+        </TextField>
+
+        {triggerType === 'cron' && (
+          <TextField
+            label="Cron Expression" value={cronExpression}
+            onChange={(e) => setCronExpression(e.target.value)} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 0 9 * * * (every day at 9am)"
+          />
+        )}
+        {triggerType === 'interval' && (
+          <TextField
+            label="Interval (seconds)" type="number" value={intervalSeconds}
+            onChange={(e) => setIntervalSeconds(Number(e.target.value))} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 3600 = every hour"
+          />
+        )}
+        {triggerType === 'once' && (
+          <TextField
+            label="Run At" type="datetime-local" value={runAt}
+            onChange={(e) => setRunAt(e.target.value)} fullWidth size="small" sx={inputSx}
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        )}
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Action</Typography>
+
+        <TextField
+          select label="Action Type" value={actionType}
+          onChange={(e) => setActionType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {ACTION_TYPES.map((a) => <MenuItem key={a.value} value={a.value}>{a.label}</MenuItem>)}
+        </TextField>
+
+        <TextField
+          label="Prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)}
+          fullWidth size="small" multiline minRows={3} sx={inputSx}
+        />
+
+        {actionType === 'message_existing' && (
+          <TextField
+            label="Target Session ID" value={targetSessionId}
+            onChange={(e) => setTargetSessionId(e.target.value)} fullWidth size="small" sx={inputSx}
+          />
+        )}
+
+        {actionType === 'new_session' && (
+          <>
+            <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Agent Config</Typography>
+
+            <TextField
+              select label="Config Source" value={configSource}
+              onChange={(e) => setConfigSource(e.target.value as 'template' | 'inline')}
+              fullWidth size="small" sx={inputSx}
+              SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+            >
+              <MenuItem value="inline">Configure Inline</MenuItem>
+              <MenuItem value="template">Use Template</MenuItem>
+            </TextField>
+
+            {configSource === 'template' ? (
+              <TextField
+                select label="Template" value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)} fullWidth size="small" sx={inputSx}
+                SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+              >
+                {templateList.map((t) => <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>)}
+              </TextField>
+            ) : (
+              <>
+                <TextField
+                  select label="Model" value={model}
+                  onChange={(e) => setModel(e.target.value)} fullWidth size="small" sx={inputSx}
+                  SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+                >
+                  <MenuItem value="sonnet">Sonnet</MenuItem>
+                  <MenuItem value="haiku">Haiku</MenuItem>
+                  <MenuItem value="opus">Opus</MenuItem>
+                </TextField>
+
+                <TextField
+                  label="Mode" value={mode}
+                  onChange={(e) => setMode(e.target.value)} fullWidth size="small" sx={inputSx}
+                />
+
+                <TextField
+                  label="System Prompt (optional)" value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  fullWidth size="small" multiline minRows={2} sx={inputSx}
+                />
+              </>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ color: c.text.muted }}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave} disabled={!prompt || !dashboardId} sx={{ bgcolor: c.accent.primary }}>
+          {scheduleId ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ScheduleEditor;

--- a/frontend/src/app/pages/Schedules/Schedules.tsx
+++ b/frontend/src/app/pages/Schedules/Schedules.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -59,10 +60,22 @@ const Schedules: React.FC = () => {
     (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
   );
 
+  const location = useLocation();
+
   useEffect(() => {
     dispatch(fetchSchedules());
     dispatch(clearUnread());
   }, [dispatch]);
+
+  // Auto-open editor when navigated with ?edit=<schedule_id>
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const editId = params.get('edit');
+    if (editId) {
+      setEditingId(editId);
+      setEditorOpen(true);
+    }
+  }, [location.search]);
 
   const handleEdit = (id: string) => {
     setEditingId(id);

--- a/frontend/src/app/pages/Schedules/Schedules.tsx
+++ b/frontend/src/app/pages/Schedules/Schedules.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import {
+  fetchSchedules,
+  deleteSchedule,
+  toggleSchedule,
+  clearUnread,
+  Schedule,
+} from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import ScheduleEditor from './ScheduleEditor';
+
+function formatTrigger(s: Schedule): string {
+  if (s.trigger_type === 'cron' && s.cron_expression) return `Cron: ${s.cron_expression}`;
+  if (s.trigger_type === 'interval' && s.interval_seconds) {
+    if (s.interval_seconds >= 3600) return `Every ${Math.round(s.interval_seconds / 3600)}h`;
+    if (s.interval_seconds >= 60) return `Every ${Math.round(s.interval_seconds / 60)}m`;
+    return `Every ${s.interval_seconds}s`;
+  }
+  if (s.trigger_type === 'once' && s.run_at) return `Once: ${new Date(s.run_at).toLocaleString()}`;
+  return s.trigger_type;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+const Schedules: React.FC = () => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const items = useAppSelector((s) => s.schedules.items);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const loading = useAppSelector((s) => s.schedules.loading);
+  const [editorOpen, setEditorOpen] = React.useState(false);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
+
+  const scheduleList = Object.values(items).sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+  );
+
+  useEffect(() => {
+    dispatch(fetchSchedules());
+    dispatch(clearUnread());
+  }, [dispatch]);
+
+  const handleEdit = (id: string) => {
+    setEditingId(id);
+    setEditorOpen(true);
+  };
+
+  const handleCreate = () => {
+    setEditingId(null);
+    setEditorOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await dispatch(deleteSchedule(id)).unwrap();
+    } catch (e: any) {
+      setDeleteError(e.message || 'Failed to delete schedule');
+    }
+  };
+
+  const handleToggle = (id: string) => {
+    dispatch(toggleSchedule(id));
+  };
+
+  return (
+    <Box sx={{ width: '100%', height: '100%', bgcolor: c.bg.page, color: c.text.primary, p: 3, overflow: 'auto' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>Schedules</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreate} sx={{ bgcolor: c.accent.primary }}>
+          New Schedule
+        </Button>
+      </Box>
+
+      {scheduleList.length === 0 && !loading ? (
+        <Typography sx={{ color: c.text.muted }}>No schedules yet. Create one to get started.</Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Trigger</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Dashboard</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Next Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Last Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Runs</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }} align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {scheduleList.map((s) => (
+                <TableRow key={s.id} hover>
+                  <TableCell sx={{ color: c.text.primary }}>{s.name}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatTrigger(s)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>
+                    {dashboards[s.dashboard_id]?.name || s.dashboard_id.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>
+                    {s.last_error ? (
+                      <Tooltip title={s.last_error}>
+                        <Chip label="Error" size="small" sx={{ bgcolor: c.status.errorBg, color: c.status.error, fontWeight: 600 }} />
+                      </Tooltip>
+                    ) : s.enabled ? (
+                      <Chip label="Active" size="small" sx={{ bgcolor: c.status.successBg, color: c.status.success, fontWeight: 600 }} />
+                    ) : (
+                      <Chip label="Paused" size="small" sx={{ bgcolor: c.status.warningBg, color: c.status.warning, fontWeight: 600 }} />
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.next_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.last_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>{s.run_count}</TableCell>
+                  <TableCell align="right">
+                    <Tooltip title={s.enabled ? 'Pause' : 'Resume'}>
+                      <IconButton size="small" onClick={() => handleToggle(s.id)} sx={{ color: c.text.muted }}>
+                        {s.enabled ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => handleEdit(s.id)} sx={{ color: c.text.muted }}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" onClick={() => handleDelete(s.id)} sx={{ color: c.text.muted }}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <ScheduleEditor
+        open={editorOpen}
+        scheduleId={editingId}
+        onClose={() => { setEditorOpen(false); setEditingId(null); }}
+      />
+
+      <Snackbar open={!!deleteError} autoHideDuration={4000} onClose={() => setDeleteError(null)}>
+        <Alert severity="error" onClose={() => setDeleteError(null)}>{deleteError}</Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default Schedules;

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -66,6 +66,7 @@ export interface AgentSession {
   branches: Record<string, MessageBranch>;
   active_branch_id: string;
   streamingMessage: StreamingMessage | null;
+  cwd?: string | null;
   target_directory?: string | null;
   tool_group_meta: Record<string, ToolGroupMeta>;
   dashboard_id?: string;

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -71,6 +71,7 @@ export interface AgentSession {
   dashboard_id?: string;
   browser_id?: string | null;
   parent_session_id?: string | null;
+  schedule_id?: string | null;
 }
 
 export interface AgentConfig {

--- a/frontend/src/shared/state/schedulesSlice.ts
+++ b/frontend/src/shared/state/schedulesSlice.ts
@@ -1,0 +1,140 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { API_BASE } from '@/shared/config';
+
+const SCHEDULES_API = `${API_BASE}/schedules`;
+
+export interface Schedule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  dashboard_id: string;
+  trigger_type: 'cron' | 'interval' | 'once';
+  cron_expression: string | null;
+  interval_seconds: number | null;
+  run_at: string | null;
+  action_type: 'new_session' | 'message_existing';
+  prompt: string;
+  target_session_id: string | null;
+  template_id: string | null;
+  model: string | null;
+  mode: string | null;
+  system_prompt: string | null;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  run_count: number;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SchedulesState {
+  items: Record<string, Schedule>;
+  loading: boolean;
+  unreadCount: number;
+}
+
+const initialState: SchedulesState = {
+  items: {},
+  loading: false,
+  unreadCount: 0,
+};
+
+export const fetchSchedules = createAsyncThunk(
+  'schedules/fetchAll',
+  async (dashboardId?: string) => {
+    const url = dashboardId
+      ? `${SCHEDULES_API}/list?dashboard_id=${dashboardId}`
+      : `${SCHEDULES_API}/list`;
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.schedules as Schedule[];
+  },
+);
+
+export const createSchedule = createAsyncThunk(
+  'schedules/create',
+  async (body: Omit<Schedule, 'id' | 'last_run_at' | 'next_run_at' | 'run_count' | 'last_error' | 'created_at' | 'updated_at' | 'enabled'> & { name?: string }) => {
+    const res = await fetch(`${SCHEDULES_API}/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const updateSchedule = createAsyncThunk(
+  'schedules/update',
+  async ({ id, ...body }: { id: string } & Partial<Schedule>) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const deleteSchedule = createAsyncThunk(
+  'schedules/delete',
+  async (id: string) => {
+    await fetch(`${SCHEDULES_API}/${id}`, { method: 'DELETE' });
+    return id;
+  },
+);
+
+export const toggleSchedule = createAsyncThunk(
+  'schedules/toggle',
+  async (id: string) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}/toggle`, { method: 'POST' });
+    return (await res.json()) as Schedule;
+  },
+);
+
+const schedulesSlice = createSlice({
+  name: 'schedules',
+  initialState,
+  reducers: {
+    incrementUnread(state) {
+      state.unreadCount += 1;
+    },
+    clearUnread(state) {
+      state.unreadCount = 0;
+    },
+    scheduleUpdatedFromWs(state, action: PayloadAction<{ schedule_id: string }>) {
+      state.unreadCount += 1;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSchedules.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchSchedules.fulfilled, (state, action) => {
+        state.loading = false;
+        const items: Record<string, Schedule> = {};
+        for (const s of action.payload) {
+          items[s.id] = s;
+        }
+        state.items = items;
+      })
+      .addCase(fetchSchedules.rejected, (state) => {
+        state.loading = false;
+      })
+      .addCase(createSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(updateSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(deleteSchedule.fulfilled, (state, action) => {
+        delete state.items[action.payload];
+      })
+      .addCase(toggleSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      });
+  },
+});
+
+export const { incrementUnread, clearUnread, scheduleUpdatedFromWs } = schedulesSlice.actions;
+export default schedulesSlice.reducer;

--- a/frontend/src/shared/state/store.ts
+++ b/frontend/src/shared/state/store.ts
@@ -12,6 +12,7 @@ import outputsReducer from './outputsSlice';
 import dashboardLayoutReducer from './dashboardLayoutSlice';
 import dashboardsReducer from './dashboardsSlice';
 import updateReducer from './updateSlice';
+import schedulesReducer from './schedulesSlice';
 
 export const store = configureStore({
   reducer: {
@@ -28,6 +29,7 @@ export const store = configureStore({
     dashboardLayout: dashboardLayoutReducer,
     dashboards: dashboardsReducer,
     update: updateReducer,
+    schedules: schedulesReducer,
   },
 });
 

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -17,6 +17,7 @@ import {
   trackAgentNotification,
 } from '../state/agentsSlice';
 import { addBrowserCardFromBackend, setBrowserCardPosition, setGlowingBrowserCards, GRID_GAP } from '../state/dashboardLayoutSlice';
+import { incrementUnread } from '../state/schedulesSlice';
 
 type WSEvent = {
   event: string;
@@ -266,6 +267,14 @@ class WebSocketManager {
             }
           }
         }
+        break;
+
+      case 'schedule:run_complete':
+        store.dispatch(incrementUnread());
+        break;
+
+      case 'schedule:run_failed':
+        store.dispatch(incrementUnread());
         break;
     }
 

--- a/run.mjs
+++ b/run.mjs
@@ -66,7 +66,6 @@ function cleanup() {
 
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
-process.on('exit', cleanup);
 
 // --- Spawn with prefixed output ---
 function spawnService(name, color, cmd, args, options = {}) {

--- a/run.mjs
+++ b/run.mjs
@@ -73,6 +73,8 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
+    // .cmd files on Windows require shell: true
+    shell: isWindows,
     ...options,
   });
   children.push(child);

--- a/run.mjs
+++ b/run.mjs
@@ -73,8 +73,6 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
-    // .cmd files on Windows require shell: true
-    shell: isWindows,
     ...options,
   });
   children.push(child);
@@ -132,7 +130,7 @@ try {
 
   // Wait for backend health
   console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
-  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  await waitForHealth('http://localhost:8324/api/health/check', 'Backend', 120000);
   console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
 
   // Start frontend
@@ -157,6 +155,7 @@ try {
   const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
     cwd: join(__dirname, 'electron'),
     env: { ...process.env, ELECTRON_DEV: '1' },
+    shell: isWindows,
   });
 
   electron.on('exit', (code) => {

--- a/run.mjs
+++ b/run.mjs
@@ -1,0 +1,177 @@
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}


### PR DESCRIPTION
## Summary
- Extracts all one-shot LLM calls into a central router (`llm_router.py`) that uses Anthropic API when key is configured, or falls back to Claude Code CLI via claude_agent_sdk
- Removes duplicated API client creation from agent_manager, browser_agent, and outputs
- Adds browser tools MCP server
- Fixes Windows uvicorn event loop to use ProactorEventLoop for subprocess support

**Depends on:** #11 (scheduling system)

## Test plan
- [ ] Title generation works with API key configured
- [ ] Title generation works without API key (CLI fallback)
- [ ] View/output generation still works
- [ ] Browser agent delegation still works
- [ ] Backend starts on Windows without event loop errors