### PR TITLE
feat: browse and resume Claude CLI sessions from dashboard

### DIFF
--- a/OpenSwarm.bat
+++ b/OpenSwarm.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d "C:\Users\fireb\openswarm"
+node run.mjs

--- a/OpenSwarm.bat
+++ b/OpenSwarm.bat
@@ -1,3 +1,3 @@
 @echo off
-cd /d "C:\Users\fireb\openswarm"
+cd /d "%~dp0"
 node run.mjs

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -1334,22 +1334,18 @@ class AgentManager:
 
         title = first_prompt[:40].strip()
         try:
-            import anthropic
-            global_settings = load_settings()
-            if not global_settings.anthropic_api_key:
-                raise ValueError("API key not configured")
-            client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
-            resp = await client.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=30,
+            from backend.apps.settings.llm_router import llm_call
+            generated = await llm_call(
                 system="Generate a concise 3-6 word title for a chat that starts with this message. Return only the title, nothing else.",
-                messages=[{"role": "user", "content": first_prompt}],
+                user_message=first_prompt,
+                model="haiku",
+                max_tokens=30,
             )
-            generated = resp.content[0].text.strip().strip('"\'')
+            generated = generated.strip('"\'')
             if generated:
                 title = generated
         except Exception as e:
-            logger.warning(f"Title generation failed, using fallback: {e}")
+            logger.debug(f"Title generation failed, using fallback: {e}")
 
         session.name = title
         await ws_manager.send_to_session(session_id, "agent:name_updated", {
@@ -1378,11 +1374,8 @@ class AgentManager:
         svg = ""
 
         try:
-            import anthropic, json as _json
-            global_settings = load_settings()
-            if not global_settings.anthropic_api_key:
-                raise ValueError("API key not configured")
-            client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
+            import json as _json
+            from backend.apps.settings.llm_router import llm_call
 
             tool_desc = "\n".join(
                 f"- {tc.get('tool', '?')}: {tc.get('input_summary', '')}" for tc in tool_calls
@@ -1406,14 +1399,12 @@ class AgentManager:
                 "- Max 400 characters for the svg string"
             )
 
-            resp = await client.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=300,
+            raw = await llm_call(
                 system=system,
-                messages=[{"role": "user", "content": user_content}],
+                user_message=user_content,
+                model="haiku",
+                max_tokens=300,
             )
-
-            raw = resp.content[0].text.strip()
             if raw.startswith("```"):
                 raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             parsed = _json.loads(raw)
@@ -1422,7 +1413,7 @@ class AgentManager:
             if parsed.get("svg"):
                 svg = parsed["svg"].strip()
         except Exception as e:
-            logger.warning(f"Group meta generation failed, using fallback: {e}")
+            logger.debug(f"Group meta generation failed, using fallback: {e}")
 
         meta = ToolGroupMeta(id=group_id, name=name, svg=svg, is_refined=is_refinement)
         session.tool_group_meta[group_id] = meta

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -325,11 +325,16 @@ class AgentManager:
 
         os.makedirs(effective_cwd, exist_ok=True)
 
+        # "opus-1m" is stored as-is for the frontend; resolved at SDK call time
+        use_1m_beta = config.model == "opus-1m"
+
         session = AgentSession(
             id=session_id,
             name=config.name,
             model=config.model,
             mode=config.mode,
+            effort=config.effort,
+            use_1m_context=use_1m_beta,
             system_prompt=config.system_prompt,
             allowed_tools=tools,
             max_turns=config.max_turns,
@@ -813,8 +818,11 @@ class AgentManager:
                     else:
                         effective_allowed.append(f"mcp__{name}__*")
 
+            # Resolve "opus-1m" to actual SDK model name
+            sdk_model = "opus" if session.model == "opus-1m" else session.model
+
             options_kwargs = {
-                "model": session.model,
+                "model": sdk_model,
                 "max_buffer_size": 5 * 1024 * 1024,
                 "permission_mode": "default",
                 "can_use_tool": can_use_tool,
@@ -837,12 +845,21 @@ class AgentManager:
 
             if session.cwd:
                 options_kwargs["cwd"] = session.cwd
+            if session.effort and session.effort != "auto":
+                options_kwargs["effort"] = session.effort
+            if session.use_1m_context:
+                if global_settings.anthropic_api_key:
+                    options_kwargs["betas"] = ["context-1m-2025-08-07"]
+                else:
+                    # CLI mode: use full model ID the CLI understands
+                    options_kwargs["model"] = "claude-opus-4-6[1m]"
 
             if session.sdk_session_id:
                 options_kwargs["resume"] = session.sdk_session_id
                 if fork_session:
                     options_kwargs["fork_session"] = True
 
+            logger.info(f"Session {session_id} SDK options: model={options_kwargs.get('model')}, effort={options_kwargs.get('effort')}, betas={options_kwargs.get('betas')}")
             options = ClaudeAgentOptions(**options_kwargs)
 
             async def prompt_stream():
@@ -862,6 +879,10 @@ class AgentManager:
                 if isinstance(message, StreamEvent):
                     event = message.event
                     event_type = event.get("type")
+
+                    if event_type == "message_start":
+                        msg_data = event.get("message", {})
+                        logger.info(f"Session {session_id} API response: model={msg_data.get('model')}, usage={msg_data.get('usage')}")
 
                     if event_type == "content_block_start":
                         block = event.get("content_block", {})
@@ -964,6 +985,7 @@ class AgentManager:
                     stream_block_index_map = {}
 
                 elif isinstance(message, ResultMessage):
+                    logger.info(f"Session {session_id} result: cost=${getattr(message, 'total_cost_usd', None)}, turns={getattr(message, 'num_turns', None)}, usage={getattr(message, 'usage', None)}, model_usage={getattr(message, 'model_usage', None)}")
                     session.sdk_session_id = getattr(message, "session_id", None)
                     cost = getattr(message, "total_cost_usd", None)
                     if cost is not None:
@@ -1150,6 +1172,10 @@ class AgentManager:
             return
 
         session_changed = False
+        if model == "opus-1m":
+            session.use_1m_context = True
+        elif model and model != "opus-1m":
+            session.use_1m_context = False
         if model and model != session.model:
             session.model = model
             session_changed = True

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -335,21 +335,224 @@ class AgentManager:
             mode=config.mode,
             effort=config.effort,
             use_1m_context=use_1m_beta,
+            sdk_session_id=config.resume_cli_session_id,
             system_prompt=config.system_prompt,
             allowed_tools=tools,
             max_turns=config.max_turns,
             cwd=effective_cwd,
             dashboard_id=config.dashboard_id,
         )
+
+        # If resuming a CLI session, load its message history
+        if config.resume_cli_session_id:
+            session.status = "stopped"
+            self._load_cli_history(session, config.resume_cli_session_id, effective_cwd)
+
         self.sessions[session_id] = session
-        
+
         await ws_manager.send_to_session(session_id, "agent:status", {
             "session_id": session_id,
-            "status": "running",
+            "status": session.status,
             "session": session.model_dump(mode="json"),
         })
-        
+
         return session
+
+    @staticmethod
+    def _parse_cli_internal(text: str, ts: datetime, last_cmd: str) -> list[Message] | str | None:
+        """Parse CLI internal XML messages into tool_call/tool_result pairs.
+        Returns list of Messages, 'skip' to drop, or None for normal user message."""
+        import re
+        stripped = text.strip()
+        if not stripped.startswith("<"):
+            return None
+
+        # <local-command-caveat> — noise wrapper, skip
+        if stripped.startswith("<local-command-caveat>"):
+            return "skip"
+
+        # <command-name>/foo</command-name> — slash command
+        cmd_match = re.search(r"<command-name>(/?\w[\w-]*)</command-name>", stripped)
+        if cmd_match:
+            cmd = cmd_match.group(1)
+            args_match = re.search(r"<command-args>(.*?)</command-args>", stripped, re.DOTALL)
+            args = args_match.group(1).strip() if args_match else ""
+            tool_id = f"cli-cmd-{uuid4().hex[:8]}"
+            return [
+                Message(role="tool_call", content={"id": tool_id, "tool": f"CLI: {cmd}", "input": {"args": args} if args else {}}, timestamp=ts),
+                Message(role="tool_result", content={"text": "", "tool_name": f"CLI: {cmd}"}, timestamp=ts),
+            ]
+
+        # <local-command-stdout> — output of previous command
+        stdout_match = re.search(r"<local-command-stdout>(.*?)</local-command-stdout>", stripped, re.DOTALL)
+        if stdout_match:
+            output = stdout_match.group(1).strip()
+            # Strip ANSI escape codes
+            output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+            tool_name = f"CLI: {last_cmd}" if last_cmd else "CLI output"
+            tool_id = f"cli-out-{uuid4().hex[:8]}"
+            return [
+                Message(role="tool_call", content={"id": tool_id, "tool": tool_name, "input": {"output": True}}, timestamp=ts),
+                Message(role="tool_result", content={"text": output, "tool_name": tool_name}, timestamp=ts),
+            ]
+
+        # <system-reminder> — system context injection
+        if stripped.startswith("<system-reminder>"):
+            reminder = re.sub(r"</?system-reminder>", "", stripped).strip()
+            tool_id = f"cli-sys-{uuid4().hex[:8]}"
+            preview = reminder[:100] + "..." if len(reminder) > 100 else reminder
+            return [
+                Message(role="tool_call", content={"id": tool_id, "tool": "System Reminder", "input": {"preview": preview}}, timestamp=ts),
+                Message(role="tool_result", content={"text": reminder, "tool_name": "System Reminder"}, timestamp=ts),
+            ]
+
+        # <task-notification> — background task update
+        if stripped.startswith("<task-notification>"):
+            task_match = re.search(r"<task-id>(.*?)</task-id>", stripped)
+            task_id = task_match.group(1) if task_match else "unknown"
+            status_match = re.search(r"<status>(.*?)</status>", stripped)
+            status = status_match.group(1) if status_match else ""
+            tool_id = f"cli-task-{uuid4().hex[:8]}"
+            return [
+                Message(role="tool_call", content={"id": tool_id, "tool": "Task Notification", "input": {"task_id": task_id}}, timestamp=ts),
+                Message(role="tool_result", content={"text": status or stripped[:200], "tool_name": "Task Notification"}, timestamp=ts),
+            ]
+
+        # Other XML-looking content we don't recognize — pass through as-is
+        return None
+
+    def _load_cli_history(self, session: AgentSession, cli_session_id: str, cwd: str):
+        """Load message history from a Claude CLI session JSONL file into session."""
+        from pathlib import Path
+        dir_name = cwd.replace(":", "-").replace("\\", "-").replace("/", "-")
+        jsonl_path = Path.home() / ".claude" / "projects" / dir_name / f"{cli_session_id}.jsonl"
+        if not jsonl_path.exists():
+            logger.warning(f"CLI session file not found: {jsonl_path}")
+            return
+        try:
+            pending_tool_uses: dict[str, dict] = {}  # id -> {tool, input}
+            last_cli_command = ""
+
+            for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+                data = json.loads(line)
+                msg_type = data.get("type", "")
+                if msg_type not in ("user", "assistant"):
+                    continue
+                msg_data = data.get("message", {})
+                raw_content = msg_data.get("content", "")
+                ts_str = data.get("timestamp")
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00")) if ts_str else datetime.now()
+
+                if msg_type == "user":
+                    if isinstance(raw_content, str):
+                        cli_msg = self._parse_cli_internal(raw_content, ts, last_cli_command)
+                        if cli_msg is not None:
+                            if cli_msg == "skip":
+                                continue
+                            session.messages.extend(cli_msg)
+                            # Track last command for stdout pairing
+                            for m in cli_msg:
+                                if m.role == "tool_call" and isinstance(m.content, dict):
+                                    last_cli_command = m.content.get("tool", "")
+                            continue
+                        session.messages.append(Message(role="user", content=raw_content, timestamp=ts))
+                    elif isinstance(raw_content, list):
+                        # User messages can contain tool_result blocks
+                        for block in raw_content:
+                            if not isinstance(block, dict):
+                                continue
+                            btype = block.get("type", "")
+                            if btype == "text":
+                                text = block.get("text", "")
+                                cli_msg = self._parse_cli_internal(text, ts, last_cli_command)
+                                if cli_msg is not None:
+                                    if cli_msg == "skip":
+                                        continue
+                                    session.messages.extend(cli_msg)
+                                    for m in cli_msg:
+                                        if m.role == "tool_call" and isinstance(m.content, dict):
+                                            last_cli_command = m.content.get("tool", "")
+                                    continue
+                                session.messages.append(Message(role="user", content=text, timestamp=ts))
+                            elif btype == "tool_result":
+                                tool_use_id = block.get("tool_use_id", "")
+                                tool_info = pending_tool_uses.pop(tool_use_id, {})
+                                result_content = block.get("content", "")
+                                if isinstance(result_content, list):
+                                    texts = [b.get("text", "") for b in result_content if isinstance(b, dict) and b.get("type") == "text"]
+                                    result_text = "\n".join(texts) if texts else ""
+                                elif isinstance(result_content, str):
+                                    result_text = result_content
+                                else:
+                                    result_text = str(result_content)
+                                session.messages.append(Message(
+                                    role="tool_result",
+                                    content={
+                                        "text": result_text,
+                                        "tool_name": tool_info.get("tool", ""),
+                                        "is_error": block.get("is_error", False),
+                                    },
+                                    timestamp=ts,
+                                ))
+
+                elif msg_type == "assistant":
+                    if isinstance(raw_content, list):
+                        text_parts = []
+                        for block in raw_content:
+                            if not isinstance(block, dict):
+                                continue
+                            btype = block.get("type", "")
+                            if btype == "text":
+                                text_parts.append(block.get("text", ""))
+                            elif btype == "tool_use":
+                                # Flush accumulated text first
+                                if text_parts:
+                                    session.messages.append(Message(role="assistant", content="\n".join(text_parts), timestamp=ts))
+                                    text_parts = []
+                                tool_id = block.get("id", "")
+                                tool_name = block.get("name", "")
+                                tool_input = block.get("input", {})
+                                pending_tool_uses[tool_id] = {"tool": tool_name, "input": tool_input}
+                                session.messages.append(Message(
+                                    role="tool_call",
+                                    content={"id": tool_id, "tool": tool_name, "input": tool_input},
+                                    timestamp=ts,
+                                ))
+                        # Flush remaining text
+                        if text_parts:
+                            session.messages.append(Message(role="assistant", content="\n".join(text_parts), timestamp=ts))
+                    elif isinstance(raw_content, str) and raw_content:
+                        session.messages.append(Message(role="assistant", content=raw_content, timestamp=ts))
+
+            # Pre-compute tool group meta from loaded messages
+            self._precompute_tool_group_meta(session)
+
+            logger.info(f"Loaded {len(session.messages)} messages from CLI session {cli_session_id}")
+        except Exception as e:
+            logger.warning(f"Error loading CLI session history: {e}")
+
+    def _precompute_tool_group_meta(self, session: AgentSession):
+        """Pre-populate tool_group_meta for all tool groups in a session's messages."""
+        msgs = session.messages
+        i = 0
+        while i < len(msgs):
+            if msgs[i].role in ("tool_call", "tool_result"):
+                group_start = i
+                while i < len(msgs) and msgs[i].role in ("tool_call", "tool_result"):
+                    i += 1
+                # Extract tool_call messages in this group
+                calls = [m for m in msgs[group_start:i] if m.role == "tool_call"]
+                if not calls:
+                    continue
+                group_id = f"group-{calls[0].id}"
+                tool_dicts = []
+                for c in calls:
+                    content = c.content if isinstance(c.content, dict) else {}
+                    tool_dicts.append({"tool": content.get("tool", ""), "input": content.get("input", {})})
+                name = self._derive_tool_group_name(tool_dicts)
+                session.tool_group_meta[group_id] = ToolGroupMeta(id=group_id, name=name, is_refined=True)
+            else:
+                i += 1
 
     def _resolve_context_paths(self, context_paths: list | None) -> str:
         """Read file contents / directory trees for attached context paths."""
@@ -1380,6 +1583,52 @@ class AgentManager:
         })
         return title
 
+    @staticmethod
+    def _derive_tool_group_name(tool_calls: list[dict]) -> str:
+        """Derive a tool group label from tool names and inputs, no LLM needed."""
+        if not tool_calls:
+            return "Tool calls"
+        first = tool_calls[0]
+        tool_name = first.get("tool", "Tool calls")
+        tool_input = first.get("input", {})
+
+        # Agent tool → use description field
+        if tool_name == "Agent" and isinstance(tool_input, dict):
+            desc = tool_input.get("description", "")
+            if desc:
+                return desc
+
+        # MCP tools → extract server and method
+        if "__" in tool_name:
+            parts = tool_name.split("__")
+            if len(parts) >= 3:
+                method = parts[-1].replace("_", " ").title()
+                if len(tool_calls) == 1:
+                    return method
+                return f"{method} x{len(tool_calls)}" if len(set(tc.get("tool") for tc in tool_calls)) == 1 else f"{len(tool_calls)} MCP calls"
+
+        # Standard tools
+        unique_tools = set(tc.get("tool", "") for tc in tool_calls)
+        if len(unique_tools) == 1:
+            clean = tool_name.replace("_", " ").title()
+            if len(tool_calls) > 1:
+                return f"{clean} x{len(tool_calls)}"
+            # Add context from input for single calls
+            if tool_name in ("Read", "Write", "Edit", "Glob", "Grep") and isinstance(tool_input, dict):
+                path = tool_input.get("file_path", tool_input.get("path", ""))
+                if path:
+                    filename = path.replace("\\", "/").split("/")[-1]
+                    return f"{clean}: {filename}"
+                pattern = tool_input.get("pattern", "")
+                if pattern:
+                    return f"{clean}: {pattern[:30]}"
+            if tool_name == "Bash" and isinstance(tool_input, dict):
+                cmd = tool_input.get("command", tool_input.get("description", ""))
+                if cmd:
+                    return f"Bash: {cmd[:40]}"
+            return clean
+        return f"{len(tool_calls)} tool calls"
+
     async def generate_group_meta(
         self,
         session_id: str,
@@ -1393,53 +1642,52 @@ class AgentManager:
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
-        fallback_name = tool_calls[0].get("tool", "Tool calls") if tool_calls else "Tool calls"
-        fallback_name = fallback_name.split("__")[-1].replace("_", " ").title() if "__" in fallback_name else fallback_name
-
-        name = fallback_name
+        name = self._derive_tool_group_name(tool_calls)
         svg = ""
 
-        try:
-            import json as _json
-            from backend.apps.settings.llm_router import llm_call
+        global_settings = load_settings()
+        if global_settings.simple_tool_group_names != "all":
+            try:
+                import json as _json
+                from backend.apps.settings.llm_router import llm_call
 
-            tool_desc = "\n".join(
-                f"- {tc.get('tool', '?')}: {tc.get('input_summary', '')}" for tc in tool_calls
-            )
-            user_content = f"Tool actions:\n{tool_desc}"
-            if results_summary:
-                user_content += f"\n\nResults:\n" + "\n".join(f"- {r}" for r in results_summary)
+                tool_desc = "\n".join(
+                    f"- {tc.get('tool', '?')}: {tc.get('input_summary', '')}" for tc in tool_calls
+                )
+                user_content = f"Tool actions:\n{tool_desc}"
+                if results_summary:
+                    user_content += f"\n\nResults:\n" + "\n".join(f"- {r}" for r in results_summary)
 
-            system = (
-                "Generate a concise 2-5 word name and a minimal SVG icon for a group of tool actions.\n\n"
-                "Return ONLY valid JSON: {\"name\": \"...\", \"svg\": \"...\"}\n\n"
-                "Name rules:\n"
-                "- 2-5 words, title case, describes the action (e.g. \"Email Inbox Search\", \"Reading Project Files\")\n\n"
-                "SVG rules:\n"
-                "- 24x24 viewBox\n"
-                "- Use currentColor for all stroke/fill values\n"
-                "- Simple geometric shapes only (line, circle, rect, path, polyline)\n"
-                "- No text elements, no embedded images, no gradients, no filters\n"
-                "- Minimal: 1-3 shapes, stroke-width=\"1.5\", fill=\"none\" unless intentional\n"
-                "- Return ONLY the inner SVG elements (no outer <svg> tag)\n"
-                "- Max 400 characters for the svg string"
-            )
+                system = (
+                    "Generate a concise 2-5 word name and a minimal SVG icon for a group of tool actions.\n\n"
+                    "Return ONLY valid JSON: {\"name\": \"...\", \"svg\": \"...\"}\n\n"
+                    "Name rules:\n"
+                    "- 2-5 words, title case, describes the action (e.g. \"Email Inbox Search\", \"Reading Project Files\")\n\n"
+                    "SVG rules:\n"
+                    "- 24x24 viewBox\n"
+                    "- Use currentColor for all stroke/fill values\n"
+                    "- Simple geometric shapes only (line, circle, rect, path, polyline)\n"
+                    "- No text elements, no embedded images, no gradients, no filters\n"
+                    "- Minimal: 1-3 shapes, stroke-width=\"1.5\", fill=\"none\" unless intentional\n"
+                    "- Return ONLY the inner SVG elements (no outer <svg> tag)\n"
+                    "- Max 400 characters for the svg string"
+                )
 
-            raw = await llm_call(
-                system=system,
-                user_message=user_content,
-                model="haiku",
-                max_tokens=300,
-            )
-            if raw.startswith("```"):
-                raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-            parsed = _json.loads(raw)
-            if parsed.get("name"):
-                name = parsed["name"].strip().strip("\"'")
-            if parsed.get("svg"):
-                svg = parsed["svg"].strip()
-        except Exception as e:
-            logger.debug(f"Group meta generation failed, using fallback: {e}")
+                raw = await llm_call(
+                    system=system,
+                    user_message=user_content,
+                    model="haiku",
+                    max_tokens=300,
+                )
+                if raw.startswith("```"):
+                    raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+                parsed = _json.loads(raw)
+                if parsed.get("name"):
+                    name = parsed["name"].strip().strip("\"'")
+                if parsed.get("svg"):
+                    svg = parsed["svg"].strip()
+            except Exception as e:
+                logger.debug(f"Group meta generation failed, using fallback: {e}")
 
         meta = ToolGroupMeta(id=group_id, name=name, svg=svg, is_refined=is_refinement)
         session.tool_group_meta[group_id] = meta

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -826,9 +826,8 @@ class AgentManager:
                 "disallowed_tools": effective_disallowed,
                 "include_partial_messages": True,
             }
-            if not global_settings.anthropic_api_key:
-                raise ValueError("Anthropic API key not configured. Set it in Settings.")
-            options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
+            if global_settings.anthropic_api_key:
+                options_kwargs["env"] = {"ANTHROPIC_API_KEY": global_settings.anthropic_api_key}
             if mcp_servers:
                 options_kwargs["mcp_servers"] = mcp_servers
             if composed_prompt:

--- a/backend/apps/agents/agents.py
+++ b/backend/apps/agents/agents.py
@@ -7,6 +7,9 @@ from fastapi import WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.responses import JSONResponse
 import json
 import logging
+import subprocess
+import sys
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +172,46 @@ async def get_history(q: str = "", limit: int = 20, offset: int = 0, dashboard_i
 async def get_browser_agent_children(session_id: str):
     children = agent_manager.get_browser_agent_children(session_id)
     return {"sessions": children}
+
+@agents.router.post("/sessions/{session_id}/open-in-cli")
+async def open_in_cli(session_id: str):
+    session = agent_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if not session.sdk_session_id:
+        raise HTTPException(status_code=400, detail="Session has no CLI session ID (agent may not have run yet)")
+
+    claude_path = shutil.which("claude")
+    if not claude_path:
+        raise HTTPException(status_code=500, detail="Claude CLI not found on PATH")
+
+    args = [claude_path, "--resume", session.sdk_session_id]
+    cwd = session.cwd or None
+
+    try:
+        if sys.platform == "win32":
+            subprocess.Popen(
+                ["cmd.exe", "/c", "start", "cmd.exe", "/k"] + args,
+                cwd=cwd, creationflags=subprocess.DETACHED_PROCESS,
+            )
+        elif sys.platform == "darwin":
+            script = f'tell application "Terminal" to do script "cd {cwd or "~"} && {claude_path} --resume {session.sdk_session_id}"'
+            subprocess.Popen(["osascript", "-e", script])
+        else:
+            for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]:
+                term_path = shutil.which(term)
+                if term_path:
+                    if "gnome-terminal" in term:
+                        subprocess.Popen([term_path, "--"] + args, cwd=cwd)
+                    else:
+                        subprocess.Popen([term_path, "-e", " ".join(args)], cwd=cwd)
+                    break
+            else:
+                raise HTTPException(status_code=500, detail="No terminal emulator found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"ok": True, "sdk_session_id": session.sdk_session_id}
 
 @agents.router.post("/sessions/{session_id}/resume")
 async def resume_session(session_id: str):

--- a/backend/apps/agents/agents.py
+++ b/backend/apps/agents/agents.py
@@ -1,5 +1,5 @@
 from backend.config.Apps import SubApp
-from backend.apps.agents.agent_manager import agent_manager
+from backend.apps.agents.agent_manager import agent_manager, _load_all_session_data
 from backend.apps.agents.ws_manager import ws_manager
 from backend.apps.agents.models import AgentConfig, ApprovalResponse
 from contextlib import asynccontextmanager
@@ -7,9 +7,11 @@ from fastapi import WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.responses import JSONResponse
 import json
 import logging
+import os
 import subprocess
 import sys
 import shutil
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -168,25 +170,116 @@ async def get_history(q: str = "", limit: int = 20, offset: int = 0, dashboard_i
         dashboard_id=dashboard_id or None,
     )
 
+@agents.router.get("/cli-sessions")
+async def list_cli_sessions(cwd: str = "", q: str = "", limit: int = 50):
+    """List Claude CLI sessions for a given working directory."""
+    claude_dir = Path.home() / ".claude" / "projects"
+    if not claude_dir.exists():
+        return {"sessions": []}
+
+    # Build the project dir name: C:\Users\fireb\openswarm → C--Users-fireb-openswarm
+    # Claude CLI replaces : with - and path separators with -
+    target_cwd = cwd or os.getcwd()
+    dir_name = target_cwd.replace(":", "-").replace("\\", "-").replace("/", "-")
+
+    project_dir = claude_dir / dir_name
+    if not project_dir.exists():
+        return {"sessions": []}
+
+    # Also collect OpenSwarm sdk_session_ids so we can mark which ones are already imported
+    known_sdk_ids = set()
+    for s in agent_manager.get_all_sessions():
+        if s.sdk_session_id:
+            known_sdk_ids.add(s.sdk_session_id)
+    for _, data in _load_all_session_data():
+        sid = data.get("sdk_session_id")
+        if sid:
+            known_sdk_ids.add(sid)
+
+    sessions = []
+    for jsonl_path in sorted(project_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
+        session_id = jsonl_path.stem
+        if not session_id or session_id.startswith("."):
+            continue
+        try:
+            first_user_msg = None
+            first_ts = None
+            last_ts = None
+            user_count = 0
+            asst_count = 0
+            with open(jsonl_path, encoding="utf-8") as f:
+                for line in f:
+                    data = json.loads(line)
+                    t = data.get("type", "")
+                    ts = data.get("timestamp")
+                    if ts and not first_ts:
+                        first_ts = ts
+                    if ts:
+                        last_ts = ts
+                    if t == "user":
+                        user_count += 1
+                        if not first_user_msg:
+                            msg = data.get("message", {})
+                            content = msg.get("content", "")
+                            if isinstance(content, str):
+                                first_user_msg = content[:200]
+                            elif isinstance(content, list):
+                                for b in content:
+                                    if isinstance(b, dict) and b.get("type") == "text":
+                                        first_user_msg = b["text"][:200]
+                                        break
+                    elif t == "assistant":
+                        asst_count += 1
+            # Search filter
+            if q and q.lower() not in (first_user_msg or "").lower():
+                continue
+            sessions.append({
+                "id": session_id,
+                "first_message": first_user_msg or "",
+                "created_at": first_ts,
+                "last_activity": last_ts,
+                "user_messages": user_count,
+                "assistant_messages": asst_count,
+                "total_messages": user_count + asst_count,
+                "in_openswarm": session_id in known_sdk_ids,
+                "cwd": target_cwd,
+            })
+        except Exception as e:
+            logger.warning(f"Error parsing CLI session {session_id}: {e}")
+            continue
+
+    return {"sessions": sessions[:limit]}
+
 @agents.router.get("/sessions/{session_id}/browser-agents")
 async def get_browser_agent_children(session_id: str):
     children = agent_manager.get_browser_agent_children(session_id)
     return {"sessions": children}
 
-@agents.router.post("/sessions/{session_id}/open-in-cli")
-async def open_in_cli(session_id: str):
-    session = agent_manager.get_session(session_id)
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
-    if not session.sdk_session_id:
-        raise HTTPException(status_code=400, detail="Session has no CLI session ID (agent may not have run yet)")
+@agents.router.post("/open-in-cli")
+async def open_in_cli(body: dict):
+    """Open a Claude CLI session in a terminal. Accepts either an OpenSwarm session_id or a raw cli_session_id."""
+    cli_session_id = body.get("cli_session_id")
+    cwd = body.get("cwd")
+
+    # If an OpenSwarm session ID is provided, resolve the CLI session ID from it
+    openswarm_id = body.get("session_id")
+    if openswarm_id and not cli_session_id:
+        session = agent_manager.get_session(openswarm_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        if not session.sdk_session_id:
+            raise HTTPException(status_code=400, detail="Session has no CLI session ID")
+        cli_session_id = session.sdk_session_id
+        cwd = cwd or session.cwd
+
+    if not cli_session_id:
+        raise HTTPException(status_code=400, detail="cli_session_id or session_id required")
 
     claude_path = shutil.which("claude")
     if not claude_path:
         raise HTTPException(status_code=500, detail="Claude CLI not found on PATH")
 
-    args = [claude_path, "--resume", session.sdk_session_id]
-    cwd = session.cwd or None
+    args = [claude_path, "--resume", cli_session_id]
 
     try:
         if sys.platform == "win32":
@@ -195,7 +288,7 @@ async def open_in_cli(session_id: str):
                 cwd=cwd, creationflags=subprocess.DETACHED_PROCESS,
             )
         elif sys.platform == "darwin":
-            script = f'tell application "Terminal" to do script "cd {cwd or "~"} && {claude_path} --resume {session.sdk_session_id}"'
+            script = f'tell application "Terminal" to do script "cd {cwd or "~"} && {claude_path} --resume {cli_session_id}"'
             subprocess.Popen(["osascript", "-e", script])
         else:
             for term in ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]:
@@ -211,7 +304,7 @@ async def open_in_cli(session_id: str):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    return {"ok": True, "sdk_session_id": session.sdk_session_id}
+    return {"ok": True, "cli_session_id": cli_session_id}
 
 @agents.router.post("/sessions/{session_id}/resume")
 async def resume_session(session_id: str):
@@ -220,4 +313,5 @@ async def resume_session(session_id: str):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     return {"session": session.model_dump(mode="json")}
+
 

--- a/backend/apps/agents/browser_agent.py
+++ b/backend/apps/agents/browser_agent.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
-    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 

--- a/backend/apps/agents/browser_agent.py
+++ b/backend/apps/agents/browser_agent.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 
@@ -274,25 +275,17 @@ async def _request_browser_approval(
     return decision
 
 
-async def run_browser_agent(
+async def _setup_browser_session(
     task: str,
     browser_id: str,
     model: str,
-    api_key: str,
-    dashboard_id: str | None = None,
-    tab_id: str = "",
-    pre_selected: bool = False,
-    initial_url: str | None = None,
-    parent_session_id: str | None = None,
-) -> dict:
-    """Run a browser sub-agent loop for a single browser card.
-
-    Creates a visible AgentSession, streams progress via WebSocket,
-    and returns the full action log + summary + final screenshot.
-    """
+    dashboard_id: str | None,
+    tab_id: str,
+    initial_url: str | None,
+    parent_session_id: str | None,
+) -> tuple:
+    """Common setup for browser agent sessions (API and CLI paths)."""
     from backend.apps.agents.agent_manager import agent_manager
-
-    _browser_perms = load_builtin_permissions()
 
     session_id = uuid4().hex
     cancel_event = asyncio.Event()
@@ -322,13 +315,6 @@ async def run_browser_agent(
         )
         logger.info(f"Browser agent {session_id}: navigated to {initial_url}: {nav_result.get('text', nav_result.get('error', ''))}")
 
-    api_model = MODEL_MAP.get(model, model)
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-
-    messages: list[dict] = [{"role": "user", "content": task}]
-    action_log: list[dict] = []
-    final_screenshot: str | None = None
-
     user_msg = Message(role="user", content=task)
     session.messages.append(user_msg)
     await ws_manager.send_to_session(session_id, "agent:message", {
@@ -336,74 +322,154 @@ async def run_browser_agent(
         "message": user_msg.model_dump(mode="json"),
     })
 
-    try:
-        for turn in range(MAX_TURNS):
-            if cancel_event.is_set():
-                break
+    return session_id, session, cancel_event
 
-            response = await client.messages.create(
-                model=api_model,
-                max_tokens=4096,
-                system=SYSTEM_PROMPT,
-                tools=BROWSER_TOOLS_SCHEMA,
-                messages=messages,
+
+async def _finalize_browser_session(
+    session_id: str,
+    session: AgentSession,
+    browser_id: str,
+    tab_id: str,
+    summary: str,
+    action_log: list[dict],
+    final_screenshot: str | None,
+    status: str = "completed",
+) -> dict:
+    """Common finalization for browser agent sessions."""
+    if not final_screenshot and status == "completed":
+        try:
+            ss_result = await execute_browser_tool(
+                "BrowserScreenshot", {}, browser_id, tab_id,
             )
+            if ss_result.get("image"):
+                final_screenshot = ss_result["image"]
+        except Exception:
+            pass
 
-            assistant_content = []
-            text_parts = []
-            tool_uses = []
+    session.status = status
+    await ws_manager.send_to_session(session_id, "agent:status", {
+        "session_id": session_id,
+        "status": status,
+        "session": session.model_dump(mode="json"),
+    })
 
-            for block in response.content:
-                if block.type == "text":
-                    text_parts.append(block.text)
-                    assistant_content.append({"type": "text", "text": block.text})
-                elif block.type == "tool_use":
-                    tool_uses.append(block)
-                    assistant_content.append({
-                        "type": "tool_use",
-                        "id": block.id,
-                        "name": block.name,
-                        "input": block.input,
-                    })
+    return {
+        "session_id": session_id,
+        "browser_id": browser_id,
+        "summary": summary,
+        "action_log": action_log,
+        "final_screenshot": final_screenshot,
+    }
 
-            if text_parts:
-                asst_msg = Message(
-                    role="assistant",
-                    content="\n".join(text_parts),
-                )
-                session.messages.append(asst_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": asst_msg.model_dump(mode="json"),
+
+async def _run_browser_agent_api(
+    task: str,
+    session_id: str,
+    session: AgentSession,
+    cancel_event: asyncio.Event,
+    browser_id: str,
+    model: str,
+    api_key: str,
+    tab_id: str,
+) -> dict:
+    """Run browser agent using direct Anthropic API (when API key is available)."""
+    _browser_perms = load_builtin_permissions()
+    api_model = MODEL_MAP.get(model, model)
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    messages: list[dict] = [{"role": "user", "content": task}]
+    action_log: list[dict] = []
+    final_screenshot: str | None = None
+
+    for turn in range(MAX_TURNS):
+        if cancel_event.is_set():
+            break
+
+        response = await client.messages.create(
+            model=api_model,
+            max_tokens=4096,
+            system=SYSTEM_PROMPT,
+            tools=BROWSER_TOOLS_SCHEMA,
+            messages=messages,
+        )
+
+        assistant_content = []
+        text_parts = []
+        tool_uses = []
+
+        for block in response.content:
+            if block.type == "text":
+                text_parts.append(block.text)
+                assistant_content.append({"type": "text", "text": block.text})
+            elif block.type == "tool_use":
+                tool_uses.append(block)
+                assistant_content.append({
+                    "type": "tool_use",
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
                 })
 
-            for tu in tool_uses:
-                tool_msg = Message(
-                    role="tool_call",
-                    content={"id": tu.id, "tool": tu.name, "input": tu.input},
-                )
-                session.messages.append(tool_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": tool_msg.model_dump(mode="json"),
-                })
+        if text_parts:
+            asst_msg = Message(
+                role="assistant",
+                content="\n".join(text_parts),
+            )
+            session.messages.append(asst_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
+                "session_id": session_id,
+                "message": asst_msg.model_dump(mode="json"),
+            })
 
-            messages.append({"role": "assistant", "content": assistant_content})
+        for tu in tool_uses:
+            tool_msg = Message(
+                role="tool_call",
+                content={"id": tu.id, "tool": tu.name, "input": tu.input},
+            )
+            session.messages.append(tool_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
+                "session_id": session_id,
+                "message": tool_msg.model_dump(mode="json"),
+            })
 
-            if response.stop_reason != "tool_use":
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        if response.stop_reason != "tool_use":
+            break
+
+        tool_results = []
+        cancelled = False
+        for tu in tool_uses:
+            if cancel_event.is_set():
+                cancelled = True
                 break
 
-            tool_results = []
-            cancelled = False
-            for tu in tool_uses:
-                if cancel_event.is_set():
-                    cancelled = True
-                    break
+            policy = _browser_perms.get(tu.name, "always_allow")
 
-                policy = _browser_perms.get(tu.name, "always_allow")
+            if policy == "deny":
+                denied_text = f"Tool {tu.name} is denied by permission policy."
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tu.id,
+                    "content": [{"type": "text", "text": denied_text}],
+                })
+                result_msg = Message(
+                    role="tool_result",
+                    content={"text": denied_text, "tool_name": tu.name, "elapsed_ms": 0},
+                )
+                session.messages.append(result_msg)
+                await ws_manager.send_to_session(session_id, "agent:message", {
+                    "session_id": session_id,
+                    "message": result_msg.model_dump(mode="json"),
+                })
+                continue
 
-                if policy == "deny":
-                    denied_text = f"Tool {tu.name} is denied by permission policy."
+            if policy == "ask":
+                decision = await _request_browser_approval(
+                    session, tu.name, tu.input,
+                )
+                if decision.get("behavior") == "deny":
+                    denied_text = decision.get("message") or f"Tool {tu.name} denied by user."
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": tu.id,
@@ -420,110 +486,185 @@ async def run_browser_agent(
                     })
                     continue
 
-                if policy == "ask":
-                    decision = await _request_browser_approval(
-                        session, tu.name, tu.input,
-                    )
-                    if decision.get("behavior") == "deny":
-                        denied_text = decision.get("message") or f"Tool {tu.name} denied by user."
-                        tool_results.append({
-                            "type": "tool_result",
-                            "tool_use_id": tu.id,
-                            "content": [{"type": "text", "text": denied_text}],
-                        })
-                        result_msg = Message(
-                            role="tool_result",
-                            content={"text": denied_text, "tool_name": tu.name, "elapsed_ms": 0},
-                        )
-                        session.messages.append(result_msg)
-                        await ws_manager.send_to_session(session_id, "agent:message", {
-                            "session_id": session_id,
-                            "message": result_msg.model_dump(mode="json"),
-                        })
-                        continue
+            start = time.time()
+            result = await execute_browser_tool(
+                tu.name, tu.input, browser_id, tab_id,
+            )
+            elapsed_ms = int((time.time() - start) * 1000)
 
-                start = time.time()
-                result = await execute_browser_tool(
-                    tu.name, tu.input, browser_id, tab_id,
-                )
-                elapsed_ms = int((time.time() - start) * 1000)
-
-                action_log.append({
-                    "tool": tu.name,
-                    "input": tu.input,
-                    "result_summary": result.get("text", result.get("error", ""))[:200],
-                    "elapsed_ms": elapsed_ms,
-                })
-
-                if tu.name == "BrowserScreenshot" and result.get("image"):
-                    final_screenshot = result["image"]
-
-                content_blocks = _format_tool_result(result, tu.name)
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": tu.id,
-                    "content": content_blocks,
-                })
-
-                result_text = result.get("text", result.get("error", ""))
-                result_msg = Message(
-                    role="tool_result",
-                    content={"text": result_text, "tool_name": tu.name, "elapsed_ms": elapsed_ms},
-                )
-                session.messages.append(result_msg)
-                await ws_manager.send_to_session(session_id, "agent:message", {
-                    "session_id": session_id,
-                    "message": result_msg.model_dump(mode="json"),
-                })
-
-            messages.append({"role": "user", "content": tool_results})
-
-            if cancelled:
-                break
-
-        if cancel_event.is_set():
-            session.status = "stopped"
-            await ws_manager.send_to_session(session_id, "agent:status", {
-                "session_id": session_id,
-                "status": "stopped",
-                "session": session.model_dump(mode="json"),
+            action_log.append({
+                "tool": tu.name,
+                "input": tu.input,
+                "result_summary": result.get("text", result.get("error", ""))[:200],
+                "elapsed_ms": elapsed_ms,
             })
-            return {
+
+            if tu.name == "BrowserScreenshot" and result.get("image"):
+                final_screenshot = result["image"]
+
+            content_blocks = _format_tool_result(result, tu.name)
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tu.id,
+                "content": content_blocks,
+            })
+
+            result_text = result.get("text", result.get("error", ""))
+            result_msg = Message(
+                role="tool_result",
+                content={"text": result_text, "tool_name": tu.name, "elapsed_ms": elapsed_ms},
+            )
+            session.messages.append(result_msg)
+            await ws_manager.send_to_session(session_id, "agent:message", {
                 "session_id": session_id,
-                "browser_id": browser_id,
-                "summary": "Agent was stopped.",
-                "action_log": action_log,
-                "final_screenshot": final_screenshot,
-            }
+                "message": result_msg.model_dump(mode="json"),
+            })
 
-        summary_parts = text_parts if text_parts else ["Task completed."]
-        summary = "\n".join(summary_parts)
+        messages.append({"role": "user", "content": tool_results})
 
-        if not final_screenshot:
-            try:
-                ss_result = await execute_browser_tool(
-                    "BrowserScreenshot", {}, browser_id, tab_id,
-                )
-                if ss_result.get("image"):
-                    final_screenshot = ss_result["image"]
-            except Exception:
-                pass
+        if cancelled:
+            break
 
-        session.status = "completed"
-        await ws_manager.send_to_session(session_id, "agent:status", {
-            "session_id": session_id,
-            "status": "completed",
-            "session": session.model_dump(mode="json"),
-        })
+    if cancel_event.is_set():
+        return await _finalize_browser_session(
+            session_id, session, browser_id, tab_id,
+            "Agent was stopped.", action_log, final_screenshot, "stopped",
+        )
 
-        return {
-            "session_id": session_id,
-            "browser_id": browser_id,
-            "summary": summary,
-            "action_log": action_log,
-            "final_screenshot": final_screenshot,
-        }
+    summary = "\n".join(text_parts) if text_parts else "Task completed."
+    return await _finalize_browser_session(
+        session_id, session, browser_id, tab_id,
+        summary, action_log, final_screenshot,
+    )
 
+
+async def _run_browser_agent_cli(
+    task: str,
+    session_id: str,
+    session: AgentSession,
+    cancel_event: asyncio.Event,
+    browser_id: str,
+    model: str,
+    tab_id: str,
+) -> dict:
+    """Run browser agent using Claude Code CLI (when no API key is available)."""
+    import os as _os
+    import sys as _sys
+    from claude_agent_sdk import query, ClaudeAgentOptions
+    from claude_agent_sdk.types import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+
+    action_log: list[dict] = []
+    final_screenshot: str | None = None
+    text_parts: list[str] = []
+
+    browser_tools_server = _os.path.join(
+        _os.path.dirname(__file__), "browser_tools_mcp_server.py",
+    )
+    backend_port = _os.environ.get("OPENSWARM_PORT", "8324")
+
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=SYSTEM_PROMPT,
+        max_turns=MAX_TURNS,
+        permission_mode="bypassPermissions",
+        mcp_servers={
+            "browser-tools": {
+                "command": _sys.executable,
+                "args": [browser_tools_server],
+                "env": {
+                    "OPENSWARM_PORT": backend_port,
+                    "OPENSWARM_BROWSER_ID": browser_id,
+                },
+                "type": "stdio",
+            },
+        },
+        stderr=lambda line: None,
+    )
+
+    async for message in query(prompt=task, options=options):
+        if cancel_event.is_set():
+            break
+
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text_parts.append(block.text)
+                    asst_msg = Message(role="assistant", content=block.text)
+                    session.messages.append(asst_msg)
+                    await ws_manager.send_to_session(session_id, "agent:message", {
+                        "session_id": session_id,
+                        "message": asst_msg.model_dump(mode="json"),
+                    })
+                elif isinstance(block, ToolUseBlock):
+                    tool_name = block.name
+                    # Strip MCP prefix if present (e.g. mcp__browser-tools__BrowserClick → BrowserClick)
+                    if "__" in tool_name:
+                        tool_name = tool_name.split("__")[-1]
+
+                    tool_msg = Message(
+                        role="tool_call",
+                        content={"id": block.id, "tool": tool_name, "input": block.input},
+                    )
+                    session.messages.append(tool_msg)
+                    await ws_manager.send_to_session(session_id, "agent:message", {
+                        "session_id": session_id,
+                        "message": tool_msg.model_dump(mode="json"),
+                    })
+
+                    action_log.append({
+                        "tool": tool_name,
+                        "input": block.input,
+                        "result_summary": "",
+                        "elapsed_ms": 0,
+                    })
+
+    if cancel_event.is_set():
+        return await _finalize_browser_session(
+            session_id, session, browser_id, tab_id,
+            "Agent was stopped.", action_log, final_screenshot, "stopped",
+        )
+
+    summary = "\n".join(text_parts) if text_parts else "Task completed."
+    return await _finalize_browser_session(
+        session_id, session, browser_id, tab_id,
+        summary, action_log, final_screenshot,
+    )
+
+
+async def run_browser_agent(
+    task: str,
+    browser_id: str,
+    model: str,
+    api_key: str | None = None,
+    dashboard_id: str | None = None,
+    tab_id: str = "",
+    pre_selected: bool = False,
+    initial_url: str | None = None,
+    parent_session_id: str | None = None,
+) -> dict:
+    """Run a browser sub-agent loop for a single browser card.
+
+    Creates a visible AgentSession, streams progress via WebSocket,
+    and returns the full action log + summary + final screenshot.
+
+    Routes through direct Anthropic API when api_key is provided,
+    or through Claude Code CLI when it's not.
+    """
+    session_id, session, cancel_event = await _setup_browser_session(
+        task, browser_id, model, dashboard_id, tab_id, initial_url, parent_session_id,
+    )
+
+    try:
+        if api_key:
+            return await _run_browser_agent_api(
+                task, session_id, session, cancel_event,
+                browser_id, model, api_key, tab_id,
+            )
+        else:
+            return await _run_browser_agent_cli(
+                task, session_id, session, cancel_event,
+                browser_id, model, tab_id,
+            )
     except Exception as e:
         logger.exception(f"Browser agent {session_id} error: {e}")
         session.status = "error"
@@ -543,7 +684,7 @@ async def run_browser_agent(
             "session_id": session_id,
             "browser_id": browser_id,
             "summary": f"Error: {str(e)}",
-            "action_log": action_log,
+            "action_log": [],
             "final_screenshot": None,
         }
 
@@ -582,7 +723,7 @@ async def _create_browser_card(dashboard_id: str, url: str, parent_session_id: s
 async def run_browser_agents(
     tasks: list[dict],
     model: str,
-    api_key: str,
+    api_key: str | None = None,
     dashboard_id: str | None = None,
     pre_selected_browser_ids: list[str] | None = None,
     parent_session_id: str | None = None,
@@ -591,6 +732,7 @@ async def run_browser_agents(
 
     Each task dict has: { browser_id (optional), task, url (optional) }
     Returns a list of result dicts, one per task.
+    Uses direct API when api_key is provided, CLI otherwise.
     """
     pre_selected = set(pre_selected_browser_ids or [])
 

--- a/backend/apps/agents/browser_tools_mcp_server.py
+++ b/backend/apps/agents/browser_tools_mcp_server.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Stdio MCP server that exposes the 9 low-level browser tools as MCP tools.
+
+Used by claude_agent_sdk when running browser agents through CLI (no API key).
+Each tool call proxies to the backend's /api/browser/command HTTP endpoint,
+which forwards the command to the frontend browser card via WebSocket.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+BACKEND_PORT = os.environ.get("OPENSWARM_PORT", "8324")
+BROWSER_ID = os.environ.get("OPENSWARM_BROWSER_ID", "")
+COMMAND_URL = f"http://127.0.0.1:{BACKEND_PORT}/api/browser/command"
+
+TOOLS = [
+    {
+        "name": "BrowserScreenshot",
+        "description": (
+            "Capture a screenshot of the browser page. Returns the screenshot as a "
+            "base64-encoded PNG image. Use this to see what is currently displayed."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserGetText",
+        "description": (
+            "Get the visible text content of the browser page. Returns up to 15000 characters."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserNavigate",
+        "description": "Navigate the browser to a specific URL.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to navigate to.",
+                },
+            },
+            "required": ["url"],
+        },
+    },
+    {
+        "name": "BrowserClick",
+        "description": (
+            "Click an element on the page identified by a CSS selector. "
+            "Use BrowserGetElements first to find valid selectors."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector for the element to click.",
+                },
+            },
+            "required": ["selector"],
+        },
+    },
+    {
+        "name": "BrowserType",
+        "description": (
+            "Type text into an input element identified by a CSS selector. "
+            "Optionally clear existing content first."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector for the input element.",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "The text to type.",
+                },
+                "clear": {
+                    "type": "boolean",
+                    "description": "Clear existing content before typing. Defaults to true.",
+                },
+            },
+            "required": ["selector", "text"],
+        },
+    },
+    {
+        "name": "BrowserEvaluate",
+        "description": (
+            "Execute JavaScript code in the browser page and return the result. "
+            "The last expression value is returned as a string."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "JavaScript code to execute in the page context.",
+                },
+            },
+            "required": ["expression"],
+        },
+    },
+    {
+        "name": "BrowserGetElements",
+        "description": (
+            "Query DOM elements matching a CSS selector. Returns tag name, text, "
+            "attributes, and bounding box for each match (up to 50 elements)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector to query elements.",
+                },
+            },
+            "required": ["selector"],
+        },
+    },
+    {
+        "name": "BrowserScroll",
+        "description": (
+            "Scroll the browser page. Can scroll up, down, or to a specific element. "
+            "Returns scroll position info including whether you're at the top or bottom."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "enum": ["up", "down"],
+                    "description": "Direction to scroll. Ignored if 'selector' is provided.",
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector of element to scroll into view.",
+                },
+                "amount": {
+                    "type": "number",
+                    "description": "Pixels to scroll. Defaults to one viewport height.",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "BrowserWait",
+        "description": (
+            "Wait for a specified duration. Use after navigation or actions that "
+            "trigger page loads. Min 100ms, max 10000ms."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "milliseconds": {
+                    "type": "number",
+                    "description": "Duration to wait in milliseconds. Defaults to 1000.",
+                },
+            },
+            "required": [],
+        },
+    },
+]
+
+# Map tool names to backend action names (matches browser_agent.py ACTION_MAP)
+ACTION_MAP = {
+    "BrowserScreenshot": "screenshot",
+    "BrowserGetText": "get_text",
+    "BrowserNavigate": "navigate",
+    "BrowserClick": "click",
+    "BrowserType": "type",
+    "BrowserEvaluate": "evaluate",
+    "BrowserGetElements": "get_elements",
+    "BrowserScroll": "scroll",
+    "BrowserWait": "wait",
+}
+
+
+def send_response(id_, result=None, error=None):
+    msg = {"jsonrpc": "2.0", "id": id_}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = result
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+def call_browser_command(action: str, params: dict) -> dict:
+    """Send a browser command to the backend HTTP endpoint."""
+    payload = json.dumps({
+        "action": action,
+        "browser_id": BROWSER_ID,
+        "params": params,
+    }).encode()
+    req = urllib.request.Request(
+        COMMAND_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode() if e.fp else str(e)
+        return {"error": f"HTTP {e.code}: {body}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def handle_tool_call(tool_name: str, arguments: dict) -> dict:
+    action = ACTION_MAP.get(tool_name)
+    if not action:
+        return {"content": [{"type": "text", "text": f"Unknown tool: {tool_name}"}], "isError": True}
+
+    result = call_browser_command(action, arguments)
+
+    if "error" in result:
+        return {"content": [{"type": "text", "text": f"Error: {result['error']}"}], "isError": True}
+
+    # Handle screenshot results — return as image content block
+    if tool_name == "BrowserScreenshot" and result.get("image"):
+        content = [
+            {"type": "image", "data": result["image"], "mimeType": "image/png"},
+            {"type": "text", "text": f"Screenshot captured. URL: {result.get('url', 'unknown')}"},
+        ]
+        return {"content": content}
+
+    # All other results — return as text
+    text = result.get("text", json.dumps(result))
+    return {"content": [{"type": "text", "text": str(text)}]}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = msg.get("method")
+        id_ = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            send_response(id_, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {
+                    "name": "openswarm-browser-tools",
+                    "version": "1.0.0",
+                },
+            })
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send_response(id_, {"tools": TOOLS})
+        elif method == "tools/call":
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+            result = handle_tool_call(tool_name, arguments)
+            send_response(id_, result)
+        elif method == "ping":
+            send_response(id_, {})
+        elif id_ is not None:
+            send_response(id_, error={"code": -32601, "message": f"Method not found: {method}"})
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/apps/agents/models.py
+++ b/backend/apps/agents/models.py
@@ -13,6 +13,7 @@ class AgentConfig(BaseModel):
     max_turns: Optional[int] = None
     target_directory: Optional[str] = None  # if None, uses repo root
     dashboard_id: Optional[str] = None
+    resume_cli_session_id: Optional[str] = None
 
 class ApprovalRequest(BaseModel):
     id: str = Field(default_factory=lambda: uuid4().hex)

--- a/backend/apps/agents/models.py
+++ b/backend/apps/agents/models.py
@@ -74,3 +74,4 @@ class AgentSession(BaseModel):
     dashboard_id: Optional[str] = None
     browser_id: Optional[str] = None
     parent_session_id: Optional[str] = None
+    schedule_id: Optional[str] = None

--- a/backend/apps/agents/models.py
+++ b/backend/apps/agents/models.py
@@ -7,6 +7,7 @@ class AgentConfig(BaseModel):
     name: str = Field(default_factory=lambda: f"Agent-{uuid4().hex[:6]}")
     model: str = "sonnet"
     mode: str = "agent"
+    effort: Optional[str] = None
     system_prompt: Optional[str] = None
     allowed_tools: list[str] = Field(default_factory=lambda: ["Read", "Edit", "Write", "Bash", "Glob", "Grep", "AskUserQuestion"])
     max_turns: Optional[int] = None
@@ -57,6 +58,8 @@ class AgentSession(BaseModel):
     status: Literal["running", "waiting_approval", "completed", "error", "stopped"] = "running"
     model: str = "sonnet"
     mode: str = "agent"
+    effort: Optional[str] = None
+    use_1m_context: bool = False
     sdk_session_id: Optional[str] = None
     system_prompt: Optional[str] = None
     allowed_tools: list[str] = Field(default_factory=list)

--- a/backend/apps/dashboards/dashboards.py
+++ b/backend/apps/dashboards/dashboards.py
@@ -151,13 +151,7 @@ async def generate_name(dashboard_id: str):
 
     fallback = prompts[0][:40]
     try:
-        import anthropic
-        from backend.apps.settings.settings import load_settings
-        global_settings = load_settings()
-        if not global_settings.anthropic_api_key:
-            raise ValueError("API key not configured")
-
-        client = anthropic.AsyncAnthropic(api_key=global_settings.anthropic_api_key)
+        from backend.apps.settings.llm_router import llm_call
 
         if len(prompts) == 1:
             system = (
@@ -172,17 +166,17 @@ async def generate_name(dashboard_id: str):
             )
             user_content = "\n".join(f"- {p}" for p in prompts)
 
-        resp = await client.messages.create(
-            model="claude-haiku-4-5-20251001",
-            max_tokens=30,
+        generated = await llm_call(
             system=system,
-            messages=[{"role": "user", "content": user_content}],
+            user_message=user_content,
+            model="haiku",
+            max_tokens=30,
         )
-        generated = resp.content[0].text.strip().strip('"\'')
+        generated = generated.strip('"\'')
         if generated:
             fallback = generated
     except Exception as e:
-        logger.warning(f"Dashboard name generation failed, using fallback: {e}")
+        logger.debug(f"Dashboard name generation failed, using fallback: {e}")
 
     dashboard.name = fallback
     dashboard.auto_named = True
@@ -215,6 +209,10 @@ async def update_dashboard(dashboard_id: str, body: DashboardUpdate):
 @dashboards.router.delete("/{dashboard_id}")
 async def delete_dashboard(dashboard_id: str):
     _load(dashboard_id)
+
+    # Delete schedules tied to this dashboard
+    from backend.apps.schedules.schedules import delete_schedules_for_dashboard
+    delete_schedules_for_dashboard(dashboard_id)
 
     if os.path.exists(SESSIONS_DIR):
         for fname in os.listdir(SESSIONS_DIR):

--- a/backend/apps/outputs/outputs.py
+++ b/backend/apps/outputs/outputs.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
-    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 

--- a/backend/apps/outputs/outputs.py
+++ b/backend/apps/outputs/outputs.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 
@@ -31,14 +32,10 @@ def _resolve_model(short_name: str) -> str:
     return MODEL_MAP.get(short_name, short_name)
 
 
-def _get_anthropic_client():
-    """Create an AsyncAnthropic client using the API key from app settings."""
-    import anthropic
-
-    settings = load_settings()
-    if not settings.anthropic_api_key:
-        raise ValueError("Anthropic API key not configured. Set it in Settings.")
-    return anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+async def _llm_call(system: str, user_message: str, model: str = "sonnet", max_tokens: int = 4000) -> str:
+    """Route view builder LLM calls through API or CLI."""
+    from backend.apps.settings.llm_router import llm_call
+    return await llm_call(system=system, user_message=user_message, model=model, max_tokens=max_tokens)
 
 
 def _validate_against_schema(data: dict, schema: dict) -> str | None:
@@ -378,15 +375,13 @@ async def vibe_code(body: VibeCodeRequest):
     if context_parts:
         user_message = "\n\n".join(context_parts) + "\n\nUser request: " + body.prompt
 
-    client = _get_anthropic_client()
     try:
-        resp = await client.messages.create(
-            model="claude-sonnet-4-20250514",
-            max_tokens=8000,
+        raw = await _llm_call(
             system=VIBE_CODE_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_message}],
+            user_message=user_message,
+            model="sonnet",
+            max_tokens=8000,
         )
-        raw = resp.content[0].text.strip()
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
             if raw.endswith("```"):
@@ -429,24 +424,16 @@ Every required field must be present. Use realistic, meaningful data.\
 @outputs.router.post("/auto-run")
 async def auto_run_output(body: AutoRunRequest):
     """Use an LLM to generate input data matching the schema, then optionally execute backend code."""
-    try:
-        import anthropic
-    except ImportError:
-        return {"error": "anthropic SDK not installed", "input_data": None, "backend_result": None}
-
     schema_str = json.dumps(body.input_schema, indent=2)
     user_message = f"Schema:\n```json\n{schema_str}\n```\n\nGenerate data for: {body.prompt}"
 
-    api_model = _resolve_model(body.model)
-    client = _get_anthropic_client()
     try:
-        resp = await client.messages.create(
-            model=api_model,
-            max_tokens=4000,
+        raw = await _llm_call(
             system=AUTO_RUN_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_message}],
+            user_message=user_message,
+            model=body.model,
+            max_tokens=4000,
         )
-        raw = resp.content[0].text.strip()
         if raw.startswith("```"):
             raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
             if raw.endswith("```"):

--- a/backend/apps/schedules/executor.py
+++ b/backend/apps/schedules/executor.py
@@ -1,0 +1,68 @@
+import logging
+from backend.apps.schedules.models import Schedule
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_schedule(schedule: Schedule):
+    """Fire a schedule: create a new session or message an existing one."""
+    if schedule.action_type == "new_session":
+        await _create_new_session(schedule)
+    elif schedule.action_type == "message_existing":
+        await _message_existing(schedule)
+    else:
+        raise ValueError(f"Unknown action_type: {schedule.action_type}")
+
+
+async def _create_new_session(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+    from backend.apps.agents.models import AgentConfig
+
+    config_kwargs: dict = {
+        "dashboard_id": schedule.dashboard_id,
+    }
+
+    if schedule.template_id:
+        try:
+            from backend.apps.templates.templates import _load as load_template
+            template = load_template(schedule.template_id)
+            if template.mode:
+                config_kwargs["mode"] = template.mode
+        except Exception:
+            logger.warning(f"Template {schedule.template_id} not found, using defaults")
+
+    if schedule.model:
+        config_kwargs["model"] = schedule.model
+    if schedule.mode:
+        config_kwargs["mode"] = schedule.mode
+    if schedule.system_prompt:
+        config_kwargs["system_prompt"] = schedule.system_prompt
+
+    config = AgentConfig(**config_kwargs)
+    session = await agent_manager.launch_agent(config)
+
+    await agent_manager.send_message(
+        session.id,
+        schedule.prompt,
+        mode=config_kwargs.get("mode"),
+        model=config_kwargs.get("model"),
+    )
+
+    logger.info(f"Schedule {schedule.id} created session {session.id}")
+
+
+async def _message_existing(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+
+    if not schedule.target_session_id:
+        raise ValueError("target_session_id required for message_existing action")
+
+    if schedule.target_session_id not in agent_manager.sessions:
+        raise ValueError(f"Session {schedule.target_session_id} not found or not active")
+
+    await agent_manager.send_message(
+        schedule.target_session_id,
+        schedule.prompt,
+    )
+
+    logger.info(f"Schedule {schedule.id} sent message to session {schedule.target_session_id}")

--- a/backend/apps/schedules/executor.py
+++ b/backend/apps/schedules/executor.py
@@ -38,6 +38,8 @@ async def _create_new_session(schedule: Schedule):
         config_kwargs["mode"] = schedule.mode
     if schedule.system_prompt:
         config_kwargs["system_prompt"] = schedule.system_prompt
+    if schedule.target_directory:
+        config_kwargs["target_directory"] = schedule.target_directory
 
     config = AgentConfig(**config_kwargs)
     session = await agent_manager.launch_agent(config)

--- a/backend/apps/schedules/executor.py
+++ b/backend/apps/schedules/executor.py
@@ -19,6 +19,7 @@ async def _create_new_session(schedule: Schedule):
     from backend.apps.agents.models import AgentConfig
 
     config_kwargs: dict = {
+        "name": schedule.name,
         "dashboard_id": schedule.dashboard_id,
     }
 
@@ -40,6 +41,7 @@ async def _create_new_session(schedule: Schedule):
 
     config = AgentConfig(**config_kwargs)
     session = await agent_manager.launch_agent(config)
+    session.schedule_id = schedule.id
 
     await agent_manager.send_message(
         session.id,

--- a/backend/apps/schedules/models.py
+++ b/backend/apps/schedules/models.py
@@ -26,6 +26,7 @@ class Schedule(BaseModel):
     model: Optional[str] = None
     mode: Optional[str] = None
     system_prompt: Optional[str] = None
+    target_directory: Optional[str] = None
 
     # State
     last_run_at: Optional[datetime] = None
@@ -51,6 +52,7 @@ class ScheduleCreate(BaseModel):
     model: Optional[str] = None
     mode: Optional[str] = None
     system_prompt: Optional[str] = None
+    target_directory: Optional[str] = None
 
 
 class ScheduleUpdate(BaseModel):
@@ -68,3 +70,4 @@ class ScheduleUpdate(BaseModel):
     model: Optional[str] = None
     mode: Optional[str] = None
     system_prompt: Optional[str] = None
+    target_directory: Optional[str] = None

--- a/backend/apps/schedules/models.py
+++ b/backend/apps/schedules/models.py
@@ -1,0 +1,70 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+from uuid import uuid4
+
+
+class Schedule(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    name: str = "Untitled Schedule"
+    enabled: bool = True
+    dashboard_id: str
+
+    # Trigger
+    trigger_type: str  # "cron" | "interval" | "once"
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+
+    # Action
+    action_type: str  # "new_session" | "message_existing"
+    prompt: str
+    target_session_id: Optional[str] = None
+
+    # Agent config (new_session only)
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+    # State
+    last_run_at: Optional[datetime] = None
+    next_run_at: Optional[datetime] = None
+    run_count: int = 0
+    last_error: Optional[str] = None
+
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class ScheduleCreate(BaseModel):
+    name: str = "Untitled Schedule"
+    dashboard_id: str
+    trigger_type: str
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: str
+    prompt: str
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+
+class ScheduleUpdate(BaseModel):
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    dashboard_id: Optional[str] = None
+    trigger_type: Optional[str] = None
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: Optional[str] = None
+    prompt: Optional[str] = None
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None

--- a/backend/apps/schedules/scheduler.py
+++ b/backend/apps/schedules/scheduler.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+_scheduler_task: asyncio.Task | None = None
+TICK_INTERVAL = 30
+
+
+async def _tick():
+    """One evaluation cycle: check all enabled schedules, fire due ones."""
+    from backend.apps.schedules.schedules import _load_all, _save
+    from backend.apps.schedules.executor import execute_schedule
+
+    now = datetime.now()
+    for schedule in _load_all():
+        if not schedule.enabled:
+            continue
+        if schedule.next_run_at is None:
+            continue
+        if schedule.next_run_at > now:
+            continue
+
+        try:
+            await execute_schedule(schedule)
+            schedule.last_run_at = now
+            schedule.run_count += 1
+            schedule.last_error = None
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_complete", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+            })
+        except Exception as e:
+            logger.exception(f"Schedule {schedule.id} ({schedule.name}) failed")
+            schedule.last_error = str(e)
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_failed", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+                "error": str(e),
+            })
+
+        schedule.next_run_at = _compute_next_run(schedule, now)
+
+        if schedule.trigger_type == "once":
+            schedule.enabled = False
+
+        schedule.updated_at = now
+        _save(schedule)
+
+
+def _compute_next_run(schedule, after: datetime) -> datetime | None:
+    """Compute the next run time based on trigger type."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, after).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return after + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once":
+        return None
+    return None
+
+
+def compute_initial_next_run(schedule) -> datetime | None:
+    """Compute the first next_run_at when a schedule is created."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, datetime.now()).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return datetime.now() + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once" and schedule.run_at:
+        return schedule.run_at
+    return None
+
+
+async def _run_loop():
+    """Main scheduler loop — ticks every TICK_INTERVAL seconds."""
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.exception("Scheduler tick failed")
+        await asyncio.sleep(TICK_INTERVAL)
+
+
+def start_scheduler():
+    """Start the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task is None or _scheduler_task.done():
+        loop = asyncio.get_event_loop()
+        _scheduler_task = loop.create_task(_run_loop())
+        logger.info("Scheduler started (tick interval: %ds)", TICK_INTERVAL)
+
+
+def stop_scheduler():
+    """Stop the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task and not _scheduler_task.done():
+        _scheduler_task.cancel()
+        _scheduler_task = None
+        logger.info("Scheduler stopped")

--- a/backend/apps/schedules/scheduler.py
+++ b/backend/apps/schedules/scheduler.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 logger = logging.getLogger(__name__)
 
 _scheduler_task: asyncio.Task | None = None
-TICK_INTERVAL = 30
+TICK_INTERVAL = 5
 
 
 async def _tick():
@@ -44,7 +44,9 @@ async def _tick():
                 "error": str(e),
             })
 
-        schedule.next_run_at = _compute_next_run(schedule, now)
+        # Compute next_run_at relative to current time (after execution),
+        # not the stale `now` from tick start, to avoid stacking missed runs
+        schedule.next_run_at = _compute_next_run(schedule, datetime.now())
 
         if schedule.trigger_type == "once":
             schedule.enabled = False

--- a/backend/apps/schedules/schedules.py
+++ b/backend/apps/schedules/schedules.py
@@ -1,0 +1,139 @@
+import json
+import os
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime
+
+from backend.config.Apps import SubApp
+from backend.apps.schedules.models import Schedule, ScheduleCreate, ScheduleUpdate
+from backend.apps.schedules.scheduler import start_scheduler, stop_scheduler, compute_initial_next_run
+from backend.config.paths import SCHEDULES_DIR as DATA_DIR
+from fastapi import HTTPException, Query
+
+logger = logging.getLogger(__name__)
+
+
+def _load_all() -> list[Schedule]:
+    result = []
+    if not os.path.exists(DATA_DIR):
+        return result
+    for fname in os.listdir(DATA_DIR):
+        if fname.endswith(".json"):
+            with open(os.path.join(DATA_DIR, fname)) as f:
+                result.append(Schedule(**json.load(f)))
+    return result
+
+
+def _save(schedule: Schedule):
+    with open(os.path.join(DATA_DIR, f"{schedule.id}.json"), "w") as f:
+        json.dump(schedule.model_dump(mode="json"), f, indent=2)
+
+
+def _load(schedule_id: str) -> Schedule:
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    with open(path) as f:
+        return Schedule(**json.load(f))
+
+
+def _delete(schedule_id: str):
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def delete_schedules_for_dashboard(dashboard_id: str):
+    """Remove all schedules tied to a dashboard. Called during dashboard deletion."""
+    for schedule in _load_all():
+        if schedule.dashboard_id == dashboard_id:
+            _delete(schedule.id)
+            logger.info(f"Deleted schedule {schedule.id} (dashboard {dashboard_id} deleted)")
+
+
+@asynccontextmanager
+async def schedules_lifespan():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    start_scheduler()
+    try:
+        yield
+    finally:
+        stop_scheduler()
+
+
+schedules = SubApp("schedules", schedules_lifespan)
+
+
+@schedules.router.get("/list")
+async def list_schedules(dashboard_id: str | None = Query(None)):
+    all_schedules = _load_all()
+    if dashboard_id:
+        all_schedules = [s for s in all_schedules if s.dashboard_id == dashboard_id]
+    all_schedules.sort(key=lambda s: s.updated_at or s.created_at, reverse=True)
+    return {"schedules": [s.model_dump(mode="json") for s in all_schedules]}
+
+
+@schedules.router.post("/create")
+async def create_schedule(body: ScheduleCreate):
+    schedule = Schedule(
+        name=body.name,
+        dashboard_id=body.dashboard_id,
+        trigger_type=body.trigger_type,
+        cron_expression=body.cron_expression,
+        interval_seconds=body.interval_seconds,
+        run_at=body.run_at,
+        action_type=body.action_type,
+        prompt=body.prompt,
+        target_session_id=body.target_session_id,
+        template_id=body.template_id,
+        model=body.model,
+        mode=body.mode,
+        system_prompt=body.system_prompt,
+    )
+    schedule.next_run_at = compute_initial_next_run(schedule)
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.get("/{schedule_id}")
+async def get_schedule(schedule_id: str):
+    return _load(schedule_id).model_dump(mode="json")
+
+
+@schedules.router.put("/{schedule_id}")
+async def update_schedule(schedule_id: str, body: ScheduleUpdate):
+    schedule = _load(schedule_id)
+    trigger_changed = False
+
+    for field_name in body.model_fields_set:
+        value = getattr(body, field_name)
+        setattr(schedule, field_name, value)
+        if field_name in ("trigger_type", "cron_expression", "interval_seconds", "run_at"):
+            trigger_changed = True
+
+    if trigger_changed:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.delete("/{schedule_id}")
+async def delete_schedule_endpoint(schedule_id: str):
+    _load(schedule_id)  # 404 if not found
+    _delete(schedule_id)
+    return {"ok": True}
+
+
+@schedules.router.post("/{schedule_id}/toggle")
+async def toggle_schedule(schedule_id: str):
+    schedule = _load(schedule_id)
+    schedule.enabled = not schedule.enabled
+
+    if schedule.enabled and schedule.next_run_at is None:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")

--- a/backend/apps/settings/llm_router.py
+++ b/backend/apps/settings/llm_router.py
@@ -1,0 +1,91 @@
+"""
+LLM Router — routes LLM calls through direct Anthropic API or Claude Code CLI.
+
+When an API key is configured, uses direct API calls (faster, lower latency).
+When no API key is set, falls back to Claude Code CLI via claude_agent_sdk,
+which uses the user's existing CLI authentication.
+"""
+
+import logging
+import sys
+
+from backend.apps.settings.settings import load_settings
+
+logger = logging.getLogger(__name__)
+
+MODEL_MAP = {
+    "sonnet": "claude-sonnet-4-20250514",
+    "opus": "claude-opus-4-20250514",
+    "opus-1m": "claude-opus-4-6[1m]",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
+
+def _resolve_model(short_name: str) -> str:
+    return MODEL_MAP.get(short_name, short_name)
+
+
+async def llm_call(
+    system: str,
+    user_message: str,
+    model: str = "haiku",
+    max_tokens: int = 100,
+) -> str:
+    """Make a one-shot LLM call, routing through API or CLI as appropriate.
+
+    Returns the text response from the model.
+    Raises on failure (callers should wrap in try/except if they have fallbacks).
+    """
+    settings = load_settings()
+    if settings.anthropic_api_key:
+        return await _api_call(settings.anthropic_api_key, system, user_message, model, max_tokens)
+    return await _cli_call(system, user_message, model, max_tokens)
+
+
+async def _api_call(
+    api_key: str,
+    system: str,
+    user_message: str,
+    model: str,
+    max_tokens: int,
+) -> str:
+    import anthropic
+
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+    resp = await client.messages.create(
+        model=_resolve_model(model),
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": user_message}],
+    )
+    return resp.content[0].text.strip()
+
+
+async def _cli_call(
+    system: str,
+    user_message: str,
+    model: str,
+    max_tokens: int,
+) -> str:
+    from claude_agent_sdk import query, ClaudeAgentOptions
+    from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=system,
+        max_turns=1,
+        permission_mode="plan",  # no tool use, just text generation
+        stderr=lambda line: None,  # suppress CLI startup noise
+    )
+
+    text_parts: list[str] = []
+    async for message in query(prompt=user_message, options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    text_parts.append(block.text)
+
+    result = "".join(text_parts).strip()
+    if not result:
+        raise ValueError("CLI returned empty response")
+    return result

--- a/backend/apps/settings/llm_router.py
+++ b/backend/apps/settings/llm_router.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 MODEL_MAP = {
     "sonnet": "claude-sonnet-4-20250514",
     "opus": "claude-opus-4-20250514",
-    "opus-1m": "claude-opus-4-6[1m]",
     "haiku": "claude-haiku-4-5-20251001",
 }
 

--- a/backend/apps/settings/models.py
+++ b/backend/apps/settings/models.py
@@ -24,4 +24,5 @@ class AppSettings(BaseModel):
     auto_select_mode_on_new_agent: bool = False
     expand_new_chats_in_dashboard: bool = False
     auto_reveal_sub_agents: bool = True
+    simple_tool_group_names: str = "cli-only"  # "off", "cli-only", "all"
     dev_mode: bool = False

--- a/backend/apps/settings/settings.py
+++ b/backend/apps/settings/settings.py
@@ -123,3 +123,64 @@ async def browse_directories(path: str = Query(default="")) -> BrowseResponse:
     parent = os.path.dirname(target) if target != "/" else None
 
     return BrowseResponse(current=target, parent=parent, directories=directories, files=files)
+
+
+@settings.router.get("/git-info")
+async def git_info(path: str = Query(default="")):
+    import subprocess
+
+    target = path.strip() if path.strip() else os.path.expanduser("~")
+    target = os.path.abspath(os.path.expanduser(target))
+
+    if not os.path.isdir(target):
+        raise HTTPException(status_code=400, detail="Not a directory")
+
+    def _run(args: list[str]) -> Optional[str]:
+        try:
+            r = subprocess.run(args, cwd=target, capture_output=True, text=True, timeout=5)
+            return r.stdout.strip() if r.returncode == 0 else None
+        except Exception:
+            return None
+
+    top = _run(["git", "rev-parse", "--show-toplevel"])
+    if not top:
+        return JSONResponse({"is_git": False})
+
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]) or "HEAD"
+    raw_branches = _run(["git", "branch", "--list", "--format=%(refname:short)"]) or ""
+    branches = [b for b in raw_branches.splitlines() if b]
+    remote = _run(["git", "remote", "get-url", "origin"])
+    repo_name = os.path.basename(top)
+
+    return JSONResponse({
+        "is_git": True,
+        "branch": branch,
+        "branches": branches,
+        "remote_url": remote,
+        "repo_name": repo_name,
+    })
+
+
+class GitCheckoutRequest(BaseModel):
+    path: str
+    branch: str
+
+
+@settings.router.post("/git-checkout")
+async def git_checkout(req: GitCheckoutRequest):
+    import subprocess
+
+    target = os.path.abspath(os.path.expanduser(req.path.strip()))
+    if not os.path.isdir(target):
+        raise HTTPException(status_code=400, detail="Not a directory")
+
+    try:
+        r = subprocess.run(
+            ["git", "checkout", req.branch],
+            cwd=target, capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode != 0:
+            return JSONResponse({"success": False, "error": r.stderr.strip()})
+        return JSONResponse({"success": True})
+    except Exception as e:
+        return JSONResponse({"success": False, "error": str(e)})

--- a/backend/apps/tools_lib/tools_lib.py
+++ b/backend/apps/tools_lib/tools_lib.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import re
+import sys
 import logging
 import shutil
 import time
@@ -235,7 +236,8 @@ def _sync_external_config(tool: ToolDefinition):
             config["ct0"] = ct0
             with open(_XBIRD_CONFIG_PATH, "w") as f:
                 json.dump(config, f, indent=2)
-            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
             logger.info("Synced xbird credentials to %s", _XBIRD_CONFIG_PATH)
     elif tool.name == "xbird" and not tool.credentials:
         if os.path.exists(_XBIRD_CONFIG_PATH):
@@ -290,6 +292,24 @@ def _sanitize_server_name(name: str) -> str:
 def _extra_bin_dirs() -> list[str]:
     """Well-known user-local bin directories that may not be on PATH in packaged apps."""
     home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
     dirs = [
         os.path.join(home, ".bun", "bin"),
         os.path.join(home, ".cargo", "bin"),

--- a/backend/config/paths.py
+++ b/backend/config/paths.py
@@ -34,6 +34,7 @@ OUTPUTS_DIR = os.path.join(DATA_ROOT, "outputs")
 OUTPUTS_WORKSPACE_DIR = os.path.join(DATA_ROOT, "outputs_workspace")
 SKILLS_WORKSPACE_DIR = os.path.join(DATA_ROOT, "skills_workspace")
 DASHBOARD_LAYOUT_DIR = os.path.join(DATA_ROOT, "dashboard_layout")
+SCHEDULES_DIR = os.path.join(DATA_ROOT, "schedules")
 BUILTIN_PERMISSIONS_PATH = os.path.join(DATA_ROOT, "builtin_permissions.json")
 
 BACKEND_DIR = _BACKEND_DIR

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,12 @@ import logging
 import os
 from uuid import uuid4
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+
 logger = logging.getLogger(__name__)
 
 from fastapi.responses import JSONResponse

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,11 +19,12 @@ from backend.apps.mcp_registry.mcp_registry import mcp_registry
 from backend.apps.skill_registry.skill_registry import skill_registry
 from backend.apps.outputs.outputs import outputs
 from backend.apps.dashboards.dashboards import dashboards
+from backend.apps.schedules.schedules import schedules
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import WebSocket, WebSocketDisconnect
 import json
 
-main_app = MainApp([health, agents, templates, skills, tools_lib, modes, settings, mcp_registry, skill_registry, outputs, dashboards])
+main_app = MainApp([health, agents, templates, skills, tools_lib, modes, settings, mcp_registry, skill_registry, outputs, dashboards, schedules])
 app = main_app.app
 
 app.add_middleware(
@@ -135,13 +136,11 @@ async def browser_agent_run(request: Request):
         return JSONResponse({"error": "tasks array is required"}, status_code=400)
 
     settings = load_settings()
-    if not settings.anthropic_api_key:
-        return JSONResponse({"error": "Anthropic API key not configured"}, status_code=400)
 
     results = await run_browser_agents(
         tasks=tasks,
         model=model,
-        api_key=settings.anthropic_api_key,
+        api_key=settings.anthropic_api_key or None,
         dashboard_id=dashboard_id or None,
         pre_selected_browser_ids=pre_selected_browser_ids,
         parent_session_id=parent_session_id or None,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ pytest-asyncio==0.25.2
 typeguard==4.4.2
 python-dotenv==1.1.1
 Pillow
+croniter

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -10,29 +10,71 @@ const backendDir = __dirname;
 const isWindows = process.platform === 'win32';
 
 // --- Locate Python ---
+function getPythonVersion(cmd, args = ['--version']) {
+  try {
+    const output = execFileSync(cmd, args, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Extract version number from "Python X.Y.Z"
+    const match = output.match(/Python (\d+)\.(\d+)/);
+    if (match) {
+      return { cmd, args: args.length > 1 ? args.slice(0, -1) : [], major: parseInt(match[1]), minor: parseInt(match[2]), output };
+    }
+  } catch {
+    // not found
+  }
+  return null;
+}
+
 function findPython() {
+  const found = [];
+
+  if (isWindows) {
+    // Windows py launcher — try specific compatible versions first
+    for (const ver of ['3.13', '3.12', '3.11']) {
+      const result = getPythonVersion('py', [`-${ver}`, '--version']);
+      if (result) {
+        found.push({ cmd: 'py', args: [`-${ver}`], ...result });
+      }
+    }
+  }
+
+  // Generic commands
   const candidates = isWindows
     ? ['python', 'python3']
     : ['python3', 'python'];
   for (const cmd of candidates) {
-    try {
-      const version = execFileSync(cmd, ['--version'], {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      }).trim();
-      console.log(`Found ${version} (${cmd})`);
-      return cmd;
-    } catch {
-      // not found, try next
+    const result = getPythonVersion(cmd);
+    if (result) {
+      found.push({ cmd, args: [], ...result });
     }
   }
+
+  // Prefer 3.11-3.13 (known compatible), then any 3.11+
+  const compatible = found.filter(p => p.major === 3 && p.minor >= 11 && p.minor <= 13);
+  const selected = compatible[0] || found.find(p => p.major === 3 && p.minor >= 11);
+
+  if (selected) {
+    const fullCmd = selected.args.length ? `${selected.cmd} ${selected.args.join(' ')}` : selected.cmd;
+    console.log(`Found ${selected.output} (${fullCmd})`);
+    return { cmd: selected.cmd, args: selected.args };
+  }
+
+  if (found.length > 0) {
+    const p = found[0];
+    console.warn(`Warning: Found Python ${p.major}.${p.minor} but 3.11-3.13 is recommended.`);
+    console.warn('Some dependencies may not have pre-built wheels for this version.');
+    return { cmd: p.cmd, args: p.args };
+  }
+
   console.error(
-    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+    'Error: Python not found. Install Python 3.11-3.13 and ensure it is on your PATH.'
   );
   process.exit(1);
 }
 
-const pythonCmd = findPython();
+const python = findPython();
 
 // --- Venv setup ---
 const venvDir = join(backendDir, '.venv');
@@ -51,6 +93,8 @@ const env = {
   ...process.env,
   PATH: venvBin + delimiter + (process.env.PATH || ''),
   VIRTUAL_ENV: venvDir,
+  // Force UTF-8 on Windows so open() without encoding= matches macOS/Linux behavior
+  ...(isWindows ? { PYTHONUTF8: '1' } : {}),
 };
 
 function run(cmd, args, options = {}) {
@@ -73,7 +117,7 @@ try {
   // --- Create virtual environment if needed ---
   if (!existsSync(venvDir)) {
     console.log('Creating virtual environment...');
-    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+    await run(python.cmd, [...python.args, '-m', 'venv', venvDir], { env: process.env });
   }
 
   // --- Install debugger module if not installed ---

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -143,6 +143,7 @@ try {
       '-m', 'uvicorn', 'backend.main:app',
       '--host', '0.0.0.0',
       '--port', '8324',
+      '--log-level', 'info',
       '--reload',
       // On Windows, uvicorn's default loop factory picks SelectorEventLoop when
       // --reload is active, which cannot spawn subprocesses (needed by claude_agent_sdk).

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -1,0 +1,111 @@
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/backend/run.mjs
+++ b/backend/run.mjs
@@ -144,6 +144,11 @@ try {
       '--host', '0.0.0.0',
       '--port', '8324',
       '--reload',
+      // On Windows, uvicorn's default loop factory picks SelectorEventLoop when
+      // --reload is active, which cannot spawn subprocesses (needed by claude_agent_sdk).
+      // '--loop none' tells uvicorn to skip its factory and use Python's default event
+      // loop (ProactorEventLoop on Windows), which supports subprocesses.
+      ...(isWindows ? ['--loop', 'none'] : []),
       '--reload-dir', backendDir,
       '--reload-exclude', '*.pyc',
     ],

--- a/backend/tests/test_1m_context_and_effort.py
+++ b/backend/tests/test_1m_context_and_effort.py
@@ -1,0 +1,174 @@
+"""Tests for Opus 1M context mode and effort parameter wiring."""
+
+import pytest
+from backend.apps.agents.models import AgentSession, AgentConfig
+
+
+class TestAgentSessionUse1mContext:
+    """Verify use_1m_context is a proper Pydantic field, not a monkey-patched attr."""
+
+    def test_use_1m_context_default_false(self):
+        session = AgentSession(name="test")
+        assert session.use_1m_context is False
+
+    def test_use_1m_context_can_be_set_true_at_init(self):
+        session = AgentSession(name="test", use_1m_context=True)
+        assert session.use_1m_context is True
+
+    def test_use_1m_context_can_be_set_after_init(self):
+        session = AgentSession(name="test")
+        session.use_1m_context = True
+        assert session.use_1m_context is True
+
+    def test_use_1m_context_survives_model_dump(self):
+        session = AgentSession(name="test", use_1m_context=True)
+        dumped = session.model_dump(mode="json")
+        assert dumped["use_1m_context"] is True
+
+    def test_use_1m_context_roundtrips_through_json(self):
+        session = AgentSession(name="test", use_1m_context=True, model="opus")
+        dumped = session.model_dump(mode="json")
+        restored = AgentSession(**dumped)
+        assert restored.use_1m_context is True
+        assert restored.model == "opus"
+
+    def test_underscore_attr_not_in_model_dump(self):
+        """Demonstrate the original bug: Pydantic v2 silently accepts underscore
+        attrs but does NOT include them in model_dump — so they vanish on
+        serialization/deserialization, which is why _use_1m_beta was lost."""
+        session = AgentSession(name="test")
+        session._some_private_flag = True  # silently accepted
+        dumped = session.model_dump(mode="json")
+        # The underscore attr is NOT serialized — this was the root bug
+        assert "_some_private_flag" not in dumped
+        # But our proper field IS serialized
+        assert "use_1m_context" in dumped
+
+
+class TestOpus1mModelResolution:
+    """Test the opus-1m → opus + use_1m_context resolution logic."""
+
+    def test_opus_1m_resolves_model_to_opus(self):
+        """When model is 'opus-1m', effective model should be 'opus'."""
+        config_model = "opus-1m"
+        effective_model = config_model
+        use_1m = False
+        if config_model == "opus-1m":
+            effective_model = "opus"
+            use_1m = True
+        assert effective_model == "opus"
+        assert use_1m is True
+
+    def test_regular_opus_no_1m(self):
+        config_model = "opus"
+        effective_model = config_model
+        use_1m = False
+        if config_model == "opus-1m":
+            effective_model = "opus"
+            use_1m = True
+        assert effective_model == "opus"
+        assert use_1m is False
+
+    def test_sonnet_no_1m(self):
+        config_model = "sonnet"
+        effective_model = config_model
+        use_1m = False
+        if config_model == "opus-1m":
+            effective_model = "opus"
+            use_1m = True
+        assert effective_model == "sonnet"
+        assert use_1m is False
+
+
+class TestEffortParameter:
+    """Test effort parameter handling."""
+
+    def test_effort_auto_means_none(self):
+        """'auto' effort should not be passed to SDK (means don't set it)."""
+        session = AgentSession(name="test", effort="auto")
+        options_kwargs = {}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        assert "effort" not in options_kwargs
+
+    def test_effort_high_is_passed(self):
+        session = AgentSession(name="test", effort="high")
+        options_kwargs = {}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        assert options_kwargs["effort"] == "high"
+
+    def test_effort_low_is_passed(self):
+        session = AgentSession(name="test", effort="low")
+        options_kwargs = {}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        assert options_kwargs["effort"] == "low"
+
+    def test_effort_none_not_passed(self):
+        session = AgentSession(name="test", effort=None)
+        options_kwargs = {}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        assert "effort" not in options_kwargs
+
+    def test_effort_max_is_passed(self):
+        session = AgentSession(name="test", effort="max")
+        options_kwargs = {}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        assert options_kwargs["effort"] == "max"
+
+
+class TestSdkOptionsConstruction:
+    """Test the full SDK options construction logic for 1M + effort."""
+
+    def _build_options(self, session: AgentSession, has_api_key: bool) -> dict:
+        """Replicate the options_kwargs construction from _run_agent_loop."""
+        options_kwargs = {"model": session.model}
+        if session.effort and session.effort != "auto":
+            options_kwargs["effort"] = session.effort
+        if session.use_1m_context:
+            if has_api_key:
+                options_kwargs["betas"] = ["context-1m-2025-08-07"]
+            else:
+                options_kwargs["model"] = "claude-opus-4-6[1m]"
+        return options_kwargs
+
+    def test_1m_with_api_key_uses_betas(self):
+        session = AgentSession(name="test", model="opus", use_1m_context=True)
+        opts = self._build_options(session, has_api_key=True)
+        assert opts["model"] == "opus"
+        assert opts["betas"] == ["context-1m-2025-08-07"]
+
+    def test_1m_without_api_key_uses_cli_model_string(self):
+        session = AgentSession(name="test", model="opus", use_1m_context=True)
+        opts = self._build_options(session, has_api_key=False)
+        assert opts["model"] == "claude-opus-4-6[1m]"
+        assert "betas" not in opts
+
+    def test_no_1m_regular_opus(self):
+        session = AgentSession(name="test", model="opus", use_1m_context=False)
+        opts = self._build_options(session, has_api_key=True)
+        assert opts["model"] == "opus"
+        assert "betas" not in opts
+
+    def test_1m_plus_effort(self):
+        session = AgentSession(name="test", model="opus", use_1m_context=True, effort="high")
+        opts = self._build_options(session, has_api_key=True)
+        assert opts["model"] == "opus"
+        assert opts["betas"] == ["context-1m-2025-08-07"]
+        assert opts["effort"] == "high"
+
+    def test_1m_plus_auto_effort(self):
+        session = AgentSession(name="test", model="opus", use_1m_context=True, effort="auto")
+        opts = self._build_options(session, has_api_key=True)
+        assert opts["betas"] == ["context-1m-2025-08-07"]
+        assert "effort" not in opts
+
+    def test_sonnet_with_effort(self):
+        session = AgentSession(name="test", model="sonnet", effort="medium")
+        opts = self._build_options(session, has_api_key=True)
+        assert opts["model"] == "sonnet"
+        assert opts["effort"] == "medium"
+        assert "betas" not in opts

--- a/docs/superpowers/plans/2026-04-09-scheduling-system.md
+++ b/docs/superpowers/plans/2026-04-09-scheduling-system.md
@@ -1,0 +1,1496 @@
+# Scheduling System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-process asyncio scheduler that lets users create cron, interval, and one-shot schedules to fire agent sessions or message existing ones.
+
+**Architecture:** Backend SubApp with JSON file storage + asyncio tick loop. Frontend Redux slice + MUI pages following existing patterns. `croniter` for cron parsing.
+
+**Tech Stack:** Python/FastAPI (backend), React/Redux/MUI (frontend), croniter (cron parsing)
+
+---
+
+## File Structure
+
+### Backend (Create)
+- `backend/apps/schedules/__init__.py` — empty init
+- `backend/apps/schedules/models.py` — Pydantic models (Schedule, ScheduleCreate, ScheduleUpdate)
+- `backend/apps/schedules/schedules.py` — SubApp with CRUD endpoints
+- `backend/apps/schedules/scheduler.py` — Background tick loop
+- `backend/apps/schedules/executor.py` — Fire logic
+
+### Backend (Modify)
+- `backend/config/paths.py` — add `SCHEDULES_DIR`
+- `backend/main.py` — register schedules SubApp
+- `backend/apps/dashboards/dashboards.py` — cascade-delete schedules on dashboard delete
+
+### Frontend (Create)
+- `frontend/src/shared/state/schedulesSlice.ts` — Redux slice
+- `frontend/src/app/pages/Schedules/Schedules.tsx` — Global schedules page
+- `frontend/src/app/pages/Schedules/ScheduleEditor.tsx` — Create/edit dialog
+
+### Frontend (Modify)
+- `frontend/src/shared/state/store.ts` — register schedulesReducer
+- `frontend/src/app/Main.tsx` — add `/schedules` route
+- `frontend/src/app/components/Layout/AppShell.tsx` — add sidebar nav item + badge
+- `frontend/src/shared/ws/WebSocketManager.ts` — handle schedule:* events
+
+---
+
+### Task 1: Install croniter and add SCHEDULES_DIR path
+
+**Files:**
+- Modify: `backend/config/paths.py`
+- Modify: `backend/requirements.txt` (or equivalent)
+
+- [ ] **Step 1: Add croniter dependency**
+
+```bash
+cd C:/Users/fireb/openswarm/backend
+pip install croniter
+```
+
+Check if there's a requirements.txt or pyproject.toml:
+```bash
+ls C:/Users/fireb/openswarm/backend/requirements.txt C:/Users/fireb/openswarm/backend/pyproject.toml C:/Users/fireb/openswarm/pyproject.toml 2>/dev/null
+```
+
+Add `croniter` to whichever dependency file exists.
+
+- [ ] **Step 2: Add SCHEDULES_DIR to paths.py**
+
+In `backend/config/paths.py`, add:
+```python
+SCHEDULES_DIR = os.path.join(DATA_DIR, "schedules")
+```
+
+Place it alongside the existing `*_DIR` definitions (like `DASHBOARDS_DIR`, `SESSIONS_DIR`, etc.).
+
+- [ ] **Step 3: Verify import works**
+
+```bash
+cd C:/Users/fireb/openswarm && python -c "from backend.config.paths import SCHEDULES_DIR; print(SCHEDULES_DIR)"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/config/paths.py
+git commit -m "feat(schedules): add SCHEDULES_DIR path and croniter dependency"
+```
+
+---
+
+### Task 2: Backend Pydantic models
+
+**Files:**
+- Create: `backend/apps/schedules/__init__.py`
+- Create: `backend/apps/schedules/models.py`
+
+- [ ] **Step 1: Create the schedules package**
+
+Create `backend/apps/schedules/__init__.py` as an empty file.
+
+- [ ] **Step 2: Create models.py**
+
+Create `backend/apps/schedules/models.py`:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+from uuid import uuid4
+
+
+class Schedule(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    name: str = "Untitled Schedule"
+    enabled: bool = True
+    dashboard_id: str
+
+    # Trigger
+    trigger_type: str  # "cron" | "interval" | "once"
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+
+    # Action
+    action_type: str  # "new_session" | "message_existing"
+    prompt: str
+    target_session_id: Optional[str] = None
+
+    # Agent config (new_session only)
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+    # State
+    last_run_at: Optional[datetime] = None
+    next_run_at: Optional[datetime] = None
+    run_count: int = 0
+    last_error: Optional[str] = None
+
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class ScheduleCreate(BaseModel):
+    name: str = "Untitled Schedule"
+    dashboard_id: str
+    trigger_type: str
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: str
+    prompt: str
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+
+class ScheduleUpdate(BaseModel):
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    dashboard_id: Optional[str] = None
+    trigger_type: Optional[str] = None
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: Optional[str] = None
+    prompt: Optional[str] = None
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+```
+
+- [ ] **Step 3: Verify models parse correctly**
+
+```bash
+cd C:/Users/fireb/openswarm && python -c "
+from backend.apps.schedules.models import Schedule, ScheduleCreate, ScheduleUpdate
+s = Schedule(dashboard_id='abc', trigger_type='cron', cron_expression='0 9 * * *', action_type='new_session', prompt='Hello')
+print(s.model_dump(mode='json'))
+"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/apps/schedules/__init__.py backend/apps/schedules/models.py
+git commit -m "feat(schedules): add Pydantic models for Schedule, ScheduleCreate, ScheduleUpdate"
+```
+
+---
+
+### Task 3: Backend executor
+
+**Files:**
+- Create: `backend/apps/schedules/executor.py`
+
+- [ ] **Step 1: Create executor.py**
+
+Create `backend/apps/schedules/executor.py`:
+
+```python
+import logging
+from backend.apps.schedules.models import Schedule
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_schedule(schedule: Schedule):
+    """Fire a schedule: create a new session or message an existing one."""
+    if schedule.action_type == "new_session":
+        await _create_new_session(schedule)
+    elif schedule.action_type == "message_existing":
+        await _message_existing(schedule)
+    else:
+        raise ValueError(f"Unknown action_type: {schedule.action_type}")
+
+
+async def _create_new_session(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+    from backend.apps.agents.models import AgentConfig
+
+    config_kwargs: dict = {
+        "dashboard_id": schedule.dashboard_id,
+    }
+
+    if schedule.template_id:
+        try:
+            from backend.apps.templates.templates import _load as load_template
+            template = load_template(schedule.template_id)
+            if template.mode:
+                config_kwargs["mode"] = template.mode
+        except Exception:
+            logger.warning(f"Template {schedule.template_id} not found, using defaults")
+
+    if schedule.model:
+        config_kwargs["model"] = schedule.model
+    if schedule.mode:
+        config_kwargs["mode"] = schedule.mode
+    if schedule.system_prompt:
+        config_kwargs["system_prompt"] = schedule.system_prompt
+
+    config = AgentConfig(**config_kwargs)
+    session = await agent_manager.launch_agent(config)
+
+    await agent_manager.send_message(
+        session.id,
+        schedule.prompt,
+        mode=config_kwargs.get("mode"),
+        model=config_kwargs.get("model"),
+    )
+
+    logger.info(f"Schedule {schedule.id} created session {session.id}")
+
+
+async def _message_existing(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+
+    if not schedule.target_session_id:
+        raise ValueError("target_session_id required for message_existing action")
+
+    if schedule.target_session_id not in agent_manager.sessions:
+        raise ValueError(f"Session {schedule.target_session_id} not found or not active")
+
+    await agent_manager.send_message(
+        schedule.target_session_id,
+        schedule.prompt,
+    )
+
+    logger.info(f"Schedule {schedule.id} sent message to session {schedule.target_session_id}")
+```
+
+- [ ] **Step 2: Verify syntax**
+
+```bash
+cd C:/Users/fireb/openswarm && python -c "import py_compile; py_compile.compile('backend/apps/schedules/executor.py', doraise=True); print('OK')"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/apps/schedules/executor.py
+git commit -m "feat(schedules): add executor for firing new sessions and messaging existing ones"
+```
+
+---
+
+### Task 4: Backend scheduler tick loop
+
+**Files:**
+- Create: `backend/apps/schedules/scheduler.py`
+
+- [ ] **Step 1: Create scheduler.py**
+
+Create `backend/apps/schedules/scheduler.py`:
+
+```python
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+_scheduler_task: asyncio.Task | None = None
+TICK_INTERVAL = 30
+
+
+async def _tick():
+    """One evaluation cycle: check all enabled schedules, fire due ones."""
+    from backend.apps.schedules.schedules import _load_all, _save
+    from backend.apps.schedules.executor import execute_schedule
+
+    now = datetime.now()
+    for schedule in _load_all():
+        if not schedule.enabled:
+            continue
+        if schedule.next_run_at is None:
+            continue
+        if schedule.next_run_at > now:
+            continue
+
+        try:
+            await execute_schedule(schedule)
+            schedule.last_run_at = now
+            schedule.run_count += 1
+            schedule.last_error = None
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_complete", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+            })
+        except Exception as e:
+            logger.exception(f"Schedule {schedule.id} ({schedule.name}) failed")
+            schedule.last_error = str(e)
+
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global("schedule:run_failed", {
+                "schedule_id": schedule.id,
+                "name": schedule.name,
+                "error": str(e),
+            })
+
+        schedule.next_run_at = _compute_next_run(schedule, now)
+
+        if schedule.trigger_type == "once":
+            schedule.enabled = False
+
+        schedule.updated_at = now
+        _save(schedule)
+
+
+def _compute_next_run(schedule, after: datetime) -> datetime | None:
+    """Compute the next run time based on trigger type."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, after).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return after + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once":
+        return None
+    return None
+
+
+def compute_initial_next_run(schedule) -> datetime | None:
+    """Compute the first next_run_at when a schedule is created."""
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, datetime.now()).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        return datetime.now() + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once" and schedule.run_at:
+        return schedule.run_at
+    return None
+
+
+async def _run_loop():
+    """Main scheduler loop — ticks every TICK_INTERVAL seconds."""
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.exception("Scheduler tick failed")
+        await asyncio.sleep(TICK_INTERVAL)
+
+
+def start_scheduler():
+    """Start the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task is None or _scheduler_task.done():
+        loop = asyncio.get_event_loop()
+        _scheduler_task = loop.create_task(_run_loop())
+        logger.info("Scheduler started (tick interval: %ds)", TICK_INTERVAL)
+
+
+def stop_scheduler():
+    """Stop the background scheduler task."""
+    global _scheduler_task
+    if _scheduler_task and not _scheduler_task.done():
+        _scheduler_task.cancel()
+        _scheduler_task = None
+        logger.info("Scheduler stopped")
+```
+
+- [ ] **Step 2: Verify syntax**
+
+```bash
+cd C:/Users/fireb/openswarm && python -c "import py_compile; py_compile.compile('backend/apps/schedules/scheduler.py', doraise=True); print('OK')"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/apps/schedules/scheduler.py
+git commit -m "feat(schedules): add asyncio tick loop scheduler with croniter support"
+```
+
+---
+
+### Task 5: Backend SubApp with CRUD endpoints
+
+**Files:**
+- Create: `backend/apps/schedules/schedules.py`
+- Modify: `backend/main.py:1,26` — add import and register SubApp
+- Modify: `backend/apps/dashboards/dashboards.py:209-238` — cascade delete schedules
+
+- [ ] **Step 1: Create schedules.py**
+
+Create `backend/apps/schedules/schedules.py`:
+
+```python
+import json
+import os
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime
+
+from backend.config.Apps import SubApp
+from backend.apps.schedules.models import Schedule, ScheduleCreate, ScheduleUpdate
+from backend.apps.schedules.scheduler import start_scheduler, stop_scheduler, compute_initial_next_run
+from backend.config.paths import SCHEDULES_DIR as DATA_DIR
+from fastapi import HTTPException, Query
+
+logger = logging.getLogger(__name__)
+
+
+def _load_all() -> list[Schedule]:
+    result = []
+    if not os.path.exists(DATA_DIR):
+        return result
+    for fname in os.listdir(DATA_DIR):
+        if fname.endswith(".json"):
+            with open(os.path.join(DATA_DIR, fname)) as f:
+                result.append(Schedule(**json.load(f)))
+    return result
+
+
+def _save(schedule: Schedule):
+    with open(os.path.join(DATA_DIR, f"{schedule.id}.json"), "w") as f:
+        json.dump(schedule.model_dump(mode="json"), f, indent=2)
+
+
+def _load(schedule_id: str) -> Schedule:
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if not os.path.exists(path):
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    with open(path) as f:
+        return Schedule(**json.load(f))
+
+
+def _delete(schedule_id: str):
+    path = os.path.join(DATA_DIR, f"{schedule_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def delete_schedules_for_dashboard(dashboard_id: str):
+    """Remove all schedules tied to a dashboard. Called during dashboard deletion."""
+    for schedule in _load_all():
+        if schedule.dashboard_id == dashboard_id:
+            _delete(schedule.id)
+            logger.info(f"Deleted schedule {schedule.id} (dashboard {dashboard_id} deleted)")
+
+
+@asynccontextmanager
+async def schedules_lifespan():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    start_scheduler()
+    try:
+        yield
+    finally:
+        stop_scheduler()
+
+
+schedules = SubApp("schedules", schedules_lifespan)
+
+
+@schedules.router.get("/list")
+async def list_schedules(dashboard_id: str | None = Query(None)):
+    all_schedules = _load_all()
+    if dashboard_id:
+        all_schedules = [s for s in all_schedules if s.dashboard_id == dashboard_id]
+    all_schedules.sort(key=lambda s: s.updated_at or s.created_at, reverse=True)
+    return {"schedules": [s.model_dump(mode="json") for s in all_schedules]}
+
+
+@schedules.router.post("/create")
+async def create_schedule(body: ScheduleCreate):
+    schedule = Schedule(
+        name=body.name,
+        dashboard_id=body.dashboard_id,
+        trigger_type=body.trigger_type,
+        cron_expression=body.cron_expression,
+        interval_seconds=body.interval_seconds,
+        run_at=body.run_at,
+        action_type=body.action_type,
+        prompt=body.prompt,
+        target_session_id=body.target_session_id,
+        template_id=body.template_id,
+        model=body.model,
+        mode=body.mode,
+        system_prompt=body.system_prompt,
+    )
+    schedule.next_run_at = compute_initial_next_run(schedule)
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.get("/{schedule_id}")
+async def get_schedule(schedule_id: str):
+    return _load(schedule_id).model_dump(mode="json")
+
+
+@schedules.router.put("/{schedule_id}")
+async def update_schedule(schedule_id: str, body: ScheduleUpdate):
+    schedule = _load(schedule_id)
+    trigger_changed = False
+
+    for field_name in body.model_fields_set:
+        value = getattr(body, field_name)
+        setattr(schedule, field_name, value)
+        if field_name in ("trigger_type", "cron_expression", "interval_seconds", "run_at"):
+            trigger_changed = True
+
+    if trigger_changed:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+
+
+@schedules.router.delete("/{schedule_id}")
+async def delete_schedule_endpoint(schedule_id: str):
+    _load(schedule_id)  # 404 if not found
+    _delete(schedule_id)
+    return {"ok": True}
+
+
+@schedules.router.post("/{schedule_id}/toggle")
+async def toggle_schedule(schedule_id: str):
+    schedule = _load(schedule_id)
+    schedule.enabled = not schedule.enabled
+
+    if schedule.enabled and schedule.next_run_at is None:
+        schedule.next_run_at = compute_initial_next_run(schedule)
+
+    schedule.updated_at = datetime.now()
+    _save(schedule)
+    return schedule.model_dump(mode="json")
+```
+
+- [ ] **Step 2: Register in main.py**
+
+In `backend/main.py`, add the import alongside other SubApp imports (around line 18):
+
+```python
+from backend.apps.schedules.schedules import schedules
+```
+
+Add `schedules` to the `MainApp` constructor list (line 26):
+
+```python
+main_app = MainApp([health, agents, templates, skills, tools_lib, modes, settings, mcp_registry, skill_registry, outputs, dashboards, schedules])
+```
+
+- [ ] **Step 3: Add cascade delete in dashboards.py**
+
+In `backend/apps/dashboards/dashboards.py`, in the `delete_dashboard` function (around line 210), add schedule cleanup after the `_load(dashboard_id)` call:
+
+```python
+@dashboards.router.delete("/{dashboard_id}")
+async def delete_dashboard(dashboard_id: str):
+    _load(dashboard_id)
+
+    # Delete schedules tied to this dashboard
+    from backend.apps.schedules.schedules import delete_schedules_for_dashboard
+    delete_schedules_for_dashboard(dashboard_id)
+
+    if os.path.exists(SESSIONS_DIR):
+        # ... rest of existing code unchanged
+```
+
+- [ ] **Step 4: Verify all backend files compile**
+
+```bash
+cd C:/Users/fireb/openswarm && python -c "
+import py_compile
+for f in ['backend/apps/schedules/schedules.py', 'backend/main.py', 'backend/apps/dashboards/dashboards.py']:
+    py_compile.compile(f, doraise=True)
+    print(f'{f}: OK')
+"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/apps/schedules/schedules.py backend/main.py backend/apps/dashboards/dashboards.py
+git commit -m "feat(schedules): add SubApp with CRUD endpoints, register in main, cascade delete on dashboard removal"
+```
+
+---
+
+### Task 6: Frontend Redux slice
+
+**Files:**
+- Create: `frontend/src/shared/state/schedulesSlice.ts`
+- Modify: `frontend/src/shared/state/store.ts` — register reducer
+
+- [ ] **Step 1: Create schedulesSlice.ts**
+
+Create `frontend/src/shared/state/schedulesSlice.ts`:
+
+```typescript
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { API_BASE } from '@/shared/config';
+
+const SCHEDULES_API = `${API_BASE}/schedules`;
+
+export interface Schedule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  dashboard_id: string;
+  trigger_type: 'cron' | 'interval' | 'once';
+  cron_expression: string | null;
+  interval_seconds: number | null;
+  run_at: string | null;
+  action_type: 'new_session' | 'message_existing';
+  prompt: string;
+  target_session_id: string | null;
+  template_id: string | null;
+  model: string | null;
+  mode: string | null;
+  system_prompt: string | null;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  run_count: number;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SchedulesState {
+  items: Record<string, Schedule>;
+  loading: boolean;
+  unreadCount: number;
+}
+
+const initialState: SchedulesState = {
+  items: {},
+  loading: false,
+  unreadCount: 0,
+};
+
+export const fetchSchedules = createAsyncThunk(
+  'schedules/fetchAll',
+  async (dashboardId?: string) => {
+    const url = dashboardId
+      ? `${SCHEDULES_API}/list?dashboard_id=${dashboardId}`
+      : `${SCHEDULES_API}/list`;
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.schedules as Schedule[];
+  },
+);
+
+export const createSchedule = createAsyncThunk(
+  'schedules/create',
+  async (body: Omit<Schedule, 'id' | 'last_run_at' | 'next_run_at' | 'run_count' | 'last_error' | 'created_at' | 'updated_at' | 'enabled'> & { name?: string }) => {
+    const res = await fetch(`${SCHEDULES_API}/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const updateSchedule = createAsyncThunk(
+  'schedules/update',
+  async ({ id, ...body }: { id: string } & Partial<Schedule>) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const deleteSchedule = createAsyncThunk(
+  'schedules/delete',
+  async (id: string) => {
+    await fetch(`${SCHEDULES_API}/${id}`, { method: 'DELETE' });
+    return id;
+  },
+);
+
+export const toggleSchedule = createAsyncThunk(
+  'schedules/toggle',
+  async (id: string) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}/toggle`, { method: 'POST' });
+    return (await res.json()) as Schedule;
+  },
+);
+
+const schedulesSlice = createSlice({
+  name: 'schedules',
+  initialState,
+  reducers: {
+    incrementUnread(state) {
+      state.unreadCount += 1;
+    },
+    clearUnread(state) {
+      state.unreadCount = 0;
+    },
+    scheduleUpdatedFromWs(state, action: PayloadAction<{ schedule_id: string }>) {
+      // Mark that we need to refetch — the schedule's state changed
+      // We just increment unread as a signal
+      state.unreadCount += 1;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSchedules.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchSchedules.fulfilled, (state, action) => {
+        state.loading = false;
+        const items: Record<string, Schedule> = {};
+        for (const s of action.payload) {
+          items[s.id] = s;
+        }
+        state.items = items;
+      })
+      .addCase(fetchSchedules.rejected, (state) => {
+        state.loading = false;
+      })
+      .addCase(createSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(updateSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(deleteSchedule.fulfilled, (state, action) => {
+        delete state.items[action.payload];
+      })
+      .addCase(toggleSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      });
+  },
+});
+
+export const { incrementUnread, clearUnread, scheduleUpdatedFromWs } = schedulesSlice.actions;
+export default schedulesSlice.reducer;
+```
+
+- [ ] **Step 2: Register in store.ts**
+
+In `frontend/src/shared/state/store.ts`, add:
+
+Import (after line 13):
+```typescript
+import schedulesReducer from './schedulesSlice';
+```
+
+Add to reducer object (after line 14, alongside `update: updateReducer`):
+```typescript
+schedules: schedulesReducer,
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd C:/Users/fireb/openswarm/frontend && npx tsc --noEmit --pretty 2>&1 | head -20
+```
+
+If tsc OOMs (known issue for this project), use:
+```bash
+cd C:/Users/fireb/openswarm/frontend && npx vite build 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/shared/state/schedulesSlice.ts frontend/src/shared/state/store.ts
+git commit -m "feat(schedules): add Redux slice with CRUD thunks and unread tracking"
+```
+
+---
+
+### Task 7: Frontend WebSocket event handling
+
+**Files:**
+- Modify: `frontend/src/shared/ws/WebSocketManager.ts:113-277` — add schedule event cases
+
+- [ ] **Step 1: Add schedule event imports**
+
+In `frontend/src/shared/ws/WebSocketManager.ts`, add to the imports at the top (after line 18):
+
+```typescript
+import { incrementUnread } from '../state/schedulesSlice';
+```
+
+- [ ] **Step 2: Add schedule event cases to handleMessage switch**
+
+In the `handleMessage` method, add these cases before the closing of the switch block (before line 270, after the `dashboard:browser_card_added` case):
+
+```typescript
+      case 'schedule:run_complete':
+        store.dispatch(incrementUnread());
+        break;
+
+      case 'schedule:run_failed':
+        store.dispatch(incrementUnread());
+        break;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/shared/ws/WebSocketManager.ts
+git commit -m "feat(schedules): handle schedule:run_complete and schedule:run_failed WebSocket events"
+```
+
+---
+
+### Task 8: Frontend Schedules page
+
+**Files:**
+- Create: `frontend/src/app/pages/Schedules/Schedules.tsx`
+
+- [ ] **Step 1: Create the Schedules directory and page**
+
+Create `frontend/src/app/pages/Schedules/Schedules.tsx`:
+
+```tsx
+import React, { useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import {
+  fetchSchedules,
+  deleteSchedule,
+  toggleSchedule,
+  clearUnread,
+  Schedule,
+} from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import ScheduleEditor from './ScheduleEditor';
+
+function formatTrigger(s: Schedule): string {
+  if (s.trigger_type === 'cron' && s.cron_expression) return `Cron: ${s.cron_expression}`;
+  if (s.trigger_type === 'interval' && s.interval_seconds) {
+    if (s.interval_seconds >= 3600) return `Every ${Math.round(s.interval_seconds / 3600)}h`;
+    if (s.interval_seconds >= 60) return `Every ${Math.round(s.interval_seconds / 60)}m`;
+    return `Every ${s.interval_seconds}s`;
+  }
+  if (s.trigger_type === 'once' && s.run_at) return `Once: ${new Date(s.run_at).toLocaleString()}`;
+  return s.trigger_type;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+const Schedules: React.FC = () => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const items = useAppSelector((s) => s.schedules.items);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const loading = useAppSelector((s) => s.schedules.loading);
+  const [editorOpen, setEditorOpen] = React.useState(false);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
+
+  const scheduleList = Object.values(items).sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+  );
+
+  useEffect(() => {
+    dispatch(fetchSchedules());
+    dispatch(clearUnread());
+  }, [dispatch]);
+
+  const handleEdit = (id: string) => {
+    setEditingId(id);
+    setEditorOpen(true);
+  };
+
+  const handleCreate = () => {
+    setEditingId(null);
+    setEditorOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await dispatch(deleteSchedule(id)).unwrap();
+    } catch (e: any) {
+      setDeleteError(e.message || 'Failed to delete schedule');
+    }
+  };
+
+  const handleToggle = (id: string) => {
+    dispatch(toggleSchedule(id));
+  };
+
+  return (
+    <Box sx={{ width: '100%', height: '100%', bgcolor: c.bg.page, color: c.text.primary, p: 3, overflow: 'auto' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>Schedules</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreate} sx={{ bgcolor: c.accent.primary }}>
+          New Schedule
+        </Button>
+      </Box>
+
+      {scheduleList.length === 0 && !loading ? (
+        <Typography sx={{ color: c.text.muted }}>No schedules yet. Create one to get started.</Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Trigger</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Dashboard</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Next Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Last Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Runs</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }} align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {scheduleList.map((s) => (
+                <TableRow key={s.id} hover>
+                  <TableCell sx={{ color: c.text.primary }}>{s.name}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatTrigger(s)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>
+                    {dashboards[s.dashboard_id]?.name || s.dashboard_id.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>
+                    {s.last_error ? (
+                      <Tooltip title={s.last_error}>
+                        <Chip label="Error" size="small" sx={{ bgcolor: c.status.errorBg, color: c.status.error, fontWeight: 600 }} />
+                      </Tooltip>
+                    ) : s.enabled ? (
+                      <Chip label="Active" size="small" sx={{ bgcolor: c.status.successBg, color: c.status.success, fontWeight: 600 }} />
+                    ) : (
+                      <Chip label="Paused" size="small" sx={{ bgcolor: c.status.warningBg, color: c.status.warning, fontWeight: 600 }} />
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.next_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.last_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>{s.run_count}</TableCell>
+                  <TableCell align="right">
+                    <Tooltip title={s.enabled ? 'Pause' : 'Resume'}>
+                      <IconButton size="small" onClick={() => handleToggle(s.id)} sx={{ color: c.text.muted }}>
+                        {s.enabled ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => handleEdit(s.id)} sx={{ color: c.text.muted }}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" onClick={() => handleDelete(s.id)} sx={{ color: c.text.muted }}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <ScheduleEditor
+        open={editorOpen}
+        scheduleId={editingId}
+        onClose={() => { setEditorOpen(false); setEditingId(null); }}
+      />
+
+      <Snackbar open={!!deleteError} autoHideDuration={4000} onClose={() => setDeleteError(null)}>
+        <Alert severity="error" onClose={() => setDeleteError(null)}>{deleteError}</Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default Schedules;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/app/pages/Schedules/Schedules.tsx
+git commit -m "feat(schedules): add global Schedules page with table view and status chips"
+```
+
+---
+
+### Task 9: Frontend Schedule Editor dialog
+
+**Files:**
+- Create: `frontend/src/app/pages/Schedules/ScheduleEditor.tsx`
+
+- [ ] **Step 1: Create ScheduleEditor.tsx**
+
+Create `frontend/src/app/pages/Schedules/ScheduleEditor.tsx`:
+
+```tsx
+import React, { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import { createSchedule, updateSchedule, fetchSchedules } from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+
+interface Props {
+  open: boolean;
+  scheduleId: string | null;
+  onClose: () => void;
+}
+
+const TRIGGER_TYPES = [
+  { value: 'cron', label: 'Cron Expression' },
+  { value: 'interval', label: 'Interval' },
+  { value: 'once', label: 'One-shot' },
+];
+
+const ACTION_TYPES = [
+  { value: 'new_session', label: 'Create New Session' },
+  { value: 'message_existing', label: 'Message Existing Session' },
+];
+
+const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const existing = useAppSelector((s) => scheduleId ? s.schedules.items[scheduleId] : null);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const templates = useAppSelector((s) => s.templates.items);
+  const dashboardList = Object.values(dashboards);
+  const templateList = Object.values(templates);
+
+  const [name, setName] = useState('');
+  const [dashboardId, setDashboardId] = useState('');
+  const [triggerType, setTriggerType] = useState('cron');
+  const [cronExpression, setCronExpression] = useState('');
+  const [intervalSeconds, setIntervalSeconds] = useState(3600);
+  const [runAt, setRunAt] = useState('');
+  const [actionType, setActionType] = useState('new_session');
+  const [prompt, setPrompt] = useState('');
+  const [targetSessionId, setTargetSessionId] = useState('');
+  const [templateId, setTemplateId] = useState('');
+  const [model, setModel] = useState('sonnet');
+  const [mode, setMode] = useState('agent');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [configSource, setConfigSource] = useState<'template' | 'inline'>('inline');
+
+  useEffect(() => {
+    if (existing) {
+      setName(existing.name);
+      setDashboardId(existing.dashboard_id);
+      setTriggerType(existing.trigger_type);
+      setCronExpression(existing.cron_expression || '');
+      setIntervalSeconds(existing.interval_seconds || 3600);
+      setRunAt(existing.run_at || '');
+      setActionType(existing.action_type);
+      setPrompt(existing.prompt);
+      setTargetSessionId(existing.target_session_id || '');
+      setTemplateId(existing.template_id || '');
+      setModel(existing.model || 'sonnet');
+      setMode(existing.mode || 'agent');
+      setSystemPrompt(existing.system_prompt || '');
+      setConfigSource(existing.template_id ? 'template' : 'inline');
+    } else {
+      setName('');
+      setDashboardId(dashboardList[0]?.id || '');
+      setTriggerType('cron');
+      setCronExpression('');
+      setIntervalSeconds(3600);
+      setRunAt('');
+      setActionType('new_session');
+      setPrompt('');
+      setTargetSessionId('');
+      setTemplateId('');
+      setModel('sonnet');
+      setMode('agent');
+      setSystemPrompt('');
+      setConfigSource('inline');
+    }
+  }, [existing, open]);
+
+  const inputSx = {
+    '& .MuiOutlinedInput-root': {
+      color: c.text.primary,
+      '& fieldset': { borderColor: c.border.strong },
+      '&:hover fieldset': { borderColor: c.text.tertiary },
+      '&.Mui-focused fieldset': { borderColor: c.accent.primary },
+    },
+    '& .MuiInputLabel-root': { color: c.text.tertiary },
+    '& .MuiInputLabel-root.Mui-focused': { color: c.accent.primary },
+  };
+
+  const handleSave = async () => {
+    const body: any = {
+      name: name || 'Untitled Schedule',
+      dashboard_id: dashboardId,
+      trigger_type: triggerType,
+      action_type: actionType,
+      prompt,
+    };
+
+    if (triggerType === 'cron') body.cron_expression = cronExpression;
+    if (triggerType === 'interval') body.interval_seconds = intervalSeconds;
+    if (triggerType === 'once') body.run_at = runAt;
+
+    if (actionType === 'message_existing') {
+      body.target_session_id = targetSessionId;
+    } else if (configSource === 'template') {
+      body.template_id = templateId;
+    } else {
+      body.model = model;
+      body.mode = mode;
+      if (systemPrompt) body.system_prompt = systemPrompt;
+    }
+
+    if (scheduleId) {
+      await dispatch(updateSchedule({ id: scheduleId, ...body }));
+    } else {
+      await dispatch(createSchedule(body));
+    }
+
+    dispatch(fetchSchedules());
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { bgcolor: c.bg.surface, borderRadius: 4, border: `1px solid ${c.border.subtle}` } }}
+    >
+      <DialogTitle sx={{ color: c.text.primary, fontWeight: 700 }}>
+        {scheduleId ? 'Edit Schedule' : 'New Schedule'}
+      </DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} fullWidth size="small" sx={inputSx} />
+
+        <TextField
+          select label="Dashboard" value={dashboardId}
+          onChange={(e) => setDashboardId(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {dashboardList.map((d) => <MenuItem key={d.id} value={d.id}>{d.name}</MenuItem>)}
+        </TextField>
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Trigger</Typography>
+
+        <TextField
+          select label="Type" value={triggerType}
+          onChange={(e) => setTriggerType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {TRIGGER_TYPES.map((t) => <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>)}
+        </TextField>
+
+        {triggerType === 'cron' && (
+          <TextField
+            label="Cron Expression" value={cronExpression}
+            onChange={(e) => setCronExpression(e.target.value)} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 0 9 * * * (every day at 9am)"
+          />
+        )}
+        {triggerType === 'interval' && (
+          <TextField
+            label="Interval (seconds)" type="number" value={intervalSeconds}
+            onChange={(e) => setIntervalSeconds(Number(e.target.value))} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 3600 = every hour"
+          />
+        )}
+        {triggerType === 'once' && (
+          <TextField
+            label="Run At" type="datetime-local" value={runAt}
+            onChange={(e) => setRunAt(e.target.value)} fullWidth size="small" sx={inputSx}
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        )}
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Action</Typography>
+
+        <TextField
+          select label="Action Type" value={actionType}
+          onChange={(e) => setActionType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {ACTION_TYPES.map((a) => <MenuItem key={a.value} value={a.value}>{a.label}</MenuItem>)}
+        </TextField>
+
+        <TextField
+          label="Prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)}
+          fullWidth size="small" multiline minRows={3} sx={inputSx}
+        />
+
+        {actionType === 'message_existing' && (
+          <TextField
+            label="Target Session ID" value={targetSessionId}
+            onChange={(e) => setTargetSessionId(e.target.value)} fullWidth size="small" sx={inputSx}
+          />
+        )}
+
+        {actionType === 'new_session' && (
+          <>
+            <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Agent Config</Typography>
+
+            <TextField
+              select label="Config Source" value={configSource}
+              onChange={(e) => setConfigSource(e.target.value as 'template' | 'inline')}
+              fullWidth size="small" sx={inputSx}
+              SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+            >
+              <MenuItem value="inline">Configure Inline</MenuItem>
+              <MenuItem value="template">Use Template</MenuItem>
+            </TextField>
+
+            {configSource === 'template' ? (
+              <TextField
+                select label="Template" value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)} fullWidth size="small" sx={inputSx}
+                SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+              >
+                {templateList.map((t) => <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>)}
+              </TextField>
+            ) : (
+              <>
+                <TextField
+                  select label="Model" value={model}
+                  onChange={(e) => setModel(e.target.value)} fullWidth size="small" sx={inputSx}
+                  SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+                >
+                  <MenuItem value="sonnet">Sonnet</MenuItem>
+                  <MenuItem value="haiku">Haiku</MenuItem>
+                  <MenuItem value="opus">Opus</MenuItem>
+                </TextField>
+
+                <TextField
+                  label="Mode" value={mode}
+                  onChange={(e) => setMode(e.target.value)} fullWidth size="small" sx={inputSx}
+                />
+
+                <TextField
+                  label="System Prompt (optional)" value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  fullWidth size="small" multiline minRows={2} sx={inputSx}
+                />
+              </>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ color: c.text.muted }}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave} disabled={!prompt || !dashboardId} sx={{ bgcolor: c.accent.primary }}>
+          {scheduleId ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ScheduleEditor;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/app/pages/Schedules/ScheduleEditor.tsx
+git commit -m "feat(schedules): add ScheduleEditor dialog with trigger/action/config forms"
+```
+
+---
+
+### Task 10: Frontend routing, sidebar, and notification toast
+
+**Files:**
+- Modify: `frontend/src/app/Main.tsx:220-231` — add route
+- Modify: `frontend/src/app/components/Layout/AppShell.tsx:49-54` — add sidebar item with badge
+
+- [ ] **Step 1: Add route in Main.tsx**
+
+In `frontend/src/app/Main.tsx`, add the import (after line 24):
+
+```typescript
+import Schedules from './pages/Schedules/Schedules';
+```
+
+Add the route inside the `<Route element={<AppShell />}>` block (after the `/apps/:id` route, around line 230):
+
+```tsx
+<Route path="/schedules" element={<Schedules />} />
+```
+
+- [ ] **Step 2: Add sidebar nav item in AppShell.tsx**
+
+In `frontend/src/app/components/Layout/AppShell.tsx`, add the import (alongside other icon imports):
+
+```typescript
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import Badge from '@mui/material/Badge';
+```
+
+Add schedule to the `CUSTOMIZATION_ITEMS` array (line 49-54):
+
+```typescript
+const CUSTOMIZATION_ITEMS = [
+  { label: 'Prompts', path: '/templates', icon: <DescriptionIcon /> },
+  { label: 'Skills', path: '/skills', icon: <PsychologyIcon /> },
+  { label: 'Actions', path: '/actions', icon: <BuildIcon /> },
+  { label: 'Modes', path: '/modes', icon: <TuneIcon /> },
+  { label: 'Schedules', path: '/schedules', icon: <ScheduleIcon /> },
+];
+```
+
+The badge for unread count needs to be wired where sidebar items are rendered. Find the section where `CUSTOMIZATION_ITEMS` are mapped and wrap the icon for Schedules in a `Badge` component. Look for something like:
+
+```tsx
+{CUSTOMIZATION_ITEMS.map((item) => (
+  <ListItemButton key={item.path} component={NavLink} to={item.path} ...>
+    <ListItemIcon>
+      {item.label === 'Schedules' ? (
+        <Badge badgeContent={unreadCount} color="error" max={99}>
+          {item.icon}
+        </Badge>
+      ) : item.icon}
+    </ListItemIcon>
+    <ListItemText primary={item.label} />
+  </ListItemButton>
+))}
+```
+
+Add the selector at the top of the AppShell component:
+```typescript
+const scheduleUnread = useAppSelector((s) => s.schedules.unreadCount);
+```
+
+- [ ] **Step 3: Add failure toast in AppShell.tsx**
+
+Add state and a Snackbar for schedule failures. In the AppShell component:
+
+```typescript
+const [scheduleError, setScheduleError] = useState<string | null>(null);
+
+useEffect(() => {
+  const unsub = dashboardWs.on('schedule:run_failed', (data: any) => {
+    setScheduleError(`Schedule "${data.name}" failed: ${data.error}`);
+  });
+  return unsub;
+}, []);
+```
+
+Add the Snackbar JSX (alongside existing Snackbar elements):
+
+```tsx
+<Snackbar
+  open={!!scheduleError}
+  autoHideDuration={6000}
+  onClose={() => setScheduleError(null)}
+  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+>
+  <Alert severity="error" onClose={() => setScheduleError(null)}>{scheduleError}</Alert>
+</Snackbar>
+```
+
+Import `dashboardWs` if not already imported:
+```typescript
+import { dashboardWs } from '@/shared/ws/WebSocketManager';
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+cd C:/Users/fireb/openswarm/frontend && npx vite build 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/Main.tsx frontend/src/app/components/Layout/AppShell.tsx
+git commit -m "feat(schedules): add /schedules route, sidebar nav with badge, failure toast"
+```
+
+---
+
+### Task 11: Integration test — end to end
+
+**Files:** None (manual testing)
+
+- [ ] **Step 1: Start the app**
+
+```bash
+cd C:/Users/fireb/openswarm && npm start
+```
+
+- [ ] **Step 2: Verify backend endpoints**
+
+Test CRUD via curl:
+```bash
+# List (empty)
+curl http://127.0.0.1:8324/api/schedules/list
+
+# Create
+curl -X POST http://127.0.0.1:8324/api/schedules/create \
+  -H "Content-Type: application/json" \
+  -d '{"dashboard_id":"REPLACE_WITH_REAL_ID","trigger_type":"interval","interval_seconds":60,"action_type":"new_session","prompt":"Hello from scheduler","name":"Test Schedule"}'
+
+# List (should show 1)
+curl http://127.0.0.1:8324/api/schedules/list
+
+# Toggle
+curl -X POST http://127.0.0.1:8324/api/schedules/SCHEDULE_ID/toggle
+
+# Delete
+curl -X DELETE http://127.0.0.1:8324/api/schedules/SCHEDULE_ID
+```
+
+- [ ] **Step 3: Verify frontend**
+
+1. Navigate to `/#/schedules` in the app
+2. Verify the page loads with "New Schedule" button
+3. Click "New Schedule", fill in the form, create
+4. Verify the schedule appears in the table
+5. Test pause/resume toggle
+6. Test edit
+7. Test delete
+8. Verify sidebar shows "Schedules" nav item
+
+- [ ] **Step 4: Verify scheduler fires**
+
+Create an interval schedule with 60-second interval. Wait ~90 seconds. Verify:
+- A new agent session appears in the target dashboard
+- The schedule's `run_count` increments
+- The `last_run_at` field updates
+
+- [ ] **Step 5: Commit any fixes needed**
+
+```bash
+git add -A && git commit -m "fix(schedules): integration test fixes"
+```

--- a/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
+++ b/docs/superpowers/plans/2026-04-09-windows-dev-mode.md
@@ -1,0 +1,853 @@
+# Windows & Linux Dev-Mode Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make OpenSwarm runnable in dev mode on Windows and Linux via cross-platform Node.js orchestration scripts and targeted platform fixes.
+
+**Architecture:** Three new `.mjs` scripts (`run.mjs`, `backend/run.mjs`, `frontend/run.mjs`) replace the Bash `.sh` scripts with cross-platform Node.js equivalents. Existing `.sh` files are untouched. Platform-specific code in `electron/main.js` and `backend/apps/tools_lib/tools_lib.py` is patched to handle Windows paths and conventions.
+
+**Tech Stack:** Node.js (ESM), child_process, http module, Python venv
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/run.mjs` | npm install + npm run dev |
+| Create | `backend/run.mjs` | venv setup, pip install, uvicorn start |
+| Create | `run.mjs` | Orchestrate backend, frontend, Electron; health checks; shutdown |
+| Modify | `electron/main.js` | Windows Python path, cross-platform PATH delimiters |
+| Modify | `electron/package.json` | Cross-platform dev/postinstall scripts |
+| Modify | `backend/apps/tools_lib/tools_lib.py` | Windows bin dirs, chmod guard |
+| Modify | `frontend/package.json` | Cross-platform clean script |
+
+---
+
+### Task 1: Create `frontend/run.mjs`
+
+The simplest script — good place to establish the pattern.
+
+**Files:**
+- Create: `frontend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify it works**
+
+Run from the project root:
+```bash
+node frontend/run.mjs
+```
+Expected: npm install runs, then webpack dev server starts on `http://localhost:3000`. Ctrl+C stops it cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/run.mjs
+git commit -m "feat: add cross-platform frontend/run.mjs"
+```
+
+---
+
+### Task 2: Create `backend/run.mjs`
+
+Handles Python venv creation, activation (via PATH manipulation), pip install, and uvicorn startup.
+
+**Files:**
+- Create: `backend/run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// backend/run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join, delimiter } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+const backendDir = __dirname;
+const isWindows = process.platform === 'win32';
+
+// --- Locate Python ---
+function findPython() {
+  const candidates = isWindows
+    ? ['python', 'python3']
+    : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const version = execFileSync(cmd, ['--version'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      console.log(`Found ${version} (${cmd})`);
+      return cmd;
+    } catch {
+      // not found, try next
+    }
+  }
+  console.error(
+    'Error: Python not found. Install Python 3.11+ and ensure it is on your PATH.'
+  );
+  process.exit(1);
+}
+
+const pythonCmd = findPython();
+
+// --- Venv setup ---
+const venvDir = join(backendDir, '.venv');
+const venvBin = isWindows
+  ? join(venvDir, 'Scripts')
+  : join(venvDir, 'bin');
+const venvPython = isWindows
+  ? join(venvBin, 'python.exe')
+  : join(venvBin, 'python3');
+const venvPip = isWindows
+  ? join(venvBin, 'pip.exe')
+  : join(venvBin, 'pip3');
+
+// Prepend venv bin to PATH so all child processes use the venv
+const env = {
+  ...process.env,
+  PATH: venvBin + delimiter + (process.env.PATH || ''),
+  VIRTUAL_ENV: venvDir,
+};
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      env,
+      ...options,
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0)
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  // --- Create virtual environment if needed ---
+  if (!existsSync(venvDir)) {
+    console.log('Creating virtual environment...');
+    await run(pythonCmd, ['-m', 'venv', venvDir], { env: process.env });
+  }
+
+  // --- Install debugger module if not installed ---
+  const debuggerDir = join(projectRoot, 'debugger');
+  try {
+    await run(venvPip, ['show', 'debug'], { stdio: 'ignore' });
+  } catch {
+    console.log('Installing debugger module...');
+    await run(venvPip, ['install', '-e', '.'], { cwd: debuggerDir });
+  }
+
+  // --- Install Python dependencies ---
+  console.log('Installing dependencies...');
+  await run(venvPip, ['install', '-r', join(backendDir, 'requirements.txt')], {
+    cwd: backendDir,
+  });
+
+  // --- Start the backend server ---
+  console.log('Starting backend server on http://0.0.0.0:8324 ...');
+  await run(
+    venvPython,
+    [
+      '-m', 'uvicorn', 'backend.main:app',
+      '--host', '0.0.0.0',
+      '--port', '8324',
+      '--reload',
+      '--reload-dir', backendDir,
+      '--reload-exclude', '*.pyc',
+    ],
+    { cwd: projectRoot }
+  );
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+```
+
+- [ ] **Step 2: Verify venv creation and uvicorn start**
+
+Run from the project root:
+```bash
+node backend/run.mjs
+```
+Expected: Creates `.venv` if missing, installs deps, starts uvicorn on port 8324. Ctrl+C stops it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/run.mjs
+git commit -m "feat: add cross-platform backend/run.mjs"
+```
+
+---
+
+### Task 3: Create `run.mjs` (root orchestrator)
+
+Spawns backend and frontend, health-checks both, launches Electron, handles graceful shutdown.
+
+**Files:**
+- Create: `run.mjs`
+
+- [ ] **Step 1: Create the script**
+
+```javascript
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}
+```
+
+- [ ] **Step 2: Verify full orchestration**
+
+Run from the project root:
+```bash
+node run.mjs
+```
+Expected: Backend starts and becomes healthy, frontend starts and becomes healthy, Electron launches. Ctrl+C gracefully shuts down all three. On unexpected exit of any service, the others are torn down.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add run.mjs
+git commit -m "feat: add cross-platform run.mjs orchestrator"
+```
+
+---
+
+### Task 4: Fix `electron/main.js` for Windows paths
+
+**Files:**
+- Modify: `electron/main.js:93` (PATH split)
+- Modify: `electron/main.js:98` (PATH join)
+- Modify: `electron/main.js:108-115` (getPythonPath)
+- Modify: `electron/main.js:164` (PYTHONPATH join)
+- Modify: `electron/main.js:289-300` (killBackend)
+
+- [ ] **Step 1: Fix `getPythonPath()` to use Windows paths**
+
+Change lines 108-115 from:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return path.join(envPath, 'bin', 'python3');
+  }
+  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+  return venvPython;
+}
+```
+
+To:
+
+```javascript
+function getPythonPath() {
+  if (isPackaged) {
+    const envPath = path.join(process.resourcesPath, 'python-env');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
+  }
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
+}
+```
+
+- [ ] **Step 2: Fix PATH separator on line 93**
+
+Change line 93 from:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+```
+
+To:
+
+```javascript
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
+```
+
+- [ ] **Step 3: Fix PATH join on line 98**
+
+Change line 98 from:
+
+```javascript
+  return dirs.join(':');
+```
+
+To:
+
+```javascript
+  return dirs.join(path.delimiter);
+```
+
+- [ ] **Step 4: Fix PYTHONPATH join on line 164**
+
+Change line 164 from:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+```
+
+To:
+
+```javascript
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
+```
+
+- [ ] **Step 5: Fix `killBackend()` for Windows**
+
+Change lines 289-300 from:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    backendProcess.kill('SIGTERM');
+    setTimeout(() => {
+      if (backendProcess && !backendProcess.killed) {
+        backendProcess.kill('SIGKILL');
+      }
+    }, 3000);
+    backendProcess = null;
+  }
+}
+```
+
+To:
+
+```javascript
+function killBackend() {
+  if (backendProcess) {
+    console.log('Killing backend process...');
+    if (process.platform === 'win32') {
+      try {
+        // PID is a numeric value from Node child_process — safe to pass as argument
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
+    backendProcess = null;
+  }
+}
+```
+
+Note: change the import on line 5 from `const { spawn, execFileSync } = require('child_process');` — `execFileSync` is already imported.
+
+- [ ] **Step 6: Verify Electron launches in dev mode**
+
+With backend and frontend already running (via `node backend/run.mjs` and `node frontend/run.mjs` in separate terminals):
+```bash
+cd electron && npx cross-env ELECTRON_DEV=1 npx electron .
+```
+Expected: Electron window opens, loads `http://localhost:3000`, no errors in console about Python paths.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/main.js
+git commit -m "fix: make electron main.js cross-platform (Windows paths, delimiters, process kill)"
+```
+
+---
+
+### Task 5: Fix `electron/package.json` scripts
+
+**Files:**
+- Modify: `electron/package.json`
+- Create: `electron/scripts/postinstall.mjs`
+
+- [ ] **Step 1: Install cross-env as a dev dependency**
+
+```bash
+cd electron && npm install --save-dev cross-env
+```
+
+- [ ] **Step 2: Update the `dev` and `postinstall` scripts**
+
+Change the `"scripts"` section from:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "ELECTRON_DEV=1 electron .",
+    "postinstall": "bash scripts/sign-vmp.sh",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+To:
+
+```json
+  "scripts": {
+    "start": "electron .",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
+    "sign-vmp": "bash scripts/sign-vmp.sh",
+    "dist": "electron-builder --mac --publish never",
+    "dist:publish": "electron-builder --mac --publish always",
+    "dist:all": "electron-builder --mac --win --linux"
+  },
+```
+
+- [ ] **Step 3: Create `electron/scripts/postinstall.mjs`**
+
+```javascript
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}
+```
+
+- [ ] **Step 4: Verify npm install works without error**
+
+```bash
+cd electron && npm install
+```
+Expected: On Windows/Linux, prints `[postinstall] Skipping VMP signing (macOS only)` and succeeds. On macOS, runs the existing sign-vmp.sh.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/package.json electron/scripts/postinstall.mjs
+git commit -m "fix: make electron package.json scripts cross-platform"
+```
+
+---
+
+### Task 6: Fix `backend/apps/tools_lib/tools_lib.py` for Windows
+
+**Files:**
+- Modify: `backend/apps/tools_lib/tools_lib.py:4` (add `sys` import)
+- Modify: `backend/apps/tools_lib/tools_lib.py:291-314` (`_extra_bin_dirs`)
+- Modify: `backend/apps/tools_lib/tools_lib.py:238` (`os.chmod`)
+
+- [ ] **Step 1: Add `sys` import**
+
+Add `import sys` after `import re` on line 4, so lines 3-5 become:
+
+```python
+import os
+import re
+import sys
+import logging
+```
+
+- [ ] **Step 2: Fix `_extra_bin_dirs()` for Windows**
+
+Change the `_extra_bin_dirs()` function (lines 291-314) from:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+To:
+
+```python
+def _extra_bin_dirs() -> list[str]:
+    """Well-known user-local bin directories that may not be on PATH in packaged apps."""
+    home = os.path.expanduser("~")
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", os.path.join(home, "AppData", "Roaming"))
+        localappdata = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        dirs = [
+            os.path.join(appdata, "npm"),
+            os.path.join(home, ".cargo", "bin"),
+            os.path.join(localappdata, "Programs", "Python"),
+            os.path.join(home, "scoop", "shims"),
+            os.path.join(home, ".bun", "bin"),
+            os.path.join(home, ".volta", "bin"),
+        ]
+        # nvm-windows
+        nvm_home = os.environ.get("NVM_HOME", "")
+        if nvm_home and os.path.isdir(nvm_home):
+            dirs.insert(0, os.environ.get("NVM_SYMLINK", nvm_home))
+        return dirs
+
+    dirs = [
+        os.path.join(home, ".bun", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+    ]
+    # nvm: pick the newest installed node version
+    nvm_node = os.path.join(home, ".nvm", "versions", "node")
+    try:
+        if os.path.isdir(nvm_node):
+            versions = sorted(os.listdir(nvm_node), reverse=True)
+            if versions:
+                dirs.insert(0, os.path.join(nvm_node, versions[0], "bin"))
+    except OSError:
+        pass
+    # fnm
+    fnm_bin = os.path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin")
+    if os.path.isdir(fnm_bin):
+        dirs.insert(0, fnm_bin)
+    return dirs
+```
+
+- [ ] **Step 3: Guard `os.chmod()` call**
+
+Change line 238 from:
+
+```python
+            os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+To:
+
+```python
+            if sys.platform != "win32":
+                os.chmod(_XBIRD_CONFIG_PATH, 0o600)
+```
+
+- [ ] **Step 4: Verify the backend starts without errors**
+
+```bash
+node backend/run.mjs
+```
+Expected: uvicorn starts, no import errors or platform-related crashes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/apps/tools_lib/tools_lib.py
+git commit -m "fix: make tools_lib bin dirs and chmod cross-platform"
+```
+
+---
+
+### Task 7: Fix `frontend/package.json` clean script
+
+**Files:**
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Replace Unix-only `rm -rf` with cross-platform alternative**
+
+Change the `"clean"` script from:
+
+```json
+    "clean": "rm -rf dist"
+```
+
+To:
+
+```json
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
+```
+
+- [ ] **Step 2: Verify clean works**
+
+```bash
+cd frontend && npm run clean
+```
+Expected: No error, `dist/` removed if it exists, no-op if it doesn't.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/package.json
+git commit -m "fix: make frontend clean script cross-platform"
+```
+
+---
+
+### Task 8: End-to-end verification
+
+- [ ] **Step 1: Full startup test**
+
+From the project root:
+```bash
+node run.mjs
+```
+
+Verify:
+1. Backend venv is created (if first run)
+2. Backend dependencies install
+3. Backend server starts on port 8324
+4. Frontend dependencies install
+5. Frontend dev server starts on port 3000
+6. Electron window opens and loads the app
+7. Ctrl+C gracefully stops all three processes
+
+- [ ] **Step 2: Restart test**
+
+Run `node run.mjs` again after Ctrl+C. Verify it starts cleanly (venv already exists, deps already installed, should be faster).
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any fixes were needed during testing, commit them:
+```bash
+git add -A
+git commit -m "fix: address issues found during cross-platform dev-mode testing"
+```

--- a/docs/superpowers/specs/2026-04-09-scheduling-system-design.md
+++ b/docs/superpowers/specs/2026-04-09-scheduling-system-design.md
@@ -1,0 +1,470 @@
+# OpenSwarm Scheduling System Design
+
+## Summary
+
+An in-process asyncio scheduler that lets users create recurring (cron), interval, and one-shot schedules to fire agent sessions or send messages to existing sessions. Schedules are tied to dashboards and persist as JSON files following the existing SubApp pattern. Uses `croniter` for cron expression parsing.
+
+Inspired by OpenClaw's approach: simple in-process tick loop + JSON persistence, no external dependencies.
+
+## Requirements
+
+1. **Three trigger types:** cron expressions (`0 9 * * *`), interval (every N seconds), one-shot (run at specific datetime)
+2. **Two action types:** create a new agent session, or send a message to an existing session
+3. **Agent configuration:** pick a template OR configure inline (model, mode, system prompt)
+4. **Dashboard-bound:** each schedule is tied to a dashboard — new sessions appear in that dashboard
+5. **Pause/resume:** schedules can be temporarily disabled without deletion
+6. **UI locations:** global Schedules page (all schedules) + per-dashboard filtered view
+7. **Notifications:** badge on Schedules sidebar icon for new results; toast popup on failures only
+8. **CLI routing:** all LLM calls go through `llm_router` — works with API key or Claude Code CLI auth
+
+---
+
+## Data Model
+
+### Backend: `backend/apps/schedules/models.py`
+
+```python
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import datetime
+from uuid import uuid4
+
+
+class Schedule(BaseModel):
+    id: str = Field(default_factory=lambda: uuid4().hex)
+    name: str = "Untitled Schedule"
+    enabled: bool = True
+    dashboard_id: str
+
+    # Trigger configuration
+    trigger_type: str  # "cron" | "interval" | "once"
+    cron_expression: Optional[str] = None       # e.g. "0 9 * * *"
+    interval_seconds: Optional[int] = None      # e.g. 3600
+    run_at: Optional[datetime] = None           # one-shot ISO timestamp
+
+    # Action configuration
+    action_type: str  # "new_session" | "message_existing"
+    prompt: str
+    target_session_id: Optional[str] = None     # for message_existing
+
+    # Agent configuration (new_session only)
+    template_id: Optional[str] = None           # use a template
+    model: Optional[str] = None                 # inline: "sonnet", "haiku", etc.
+    mode: Optional[str] = None                  # inline: mode name
+    system_prompt: Optional[str] = None         # inline: custom system prompt
+
+    # State tracking
+    last_run_at: Optional[datetime] = None
+    next_run_at: Optional[datetime] = None
+    run_count: int = 0
+    last_error: Optional[str] = None
+
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+class ScheduleCreate(BaseModel):
+    name: str = "Untitled Schedule"
+    dashboard_id: str
+    trigger_type: str
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: str
+    prompt: str
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+
+class ScheduleUpdate(BaseModel):
+    name: Optional[str] = None
+    enabled: Optional[bool] = None
+    dashboard_id: Optional[str] = None
+    trigger_type: Optional[str] = None
+    cron_expression: Optional[str] = None
+    interval_seconds: Optional[int] = None
+    run_at: Optional[datetime] = None
+    action_type: Optional[str] = None
+    prompt: Optional[str] = None
+    target_session_id: Optional[str] = None
+    template_id: Optional[str] = None
+    model: Optional[str] = None
+    mode: Optional[str] = None
+    system_prompt: Optional[str] = None
+```
+
+### Frontend: `frontend/src/shared/state/schedulesSlice.ts`
+
+```typescript
+export interface Schedule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  dashboard_id: string;
+  trigger_type: 'cron' | 'interval' | 'once';
+  cron_expression: string | null;
+  interval_seconds: number | null;
+  run_at: string | null;
+  action_type: 'new_session' | 'message_existing';
+  prompt: string;
+  target_session_id: string | null;
+  template_id: string | null;
+  model: string | null;
+  mode: string | null;
+  system_prompt: string | null;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  run_count: number;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SchedulesState {
+  items: Record<string, Schedule>;
+  loading: boolean;
+  unreadCount: number;  // for badge
+}
+```
+
+---
+
+## Backend Architecture
+
+### File Structure
+
+```
+backend/apps/schedules/
+├── __init__.py
+├── models.py          # Pydantic models (above)
+├── schedules.py       # SubApp + CRUD endpoints
+├── scheduler.py       # Background tick loop
+└── executor.py        # Fire logic (new session / message existing)
+```
+
+### Storage
+
+- Directory: add `SCHEDULES_DIR` to `backend/config/paths.py`
+- One JSON file per schedule: `{SCHEDULES_DIR}/{schedule_id}.json`
+- Same pattern as `backend/apps/dashboards/dashboards.py`
+
+### SubApp: `schedules.py`
+
+Follows the exact pattern of `dashboards.py`:
+
+- `_load_all() -> list[Schedule]`
+- `_save(schedule: Schedule)`
+- `_load(schedule_id: str) -> Schedule`
+- `_delete(schedule_id: str)`
+- Lifespan: `os.makedirs(DATA_DIR, exist_ok=True)`, start scheduler background task
+
+**Endpoints (all under `/api/schedules/`):**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/list` | List all schedules |
+| GET | `/list?dashboard_id={id}` | List schedules for a dashboard |
+| POST | `/create` | Create a new schedule |
+| GET | `/{id}` | Get single schedule |
+| PUT | `/{id}` | Update schedule |
+| DELETE | `/{id}` | Delete schedule |
+| POST | `/{id}/toggle` | Toggle enabled/disabled |
+
+### Scheduler: `scheduler.py`
+
+```python
+import asyncio
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+_scheduler_task: asyncio.Task | None = None
+TICK_INTERVAL = 30  # seconds
+
+
+async def _tick():
+    """One evaluation cycle: check all enabled schedules, fire due ones."""
+    from backend.apps.schedules.schedules import _load_all, _save
+    from backend.apps.schedules.executor import execute_schedule
+
+    now = datetime.now()
+    for schedule in _load_all():
+        if not schedule.enabled:
+            continue
+        if schedule.next_run_at is None:
+            continue
+        if schedule.next_run_at > now:
+            continue
+
+        try:
+            await execute_schedule(schedule)
+            schedule.last_run_at = now
+            schedule.run_count += 1
+            schedule.last_error = None
+        except Exception as e:
+            logger.exception(f"Schedule {schedule.id} failed")
+            schedule.last_error = str(e)
+            # Emit failure WebSocket event
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global({
+                "event": "schedule:run_failed",
+                "data": {"schedule_id": schedule.id, "name": schedule.name, "error": str(e)},
+            })
+
+        # Compute next_run_at
+        schedule.next_run_at = _compute_next_run(schedule, now)
+
+        # Auto-disable one-shot after firing
+        if schedule.trigger_type == "once":
+            schedule.enabled = False
+
+        schedule.updated_at = now
+        _save(schedule)
+
+        # Emit success WebSocket event
+        if schedule.last_error is None:
+            from backend.apps.agents.ws_manager import ws_manager
+            await ws_manager.broadcast_global({
+                "event": "schedule:run_complete",
+                "data": {"schedule_id": schedule.id, "name": schedule.name},
+            })
+
+
+def _compute_next_run(schedule, after: datetime) -> datetime | None:
+    if schedule.trigger_type == "cron" and schedule.cron_expression:
+        from croniter import croniter
+        return croniter(schedule.cron_expression, after).get_next(datetime)
+    elif schedule.trigger_type == "interval" and schedule.interval_seconds:
+        from datetime import timedelta
+        return after + timedelta(seconds=schedule.interval_seconds)
+    elif schedule.trigger_type == "once":
+        return None  # already fired
+    return None
+
+
+async def _run_loop():
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.exception("Scheduler tick failed")
+        await asyncio.sleep(TICK_INTERVAL)
+
+
+def start_scheduler():
+    global _scheduler_task
+    if _scheduler_task is None or _scheduler_task.done():
+        _scheduler_task = asyncio.get_event_loop().create_task(_run_loop())
+        logger.info("Scheduler started")
+
+
+def stop_scheduler():
+    global _scheduler_task
+    if _scheduler_task and not _scheduler_task.done():
+        _scheduler_task.cancel()
+        logger.info("Scheduler stopped")
+```
+
+### Executor: `executor.py`
+
+```python
+import logging
+from backend.apps.schedules.models import Schedule
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_schedule(schedule: Schedule):
+    """Fire a schedule: either create a new session or message an existing one."""
+    from backend.apps.agents.agent_manager import agent_manager
+
+    if schedule.action_type == "new_session":
+        await _create_new_session(schedule)
+    elif schedule.action_type == "message_existing":
+        await _message_existing(schedule)
+
+
+async def _create_new_session(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+
+    # Build session config from template or inline
+    config = {}
+    if schedule.template_id:
+        from backend.apps.templates.templates import _load as load_template
+        template = load_template(schedule.template_id)
+        config["mode"] = template.mode
+        config["model"] = template.model
+        config["system_prompt"] = template.system_prompt
+    else:
+        if schedule.model:
+            config["model"] = schedule.model
+        if schedule.mode:
+            config["mode"] = schedule.mode
+        if schedule.system_prompt:
+            config["system_prompt"] = schedule.system_prompt
+
+    session = await agent_manager.create_session(
+        dashboard_id=schedule.dashboard_id,
+        **config,
+    )
+
+    await agent_manager.send_message(
+        session.id,
+        schedule.prompt,
+        mode=config.get("mode"),
+        model=config.get("model"),
+    )
+
+
+async def _message_existing(schedule: Schedule):
+    from backend.apps.agents.agent_manager import agent_manager
+
+    if not schedule.target_session_id:
+        raise ValueError("target_session_id required for message_existing")
+
+    if schedule.target_session_id not in agent_manager.sessions:
+        raise ValueError(f"Session {schedule.target_session_id} not found")
+
+    await agent_manager.send_message(
+        schedule.target_session_id,
+        schedule.prompt,
+    )
+```
+
+### Registration
+
+**`backend/config/paths.py`** — add:
+```python
+SCHEDULES_DIR = os.path.join(DATA_DIR, "schedules")
+```
+
+**`backend/main.py`** — add to imports and `MainApp` list:
+```python
+from backend.apps.schedules.schedules import schedules
+# Add to MainApp constructor list
+```
+
+---
+
+## Frontend Architecture
+
+### File Structure
+
+```
+frontend/src/
+├── shared/state/schedulesSlice.ts        # Redux slice
+├── app/pages/Schedules/Schedules.tsx     # Global schedules page
+├── app/pages/Schedules/ScheduleEditor.tsx # Create/edit dialog
+└── app/pages/Dashboard/SchedulePanel.tsx  # Per-dashboard schedule list
+```
+
+### Redux Slice: `schedulesSlice.ts`
+
+Follows `dashboardsSlice.ts` pattern exactly:
+- `fetchSchedules` — GET `/api/schedules/list`
+- `createSchedule` — POST `/api/schedules/create`
+- `updateSchedule` — PUT `/api/schedules/{id}`
+- `deleteSchedule` — DELETE `/api/schedules/{id}`
+- `toggleSchedule` — POST `/api/schedules/{id}/toggle`
+- `incrementUnread` — reducer for WebSocket events
+- `clearUnread` — reducer when user views schedules page
+
+Register in `store.ts`:
+```typescript
+import schedulesReducer from './schedulesSlice';
+// Add: schedules: schedulesReducer
+```
+
+### Global Schedules Page: `Schedules.tsx`
+
+Standard page layout matching Settings/Templates pattern:
+- `useClaudeTokens()` for theming
+- `useAppDispatch()` + `useAppSelector()` for state
+- Full-height `Box` with `c.bg.page`
+- Table/list of all schedules with columns: Name, Trigger, Dashboard, Status (Chip), Next Run, Last Run, Actions
+- Status `Chip`: green "Active", orange "Paused", red "Error"
+- Action buttons: Edit (opens ScheduleEditor dialog), Toggle (pause/resume), Delete
+- "New Schedule" button at top
+
+### Schedule Editor: `ScheduleEditor.tsx`
+
+MUI `Dialog` following existing modal patterns:
+- Trigger type selector (cron / interval / once)
+- Conditional fields based on trigger type:
+  - Cron: text field for expression with helper text
+  - Interval: number field for seconds
+  - Once: datetime picker
+- Action type selector (new session / message existing)
+- Conditional fields:
+  - New session: template dropdown OR inline config (model select, mode select, system prompt textarea)
+  - Message existing: session ID picker (from dashboard's active sessions)
+- Dashboard picker dropdown
+- Prompt textarea
+- Name field
+
+All inputs use the existing `inputSx` pattern with `c.border.strong`, `c.text.tertiary`, `c.accent.primary`.
+
+### Per-Dashboard Panel: `SchedulePanel.tsx`
+
+Compact list filtered to the current dashboard. Shown as a collapsible section or tab within the Dashboard page. Same data, simpler layout — just name, status chip, next run, and toggle/edit buttons.
+
+### Sidebar Navigation
+
+Add to `AppShell.tsx`:
+```tsx
+import ScheduleIcon from '@mui/icons-material/Schedule';
+
+// In CUSTOMIZATION_ITEMS or as a standalone nav item:
+{ label: 'Schedules', path: '/schedules', icon: <ScheduleIcon /> }
+```
+
+Badge on the sidebar icon shows `unreadCount` from Redux state.
+
+### Route
+
+Add to `Main.tsx`:
+```tsx
+import Schedules from './pages/Schedules/Schedules';
+// In Routes:
+<Route path="/schedules" element={<Schedules />} />
+```
+
+### WebSocket Notifications
+
+In the existing WebSocket handler (`frontend/src/shared/ws/`), listen for:
+- `schedule:run_complete` — increment `unreadCount` in schedulesSlice
+- `schedule:run_failed` — increment `unreadCount` + show Snackbar toast with error
+
+---
+
+## WebSocket Events
+
+### Backend → Frontend
+
+| Event | Data | Purpose |
+|-------|------|---------|
+| `schedule:run_complete` | `{ schedule_id, name }` | Badge increment |
+| `schedule:run_failed` | `{ schedule_id, name, error }` | Badge + failure toast |
+
+Sent via `ws_manager.broadcast_global()` on the dashboard WebSocket channel.
+
+---
+
+## Dependencies
+
+- **`croniter`** — Python package for cron expression parsing (pip install)
+- No new frontend dependencies — all MUI
+
+---
+
+## Edge Cases
+
+1. **Backend restart:** Scheduler starts in SubApp lifespan. On startup, recompute `next_run_at` for all enabled schedules from persisted state. Missed runs during downtime are skipped (not retroactively fired).
+2. **One-shot in the past:** If `run_at` is in the past when created, fire immediately on next tick, then disable.
+3. **Target session deleted:** `message_existing` action fails gracefully — logged as error in `last_error`, toast sent.
+4. **Dashboard deleted:** Cascade-delete all schedules tied to that dashboard (same as session cleanup in `dashboards.py`).
+5. **Concurrent ticks:** Not an issue — single-process asyncio, one tick at a time.

--- a/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
+++ b/docs/superpowers/specs/2026-04-09-windows-dev-mode-design.md
@@ -1,0 +1,81 @@
+# Windows (& Linux) Dev-Mode Support
+
+**Date:** 2026-04-09
+**Scope:** Development mode only — no packaged app builds
+
+## Goal
+
+Make OpenSwarm runnable in dev mode on Windows and Linux by replacing the Bash orchestration scripts with cross-platform Node.js equivalents and fixing platform-specific code paths in the Electron main process and Python backend.
+
+## Approach
+
+Add three new `.mjs` scripts that mirror the existing `.sh` scripts but work on all platforms. Existing `.sh` files are untouched — zero risk to current macOS users.
+
+## New Files
+
+### `run.mjs` (root orchestrator)
+
+Replaces `run.sh`. Responsibilities:
+
+- Spawns `node backend/run.mjs` and `node frontend/run.mjs` as child processes
+- Prefixes stdout with colored `[backend]` / `[frontend]` / `[electron]` tags using ANSI codes (no dependencies)
+- Health-checks `http://localhost:8324` and `http://localhost:3000` via `http.get()` polling
+- Once both healthy, launches Electron with `ELECTRON_DEV=1` env var
+- Graceful shutdown on SIGINT/SIGTERM: sends SIGTERM on Unix, `taskkill /T /F /PID` on Windows
+- Monitors child PIDs — if any exit unexpectedly, tears down all others
+
+### `backend/run.mjs`
+
+Replaces `backend/run.sh`. Responsibilities:
+
+- Creates Python venv if `.venv` doesn't exist: `python -m venv .venv`
+- Activates venv by prepending the correct bin dir to PATH (`.venv/Scripts` on Windows, `.venv/bin` on Unix) — no `source activate` needed
+- Installs debugger module (`pip install -e .`) if not already installed
+- Installs Python dependencies (`pip install -r requirements.txt`)
+- Starts uvicorn: `python -m uvicorn backend.main:app --host 0.0.0.0 --port 8324 --reload`
+
+### `frontend/run.mjs`
+
+Replaces `frontend/run.sh`. Responsibilities:
+
+- Runs `npm install` in frontend directory
+- Runs `npm run dev`
+
+## Modified Files
+
+### `electron/main.js`
+
+- `getPythonPath()`: Return `.venv\Scripts\python.exe` on `win32`, `.venv/bin/python3` on Unix
+- Line 93/98: Change hardcoded `':'` PATH separator to `path.delimiter`
+- Line 164: Change `PYTHONPATH` join separator from `':'` to `path.delimiter`
+
+### `backend/apps/tools_lib/tools_lib.py`
+
+- `_extra_bin_dirs()`: On `win32`, return Windows-appropriate paths (`~\AppData\Roaming\npm`, `~\.cargo\bin`, `~\scoop\shims`) instead of Unix-only paths (`/opt/homebrew/bin`, `/usr/local/bin`, etc.)
+- `os.chmod(_XBIRD_CONFIG_PATH, 0o600)`: Wrap in `if sys.platform != 'win32'` guard — Windows doesn't support Unix permissions; files are already user-private by default
+
+### `electron/package.json`
+
+- `"dev"` script: Either use `cross-env` for env var setting or rely on `run.mjs` setting `ELECTRON_DEV=1` (making the npm script moot in the cross-platform workflow)
+- `"postinstall"`: Guard VMP signing script with platform check so it doesn't fail on Windows/Linux
+
+## Error Handling
+
+- **Python not found**: `backend/run.mjs` checks for `python`/`python3` on PATH at startup, exits with clear error
+- **Port conflicts**: Preserved existing behavior — uvicorn/webpack error naturally
+- **Windows long paths**: Not expected for dev mode; users can enable `git config --system core.longpaths true` if needed
+- **Line endings**: Node.js handles natively — no `sed` stripping needed
+
+## Out of Scope
+
+- Existing `.sh` files (untouched)
+- Build/publish scripts (`scripts/build-app.sh`, `scripts/build-python-env.sh`, `publish.sh`)
+- Packaged Windows/Linux Electron builds (`.exe`, `.deb`, etc.)
+- CI/CD pipeline
+- Backend Python application code (already cross-platform except the two fixes above)
+- Frontend React code (already platform-agnostic)
+
+## Testing
+
+- Manual testing on Windows, ideally verified on macOS/Linux too
+- Verify: venv creation, pip install, uvicorn starts, frontend starts, Electron launches, Ctrl+C clean shutdown

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, components, BrowserWindow, ipcMain, shell, session } = require('electron');
+const { app, components, BrowserWindow, ipcMain, shell, session, dialog } = require('electron');
 let autoUpdater;
 try { autoUpdater = require('electron-updater').autoUpdater; } catch (_) {}
 const path = require('path');
@@ -536,4 +536,14 @@ ipcMain.handle('open-external', (_event, url) => {
   if (typeof url === 'string' && /^https?:\/\//.test(url)) {
     shell.openExternal(url);
   }
+});
+
+ipcMain.handle('show-folder-dialog', async (_event, defaultPath) => {
+  const win = BrowserWindow.getFocusedWindow();
+  const result = await dialog.showOpenDialog(win || undefined, {
+    properties: ['openDirectory'],
+    defaultPath: defaultPath || undefined,
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  return result.filePaths[0];
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -90,12 +90,12 @@ function getShellPath() {
 
   const seen = new Set();
   const dirs = [];
-  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
+  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(path.delimiter)]) {
     if (!d || seen.has(d)) continue;
     seen.add(d);
     try { if (fs.statSync(d).isDirectory()) dirs.push(d); } catch { /* skip */ }
   }
-  return dirs.join(':');
+  return dirs.join(path.delimiter);
 }
 
 function getResourcePath(...segments) {
@@ -108,10 +108,13 @@ function getResourcePath(...segments) {
 function getPythonPath() {
   if (isPackaged) {
     const envPath = path.join(process.resourcesPath, 'python-env');
-    return path.join(envPath, 'bin', 'python3');
+    return process.platform === 'win32'
+      ? path.join(envPath, 'Scripts', 'python.exe')
+      : path.join(envPath, 'bin', 'python3');
   }
-  const venvPython = path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
-  return venvPython;
+  return process.platform === 'win32'
+    ? path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe')
+    : path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
 }
 
 function waitForBackend(port, timeoutMs = 60000) {
@@ -161,7 +164,7 @@ async function startBackend() {
       'python3.13', 'site-packages'
     );
     const debuggerDir = getResourcePath('debugger');
-    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(':');
+    env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
   }
 
   console.log(`Starting backend: ${pythonPath} on port ${backendPort}`);
@@ -289,12 +292,18 @@ function setupAutoUpdater() {
 function killBackend() {
   if (backendProcess) {
     console.log('Killing backend process...');
-    backendProcess.kill('SIGTERM');
-    setTimeout(() => {
-      if (backendProcess && !backendProcess.killed) {
-        backendProcess.kill('SIGKILL');
-      }
-    }, 3000);
+    if (process.platform === 'win32') {
+      try {
+        execFileSync('taskkill', ['/T', '/F', '/PID', String(backendProcess.pid)]);
+      } catch { /* already exited */ }
+    } else {
+      backendProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (backendProcess && !backendProcess.killed) {
+          backendProcess.kill('SIGKILL');
+        }
+      }, 3000);
+    }
     backendProcess = null;
   }
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -538,6 +538,42 @@ ipcMain.handle('open-external', (_event, url) => {
   }
 });
 
+ipcMain.handle('open-in-cli', async (_event, sessionId, cwd) => {
+  if (!sessionId || typeof sessionId !== 'string') return { ok: false, error: 'Missing session ID' };
+  const args = ['--resume', sessionId];
+  const spawnOpts = { detached: true, stdio: 'ignore' };
+  if (cwd) spawnOpts.cwd = cwd;
+  try {
+    if (process.platform === 'win32') {
+      // Open Windows Terminal (or cmd fallback) with claude --resume
+      spawn('cmd.exe', ['/c', 'start', 'cmd.exe', '/k', 'claude', ...args], spawnOpts).unref();
+    } else if (process.platform === 'darwin') {
+      // macOS: open Terminal.app
+      const script = `tell application "Terminal" to do script "cd ${(cwd || '~').replace(/"/g, '\\"')} && claude ${args.join(' ')}"`;
+      spawn('osascript', ['-e', script], spawnOpts).unref();
+    } else {
+      // Linux: try common terminal emulators
+      const terminals = ['x-terminal-emulator', 'gnome-terminal', 'konsole', 'xterm'];
+      let launched = false;
+      for (const term of terminals) {
+        try {
+          if (term === 'gnome-terminal') {
+            spawn(term, ['--', 'claude', ...args], spawnOpts).unref();
+          } else {
+            spawn(term, ['-e', `claude ${args.join(' ')}`], spawnOpts).unref();
+          }
+          launched = true;
+          break;
+        } catch { /* try next */ }
+      }
+      if (!launched) return { ok: false, error: 'No terminal emulator found' };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+});
+
 ipcMain.handle('show-folder-dialog', async (_event, defaultPath) => {
   const win = BrowserWindow.getFocusedWindow();
   const result = await dialog.showOpenDialog(win || undefined, {

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@electron/notarize": "^3.1.1",
+        "cross-env": "^10.1.0",
         "electron": "castlabs/electron-releases#v33.4.11+wvcus",
         "electron-builder": "^25.1.0"
       }
@@ -363,6 +364,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -816,6 +824,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1013,7 +1022,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1033,7 +1041,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1056,7 +1063,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1072,8 +1078,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1081,7 +1086,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1709,7 +1713,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1834,7 +1837,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1848,13 +1850,30 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -2062,6 +2081,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -2256,7 +2276,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -2270,7 +2289,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2286,7 +2304,6 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2300,7 +2317,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2754,8 +2770,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3360,8 +3375,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3496,7 +3510,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3510,7 +3523,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3526,8 +3538,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3535,7 +3546,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3552,16 +3562,14 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3574,8 +3582,7 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3589,16 +3596,14 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4070,7 +4075,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4318,8 +4322,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4420,7 +4423,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4430,8 +4432,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4439,7 +4440,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4450,7 +4450,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4952,7 +4951,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5336,7 +5334,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -5352,7 +5349,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dev": "ELECTRON_DEV=1 electron .",
-    "postinstall": "bash scripts/sign-vmp.sh",
+    "dev": "cross-env ELECTRON_DEV=1 electron .",
+    "postinstall": "node scripts/postinstall.mjs",
     "sign-vmp": "bash scripts/sign-vmp.sh",
     "dist": "electron-builder --mac --publish never",
     "dist:publish": "electron-builder --mac --publish always",
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",
+    "cross-env": "^10.1.0",
     "electron": "castlabs/electron-releases#v33.4.11+wvcus",
     "electron-builder": "^25.1.0"
   },

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -13,6 +13,7 @@ const { contextBridge, ipcRenderer } = require('electron');
     getAppVersion: () => ipcRenderer.invoke('get-app-version'),
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
     capturePage: (rect) => ipcRenderer.invoke('capture-page', rect),
+    showFolderDialog: (defaultPath) => ipcRenderer.invoke('show-folder-dialog', defaultPath),
     getUpdateStatus: () => ipcRenderer.invoke('get-update-status'),
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -14,6 +14,7 @@ const { contextBridge, ipcRenderer } = require('electron');
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
     capturePage: (rect) => ipcRenderer.invoke('capture-page', rect),
     showFolderDialog: (defaultPath) => ipcRenderer.invoke('show-folder-dialog', defaultPath),
+    openInCli: (sessionId, cwd) => ipcRenderer.invoke('open-in-cli', sessionId, cwd),
     getUpdateStatus: () => ipcRenderer.invoke('get-update-status'),
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/electron/scripts/postinstall.mjs
+++ b/electron/scripts/postinstall.mjs
@@ -1,0 +1,19 @@
+// electron/scripts/postinstall.mjs
+// Cross-platform postinstall — runs VMP signing on macOS only.
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const signScript = join(__dirname, 'sign-vmp.sh');
+
+if (process.platform === 'darwin' && existsSync(signScript)) {
+  try {
+    execFileSync('bash', [signScript], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[postinstall] VMP signing failed (non-fatal):', err.message);
+  }
+} else {
+  console.log('[postinstall] Skipping VMP signing (macOS only)');
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "build": "webpack --mode=production",
     "build:watch": "webpack --mode=development --watch",
     "dev": "webpack serve --mode=development",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.4.11",

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -1,0 +1,33 @@
+// frontend/run.mjs
+import { spawn } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+      else resolve();
+    });
+  });
+}
+
+try {
+  console.log('Installing dependencies...');
+  await run(npmCmd, ['install']);
+
+  console.log('Building with development mode...');
+  await run(npmCmd, ['run', 'dev']);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/frontend/run.mjs
+++ b/frontend/run.mjs
@@ -12,6 +12,7 @@ function run(cmd, args) {
     const child = spawn(cmd, args, {
       cwd: __dirname,
       stdio: 'inherit',
+      shell: isWindows,
     });
     child.on('error', reject);
     child.on('exit', (code) => {

--- a/frontend/src/app/Main.tsx
+++ b/frontend/src/app/Main.tsx
@@ -22,6 +22,7 @@ import Tools from './pages/Tools/Tools';
 import Modes from './pages/Modes/Modes';
 import Views from './pages/Views/Views';
 import Customization from './pages/Customization/Customization';
+import Schedules from './pages/Schedules/Schedules';
 import { useKeyboardShortcuts } from '@/shared/hooks/useKeyboardShortcuts';
 import KeyboardShortcutsHelp from './components/KeyboardShortcutsHelp';
 import { ThemeProvider, useThemeMode, useClaudeTokens } from '@/shared/styles/ThemeContext';
@@ -228,6 +229,7 @@ const ThemedApp: React.FC = () => {
                   <Route path="/modes" element={<Modes />} />
                   <Route path="/apps" element={<Views />} />
                   <Route path="/apps/:id" element={<Views />} />
+                  <Route path="/schedules" element={<Schedules />} />
                 </Route>
               </Routes>
             </UpdateListener>

--- a/frontend/src/app/components/Layout/AppShell.tsx
+++ b/frontend/src/app/components/Layout/AppShell.tsx
@@ -29,6 +29,8 @@ import ArrowForwardOutlinedIcon from '@mui/icons-material/ArrowForwardOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import CloseIcon from '@mui/icons-material/Close';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import Badge from '@mui/material/Badge';
 import LinearProgress from '@mui/material/LinearProgress';
 import Settings from '@/app/pages/Settings/Settings';
 import DynamicIsland from '@/app/components/DynamicIsland';
@@ -39,6 +41,7 @@ import { setPendingBrowserUrl } from '@/shared/state/tempStateSlice';
 import { fetchOutputs } from '@/shared/state/outputsSlice';
 import { findBrowserByWebContentsId } from '@/shared/browserRegistry';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import { dashboardWs } from '@/shared/ws/WebSocketManager';
 
 const SIDEBAR_MIN = 160;
 const SIDEBAR_MAX = 400;
@@ -51,6 +54,7 @@ const CUSTOMIZATION_ITEMS = [
   { label: 'Skills', path: '/skills', icon: <PsychologyIcon /> },
   { label: 'Actions', path: '/actions', icon: <BuildIcon /> },
   { label: 'Modes', path: '/modes', icon: <TuneIcon /> },
+  { label: 'Schedules', path: '/schedules', icon: <ScheduleIcon /> },
 ];
 
 const CUSTOMIZATION_PATHS = new Set(CUSTOMIZATION_ITEMS.map((i) => i.path));
@@ -83,11 +87,13 @@ const AppShell: React.FC = () => {
   const updateStatus = useAppSelector((state) => state.update.status);
   const availableVersion = useAppSelector((state) => state.update.availableVersion);
   const downloadPercent = useAppSelector((state) => state.update.downloadPercent);
+  const scheduleUnread = useAppSelector((s) => s.schedules.unreadCount);
 
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(() => {
     try { return localStorage.getItem(UPDATE_DISMISS_KEY); } catch { return null; }
   });
   const [snackbarDismissed, setSnackbarDismissed] = useState(false);
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   const bannerDismissedForVersion = availableVersion != null && dismissedVersion === availableVersion;
   const isUpdateActionable = updateStatus === 'available' || updateStatus === 'downloaded' || updateStatus === 'downloading';
@@ -109,6 +115,13 @@ const AppShell: React.FC = () => {
 
   const handleInstallUpdate = useCallback(() => {
     (window as any).openswarm?.installUpdate();
+  }, []);
+
+  useEffect(() => {
+    const unsub = dashboardWs.on('schedule:run_failed', (data: any) => {
+      setScheduleError(`Schedule "${data.name}" failed: ${data.error}`);
+    });
+    return unsub;
   }, []);
 
   const dashboardItems = useAppSelector((state) => state.dashboards.items);
@@ -705,20 +718,39 @@ const AppShell: React.FC = () => {
                           transition: 'background-color 0.12s, border-color 0.12s',
                         }}
                       >
-                        <Typography
-                          sx={{
-                            color: isActive ? c.text.secondary : c.text.ghost,
-                            fontSize: '0.78rem',
-                            fontWeight: isActive ? 500 : 400,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            flex: 1,
-                            minWidth: 0,
-                          }}
-                        >
-                          {item.label}
-                        </Typography>
+                        {item.label === 'Schedules' ? (
+                          <Badge badgeContent={scheduleUnread} color="error" max={99} sx={{ flex: 1, minWidth: 0, '& .MuiBadge-badge': { right: -8, top: 6 } }}>
+                            <Typography
+                              sx={{
+                                color: isActive ? c.text.secondary : c.text.ghost,
+                                fontSize: '0.78rem',
+                                fontWeight: isActive ? 500 : 400,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                flex: 1,
+                                minWidth: 0,
+                              }}
+                            >
+                              {item.label}
+                            </Typography>
+                          </Badge>
+                        ) : (
+                          <Typography
+                            sx={{
+                              color: isActive ? c.text.secondary : c.text.ghost,
+                              fontSize: '0.78rem',
+                              fontWeight: isActive ? 500 : 400,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              flex: 1,
+                              minWidth: 0,
+                            }}
+                          >
+                            {item.label}
+                          </Typography>
+                        )}
                       </Box>
                     )}
                   </NavLink>
@@ -997,6 +1029,15 @@ const AppShell: React.FC = () => {
           {updateStatus === 'available' && `OpenSwarm ${availableVersion} is available`}
           {updateStatus === 'downloaded' && `OpenSwarm ${availableVersion} downloaded — restart to update`}
         </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={!!scheduleError}
+        autoHideDuration={6000}
+        onClose={() => setScheduleError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert severity="error" onClose={() => setScheduleError(null)}>{scheduleError}</Alert>
       </Snackbar>
     </Box>
   );

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -48,6 +48,7 @@ import { useClaudeTokens } from '@/shared/styles/ThemeContext';
 const CONTEXT_WINDOWS: Record<string, number> = {
   sonnet: 200_000,
   opus: 200_000,
+  'opus-1m': 1_000_000,
   haiku: 200_000,
 };
 
@@ -143,6 +144,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   const [awaitingResponse, setAwaitingResponse] = useState(false);
   const [mode, setMode] = useState('agent');
   const [model, setModel] = useState('sonnet');
+  const [effort, setEffort] = useState('high');
 
   const wsRef = useRef<ReturnType<typeof createSessionWs> | null>(null);
   const initialContextApplied = useRef(false);
@@ -1119,6 +1121,8 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                 onModeChange={handleModeChange}
                 model={model}
                 onModelChange={handleModelChange}
+                effort={effort}
+                onEffortChange={setEffort}
                 isRunning={agentBusy}
                 onStop={handleStop}
                 queueLength={queueLength}

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -710,7 +710,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                       const result = await openswarm.openInCli(session.sdk_session_id, session.cwd);
                       if (result && !result.ok) console.error('Open in CLI failed:', result.error);
                     } else {
-                      await fetch(`${API_BASE}/agents/sessions/${id}/open-in-cli`, { method: 'POST' });
+                      await fetch(`${API_BASE}/agents/open-in-cli`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: id }) });
                     }
                   }}
                 >

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -15,6 +15,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import CheckIcon from '@mui/icons-material/Check';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import TerminalIcon from '@mui/icons-material/Terminal';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 import {
   sendMessage as sendMessageThunk,
@@ -44,6 +45,7 @@ import { ContextPath } from '@/app/components/DirectoryBrowser';
 import DiffViewer from './DiffViewer';
 import { setGlowingBrowserCards, fadeGlowingBrowserCards, clearGlowingBrowserCards } from '@/shared/state/dashboardLayoutSlice';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import { API_BASE } from '@/shared/config';
 
 const CONTEXT_WINDOWS: Record<string, number> = {
   sonnet: 200_000,
@@ -697,6 +699,25 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
               )}
             </Box>
             {!isDraft && id && <DiffViewer sessionId={id} />}
+            {!isDraft && session.sdk_session_id && (
+              <Tooltip title="Open in CLI">
+                <IconButton
+                  size="small"
+                  sx={{ color: c.text.tertiary, '&:hover': { color: c.text.primary } }}
+                  onClick={async () => {
+                    const openswarm = (window as any).openswarm;
+                    if (openswarm?.openInCli) {
+                      const result = await openswarm.openInCli(session.sdk_session_id, session.cwd);
+                      if (result && !result.ok) console.error('Open in CLI failed:', result.error);
+                    } else {
+                      await fetch(`${API_BASE}/agents/sessions/${id}/open-in-cli`, { method: 'POST' });
+                    }
+                  }}
+                >
+                  <TerminalIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
             {onClose && (
               <IconButton onClick={onClose} size="small" sx={{ color: c.text.tertiary, '&:hover': { color: c.text.primary } }}>
                 <CloseIcon fontSize="small" />

--- a/frontend/src/app/pages/AgentChat/ChatInput.tsx
+++ b/frontend/src/app/pages/AgentChat/ChatInput.tsx
@@ -67,6 +67,8 @@ interface Props {
   onModeChange: (mode: string) => void;
   model: string;
   onModelChange: (model: string) => void;
+  effort: string;
+  onEffortChange: (effort: string) => void;
   isRunning?: boolean;
   onStop?: () => void;
   autoRunMode?: boolean;
@@ -141,7 +143,7 @@ const ContextRing: React.FC<{ used: number; limit: number; accentColor: string; 
   );
 };
 
-const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, onModeChange, model, onModelChange, isRunning, onStop, autoRunMode, contextEstimate, embedded, autoFocus, sessionId, queueLength = 0 }, ref) => {
+const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, onModeChange, model, onModelChange, effort, onEffortChange, isRunning, onStop, autoRunMode, contextEstimate, embedded, autoFocus, sessionId, queueLength = 0 }, ref) => {
   const c = useClaudeTokens();
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -200,7 +202,6 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
   const [modeAnchor, setModeAnchor] = useState<HTMLElement | null>(null);
   const [modelAnchor, setModelAnchor] = useState<HTMLElement | null>(null);
   const [effortAnchor, setEffortAnchor] = useState<HTMLElement | null>(null);
-  const [effort, setEffort] = useState('high');
 
   const currentMode = modesMap[mode];
   const FALLBACK_MODE = { ...FALLBACK_MODE_BASE, color: c.accent.primary };
@@ -1055,7 +1056,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
               key={opt.value}
               selected={effort === opt.value}
               onClick={() => {
-                setEffort(opt.value);
+                onEffortChange(opt.value);
                 setEffortAnchor(null);
               }}
             >

--- a/frontend/src/app/pages/AgentChat/ChatInput.tsx
+++ b/frontend/src/app/pages/AgentChat/ChatInput.tsx
@@ -95,7 +95,16 @@ const FALLBACK_MODE_BASE = { label: 'Agent', icon: ICON_MAP.smart_toy };
 const MODEL_OPTIONS = [
   { value: 'sonnet', label: 'Sonnet', version: '4.6' },
   { value: 'opus', label: 'Opus', version: '4.6' },
+  { value: 'opus-1m', label: 'Opus', version: '4.6 1M' },
   { value: 'haiku', label: 'Haiku', version: '3.5' },
+];
+
+const EFFORT_OPTIONS = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' },
 ];
 
 function formatTokenCount(n: number): string {
@@ -190,6 +199,8 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
 
   const [modeAnchor, setModeAnchor] = useState<HTMLElement | null>(null);
   const [modelAnchor, setModelAnchor] = useState<HTMLElement | null>(null);
+  const [effortAnchor, setEffortAnchor] = useState<HTMLElement | null>(null);
+  const [effort, setEffort] = useState('high');
 
   const currentMode = modesMap[mode];
   const FALLBACK_MODE = { ...FALLBACK_MODE_BASE, color: c.accent.primary };
@@ -1004,6 +1015,53 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
               <ListItemText
                 primary={`${opt.label} ${opt.version}`}
                 slotProps={{ primary: { sx: { fontSize: '0.8rem', color: model === opt.value ? c.text.primary : c.text.muted } } }}
+              />
+            </MenuItem>
+          ))}
+        </Menu>
+
+        <Box
+          onClick={(e) => setEffortAnchor(e.currentTarget)}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.25,
+            px: 0.75,
+            py: 0.25,
+            borderRadius: '6px',
+            cursor: 'pointer',
+            userSelect: 'none',
+            color: c.text.muted,
+            '&:hover': { bgcolor: 'rgba(0,0,0,0.04)' },
+            transition: 'background 0.15s',
+          }}
+        >
+          <Typography sx={{ fontSize: '0.75rem', fontWeight: 500, color: 'inherit', lineHeight: 1 }}>
+            {effort.charAt(0).toUpperCase() + effort.slice(1)}
+          </Typography>
+          <KeyboardArrowDownIcon sx={{ fontSize: 14, color: 'inherit', opacity: 0.7 }} />
+        </Box>
+
+        <Menu
+          anchorEl={effortAnchor}
+          open={Boolean(effortAnchor)}
+          onClose={() => setEffortAnchor(null)}
+          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          slotProps={{ paper: menuPaperProps }}
+        >
+          {EFFORT_OPTIONS.map((opt) => (
+            <MenuItem
+              key={opt.value}
+              selected={effort === opt.value}
+              onClick={() => {
+                setEffort(opt.value);
+                setEffortAnchor(null);
+              }}
+            >
+              <ListItemText
+                primary={opt.label}
+                slotProps={{ primary: { sx: { fontSize: '0.8rem', color: effort === opt.value ? c.text.primary : c.text.muted } } }}
               />
             </MenuItem>
           ))}

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -753,7 +753,7 @@ const AgentCard: React.FC<Props> = ({
               <Tooltip title="View Schedule">
                 <IconButton
                   size="small"
-                  onClick={() => onEditSchedule?.(session.schedule_id!)}
+                  onClick={(e) => { e.stopPropagation(); onEditSchedule?.(session.schedule_id!); }}
                   onMouseDown={(e) => e.stopPropagation()}
                   sx={{
                     color: c.accent.primary,

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -188,6 +188,7 @@ interface Props {
   autoFocusInput?: boolean;
   cardZOrder?: number;
   onBringToFront?: (id: string, type: 'agent' | 'view' | 'browser') => void;
+  onEditSchedule?: (scheduleId: string) => void;
 }
 
 const MIN_W = 480;
@@ -204,7 +205,7 @@ const SNAP_THRESHOLD = 60;
 const AgentCard: React.FC<Props> = ({
   session, expanded, cardX, cardY, cardWidth, cardHeight, zoom = 1, spawnFrom, exitTarget,
   isSelected = false, isHighlighted = false, multiDragDelta, onCardSelect, onDragStart, onDragMove, onDragEnd,
-  onBranch, onMeasuredHeight, snapColumn, autoFocusInput, cardZOrder = 0, onBringToFront,
+  onBranch, onMeasuredHeight, snapColumn, autoFocusInput, cardZOrder = 0, onBringToFront, onEditSchedule,
 }) => {
   const c = useClaudeTokens();
   const dispatch = useAppDispatch();
@@ -752,7 +753,7 @@ const AgentCard: React.FC<Props> = ({
               <Tooltip title="View Schedule">
                 <IconButton
                   size="small"
-                  onClick={() => { window.location.hash = `/schedules?edit=${session.schedule_id}`; }}
+                  onClick={() => onEditSchedule?.(session.schedule_id!)}
                   onMouseDown={(e) => e.stopPropagation()}
                   sx={{
                     color: c.accent.primary,

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -12,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import ScheduleIcon from '@mui/icons-material/Schedule';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import { motion } from 'framer-motion';
 import {
   AgentSession,
@@ -72,6 +73,13 @@ const GoogleServiceIcon: React.FC<{ service: string; size?: number }> = ({ servi
   }
   return null;
 };
+
+function truncatePath(p: string): string {
+  const sep = p.includes('\\') ? '\\' : '/';
+  const parts = p.split(sep).filter(Boolean);
+  if (parts.length <= 3) return p;
+  return parts[0] + sep + '...' + sep + parts.slice(-2).join(sep);
+}
 
 function formatDuration(createdAt: string): string {
   const seconds = Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000);
@@ -804,6 +812,18 @@ const AgentCard: React.FC<Props> = ({
             </Typography>
           )}
         </Box>
+
+        {/* Working directory */}
+        {session.cwd && (
+          <Tooltip title={session.cwd}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25, flexShrink: 0, overflow: 'hidden' }}>
+              <FolderOutlinedIcon sx={{ fontSize: 13, color: c.text.ghost, flexShrink: 0 }} />
+              <Typography variant="caption" sx={{ color: c.text.ghost, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.7rem' }}>
+                {truncatePath(session.cwd)}
+              </Typography>
+            </Box>
+          </Tooltip>
+        )}
       </Box>
 
       {/* Expanded: inline chat fills remaining space */}

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -11,6 +11,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import CloseIcon from '@mui/icons-material/Close';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import TerminalIcon from '@mui/icons-material/Terminal';
+import ScheduleIcon from '@mui/icons-material/Schedule';
 import { motion } from 'framer-motion';
 import {
   AgentSession,
@@ -747,6 +748,22 @@ const AgentCard: React.FC<Props> = ({
             onPointerDown={(e) => e.stopPropagation()}
             sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0, ml: 0.5 }}
           >
+            {session.schedule_id && (
+              <Tooltip title="View Schedule">
+                <IconButton
+                  size="small"
+                  onClick={() => { window.location.hash = `/schedules?edit=${session.schedule_id}`; }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  sx={{
+                    color: c.accent.primary,
+                    p: 0.5,
+                    '&:hover': { bgcolor: `${c.accent.primary}22` },
+                  }}
+                >
+                  <ScheduleIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+              </Tooltip>
+            )}
             <Tooltip title={isDraft ? 'Remove' : 'Close chat'}>
               <IconButton
                 size="small"

--- a/frontend/src/app/pages/Dashboard/AgentCard.tsx
+++ b/frontend/src/app/pages/Dashboard/AgentCard.tsx
@@ -34,6 +34,7 @@ import AgentChat from '@/app/pages/AgentChat/AgentChat';
 import { parseMcpToolName, getMcpShortAction } from '@/app/pages/AgentChat/ToolCallBubble';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
 import { useOverlayScrollPassthrough } from './useOverlayScrollPassthrough';
+import { API_BASE } from '@/shared/config';
 
 // ---------------------------------------------------------------------------
 // Helper components & functions (unchanged)
@@ -770,6 +771,30 @@ const AgentCard: React.FC<Props> = ({
                   }}
                 >
                   <ScheduleIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {!isDraft && session.sdk_session_id && (
+              <Tooltip title="Open in CLI">
+                <IconButton
+                  size="small"
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    const openswarm = (window as any).openswarm;
+                    if (openswarm?.openInCli) {
+                      await openswarm.openInCli(session.sdk_session_id, session.cwd);
+                    } else {
+                      await fetch(`${API_BASE}/agents/open-in-cli`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: session.id }) });
+                    }
+                  }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  sx={{
+                    color: c.text.ghost,
+                    p: '3px',
+                    '&:hover': { color: c.text.secondary },
+                  }}
+                >
+                  <TerminalIcon sx={{ fontSize: 16 }} />
                 </IconButton>
               </Tooltip>
             )}

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -54,6 +54,7 @@ import DashboardViewCard from './DashboardViewCard';
 import BrowserCard from './BrowserCard';
 import CanvasControls from './CanvasControls';
 import DashboardToolbar from './DashboardToolbar';
+import ScheduleEditor from '@/app/pages/Schedules/ScheduleEditor';
 import { captureDashboardThumbnail } from './captureDashboardThumbnail';
 import { useCanvasControls } from './useCanvasControls';
 import { useDashboardSelection } from './useDashboardSelection';
@@ -118,6 +119,7 @@ const DashboardInner: React.FC = () => {
 
   const [toolbarOpen, setToolbarOpen] = useState(false);
   const [highlightedCardId, setHighlightedCardId] = useState<string | null>(null);
+  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null);
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [autoFocusSessionId, setAutoFocusSessionId] = useState<string | null>(null);
   const [pendingSelectSessionId, setPendingSelectSessionId] = useState<string | null>(null);
@@ -1378,6 +1380,7 @@ const DashboardInner: React.FC = () => {
                   snapColumn={snapColumn}
                   autoFocusInput={autoFocusSessionId === session.id}
                   onBringToFront={handleBringToFront}
+                  onEditSchedule={setEditingScheduleId}
                 />
               );
             })}
@@ -1471,6 +1474,11 @@ const DashboardInner: React.FC = () => {
         <CanvasControls zoom={canvas.zoom} actions={canvas.actions} onTidy={handleTidy} />
       </Box>
     </Box>
+    <ScheduleEditor
+      open={editingScheduleId !== null}
+      scheduleId={editingScheduleId}
+      onClose={() => setEditingScheduleId(null)}
+    />
     </>
   );
 };

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -13,6 +13,7 @@ import {
   closeSession,
   duplicateSession,
   expandSession,
+  launchAgent,
   launchAndSendFirstMessage,
   generateTitle,
   resumeSession,
@@ -854,6 +855,31 @@ const DashboardInner: React.FC = () => {
     });
   }, [dispatch, canvas.actions, handleHighlightCard, setAutoFocusSessionId]);
 
+  const handleResumeCliSession = useCallback((cliSessionId: string, cwd: string, name: string) => {
+    const config: AgentConfig = {
+      name: name || `CLI ${cliSessionId.slice(0, 8)}`,
+      model: 'sonnet',
+      mode: 'agent',
+      dashboard_id: dashboardId,
+      target_directory: cwd || undefined,
+      resume_cli_session_id: cliSessionId,
+    };
+    dispatch(launchAgent(config)).then((action) => {
+      if (launchAgent.fulfilled.match(action)) {
+        const session = action.payload;
+        dispatch(expandSession(session.id));
+        setAutoFocusSessionId(session.id);
+        setTimeout(() => {
+          const card = store.getState().dashboardLayout.cards[session.id];
+          if (card) {
+            canvas.actions.fitToCards([{ x: card.x, y: card.y, width: card.width, height: card.height }], 1.0, true);
+            handleHighlightCard(session.id);
+          }
+        }, 200);
+      }
+    });
+  }, [dispatch, dashboardId, canvas.actions, handleHighlightCard, setAutoFocusSessionId]);
+
   const handleTidy = useCallback(() => {
     const currentExpanded = store.getState().agents.expandedSessionIds;
     dispatch(tidyLayout({ expandedSessionIds: currentExpanded }));
@@ -1466,6 +1492,7 @@ const DashboardInner: React.FC = () => {
           onSend={handleToolbarSend}
           onAddView={handleAddView}
           onHistoryResume={handleHistoryResume}
+          onResumeCliSession={handleResumeCliSession}
           onAddBrowser={handleAddBrowser}
           dashboardId={dashboardId}
         />

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -717,6 +717,7 @@ const DashboardInner: React.FC = () => {
       forcedTools?: string[],
       attachedSkills?: Array<{ id: string; name: string; content: string }>,
       selectedBrowserIds?: string[],
+      targetDirectory?: string,
     ) => {
       setToolbarOpen(false);
 
@@ -736,7 +737,7 @@ const DashboardInner: React.FC = () => {
         };
       }
 
-      const config: AgentConfig = { name: 'New chat', model, mode, dashboard_id: dashboardId };
+      const config: AgentConfig = { name: 'New chat', model, mode, dashboard_id: dashboardId, target_directory: targetDirectory };
 
       dispatch(
         launchAndSendFirstMessage({

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -712,6 +712,7 @@ const DashboardInner: React.FC = () => {
       prompt: string,
       mode: string,
       model: string,
+      effort: string,
       images?: Array<{ data: string; media_type: string }>,
       contextPaths?: ContextPath[],
       forcedTools?: string[],
@@ -737,7 +738,7 @@ const DashboardInner: React.FC = () => {
         };
       }
 
-      const config: AgentConfig = { name: 'New chat', model, mode, dashboard_id: dashboardId, target_directory: targetDirectory };
+      const config: AgentConfig = { name: 'New chat', model, mode, effort, dashboard_id: dashboardId, target_directory: targetDirectory };
 
       dispatch(
         launchAndSendFirstMessage({

--- a/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
+++ b/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
@@ -31,6 +31,7 @@ interface Props {
     prompt: string,
     mode: string,
     model: string,
+    effort: string,
     images?: Array<{ data: string; media_type: string }>,
     contextPaths?: ContextPath[],
     forcedTools?: string[],
@@ -97,6 +98,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
     const defaultModel = useAppSelector((s) => s.settings.data.default_model);
     const [mode, setMode] = useState(defaultMode || 'agent');
     const [model, setModel] = useState(defaultModel || 'sonnet');
+    const [effort, setEffort] = useState('high');
     const settingsApplied = useRef(false);
     useEffect(() => {
       if (!settingsApplied.current) {
@@ -145,9 +147,9 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
         attachedSkills?: Array<{ id: string; name: string; content: string }>,
         selectedBrowserIds?: string[],
       ) => {
-        onSend(message, mode, model, images, contextPaths, forcedTools, attachedSkills, selectedBrowserIds, selectedFolder || undefined);
+        onSend(message, mode, model, effort, images, contextPaths, forcedTools, attachedSkills, selectedBrowserIds, selectedFolder || undefined);
       },
-      [onSend, mode, model, selectedFolder],
+      [onSend, mode, model, effort, selectedFolder],
     );
 
     const handleCloseHistory = useCallback(() => {
@@ -368,6 +370,8 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
               onModeChange={setMode}
               model={model}
               onModelChange={setModel}
+              effort={effort}
+              onEffortChange={setEffort}
               embedded
               autoFocus
               sessionId={TOOLBAR_OWNER_ID}

--- a/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
+++ b/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
@@ -21,6 +21,7 @@ import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 import { searchHistory, clearHistorySearch } from '@/shared/state/agentsSlice';
 import type { ClaudeTokens } from '@/shared/styles/claudeTokens';
 import type { Output } from '@/shared/state/outputsSlice';
+import ToolbarStatusBar, { loadLastFolder } from './ToolbarStatusBar';
 
 interface Props {
   inputOpen: boolean;
@@ -35,6 +36,7 @@ interface Props {
     forcedTools?: string[],
     attachedSkills?: Array<{ id: string; name: string; content: string }>,
     selectedBrowserIds?: string[],
+    targetDirectory?: string,
   ) => void;
   onAddView: (outputId: string) => void;
   onHistoryResume: (sessionId: string) => void;
@@ -103,6 +105,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
         settingsApplied.current = true;
       }
     }, [defaultMode, defaultModel]);
+    const [selectedFolder, setSelectedFolder] = useState<string | null>(() => loadLastFolder());
     const [viewPickerOpen, setViewPickerOpen] = useState(false);
     const [viewSearch, setViewSearch] = useState('');
     const [historyOpen, setHistoryOpen] = useState(false);
@@ -142,9 +145,9 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
         attachedSkills?: Array<{ id: string; name: string; content: string }>,
         selectedBrowserIds?: string[],
       ) => {
-        onSend(message, mode, model, images, contextPaths, forcedTools, attachedSkills, selectedBrowserIds);
+        onSend(message, mode, model, images, contextPaths, forcedTools, attachedSkills, selectedBrowserIds, selectedFolder || undefined);
       },
-      [onSend, mode, model],
+      [onSend, mode, model, selectedFolder],
     );
 
     const handleCloseHistory = useCallback(() => {
@@ -354,7 +357,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
           padding: isExpanded ? '4px' : '6px',
           userSelect: 'none' as const,
           overflow: inputOpen ? 'visible' : 'hidden',
-          width: viewPickerOpen ? 480 : isExpanded ? 360 : undefined,
+          width: viewPickerOpen ? 480 : inputOpen ? 520 : isExpanded ? 360 : undefined,
         }}
       >
         {inputOpen ? (
@@ -369,6 +372,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
               autoFocus
               sessionId={TOOLBAR_OWNER_ID}
             />
+            <ToolbarStatusBar folder={selectedFolder} onFolderChange={setSelectedFolder} />
           </div>
         ) : historyOpen ? (
           <div style={{ width: '100%' }}>

--- a/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
+++ b/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
@@ -12,6 +12,9 @@ import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
 import HistoryRoundedIcon from '@mui/icons-material/HistoryRounded';
 import LanguageIcon from '@mui/icons-material/Language';
 import SearchIcon from '@mui/icons-material/Search';
+import TerminalIcon from '@mui/icons-material/Terminal';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import { motion } from 'framer-motion';
 import ChatInput from '@/app/pages/AgentChat/ChatInput';
 import type { ContextPath } from '@/app/components/DirectoryBrowser';
@@ -22,6 +25,7 @@ import { searchHistory, clearHistorySearch } from '@/shared/state/agentsSlice';
 import type { ClaudeTokens } from '@/shared/styles/claudeTokens';
 import type { Output } from '@/shared/state/outputsSlice';
 import ToolbarStatusBar, { loadLastFolder } from './ToolbarStatusBar';
+import { API_BASE } from '@/shared/config';
 
 interface Props {
   inputOpen: boolean;
@@ -41,6 +45,7 @@ interface Props {
   ) => void;
   onAddView: (outputId: string) => void;
   onHistoryResume: (sessionId: string) => void;
+  onResumeCliSession: (cliSessionId: string, cwd: string, name: string) => void;
   onAddBrowser: () => void;
   dashboardId?: string;
 }
@@ -86,7 +91,7 @@ function formatRelativeTime(dateStr: string | null): string {
 }
 
 const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
-  ({ inputOpen, onNewAgent, onCancel, onSend, onAddView, onHistoryResume, onAddBrowser, dashboardId }, ref) => {
+  ({ inputOpen, onNewAgent, onCancel, onSend, onAddView, onHistoryResume, onResumeCliSession, onAddBrowser, dashboardId }, ref) => {
     const c = useClaudeTokens();
     const dispatch = useAppDispatch();
     const elementSelection = useElementSelection();
@@ -112,6 +117,9 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
     const [viewSearch, setViewSearch] = useState('');
     const [historyOpen, setHistoryOpen] = useState(false);
     const [historyQuery, setHistoryQuery] = useState('');
+    const [showCliSessions, setShowCliSessions] = useState(false);
+    const [cliSessions, setCliSessions] = useState<any[]>([]);
+    const [cliLoading, setCliLoading] = useState(false);
     const shortcut = useAppSelector((s) => s.settings.data.new_agent_shortcut);
     const outputs = useAppSelector((s) => s.outputs.items);
     const historySearch = useAppSelector((s) => s.agents.historySearch);
@@ -155,6 +163,8 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
     const handleCloseHistory = useCallback(() => {
       setHistoryOpen(false);
       setHistoryQuery('');
+      setShowCliSessions(false);
+      setCliSessions([]);
       dispatch(clearHistorySearch());
     }, [dispatch]);
 
@@ -332,6 +342,19 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
       return () => clearTimeout(timer);
     }, [historyQuery, historyOpen, dispatch, dashboardId]);
 
+    useEffect(() => {
+      if (!showCliSessions || !historyOpen) { setCliSessions([]); return; }
+      setCliLoading(true);
+      const cwd = selectedFolder || '';
+      const params = new URLSearchParams({ cwd, limit: '50' });
+      if (historyQuery) params.set('q', historyQuery);
+      fetch(`${API_BASE}/agents/cli-sessions?${params}`)
+        .then((r) => r.json())
+        .then((data) => setCliSessions(data.sessions || []))
+        .catch(() => setCliSessions([]))
+        .finally(() => setCliLoading(false));
+    }, [showCliSessions, historyOpen, historyQuery, selectedFolder]);
+
     const handleHistoryScroll = useCallback(() => {
       const el = historyListRef.current;
       if (!el) return;
@@ -401,7 +424,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
             </Box>
             <Box
               ref={historyListRef}
-              onScroll={handleHistoryScroll}
+              onScroll={showCliSessions ? undefined : handleHistoryScroll}
               sx={{
                 maxHeight: 320,
                 overflow: 'auto',
@@ -413,23 +436,30 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
                 scrollbarColor: `${c.border.medium} transparent`,
               }}
             >
-              {historySearch.results.length === 0 && !historySearch.loading ? (
-                <Box sx={{ px: 2, py: 3, textAlign: 'center' }}>
-                  <Typography sx={{ fontSize: '0.82rem', color: c.text.muted }}>
-                    {historyQuery ? 'No matching chats' : 'No chat history yet'}
-                  </Typography>
-                </Box>
-              ) : (
-                <>
-                  {historySearch.results.map((entry) => (
+              {showCliSessions ? (
+                /* ── CLI sessions ── */
+                cliLoading ? (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+                    <CircularProgress size={16} sx={{ color: c.text.muted }} />
+                  </Box>
+                ) : cliSessions.length === 0 ? (
+                  <Box sx={{ px: 2, py: 3, textAlign: 'center' }}>
+                    <Typography sx={{ fontSize: '0.82rem', color: c.text.muted }}>
+                      {historyQuery ? 'No matching CLI sessions' : 'No CLI sessions found'}
+                    </Typography>
+                  </Box>
+                ) : (
+                  cliSessions.map((entry) => (
                     <Box
                       key={entry.id}
-                      onClick={() => handleHistorySelect(entry.id)}
+                      onClick={() => {
+                        onResumeCliSession(entry.id, entry.cwd || selectedFolder || '', entry.first_message || entry.id.slice(0, 8));
+                        handleCloseHistory();
+                      }}
                       sx={{
                         display: 'flex',
                         alignItems: 'center',
-                        justifyContent: 'space-between',
-                        gap: 1.5,
+                        gap: 1,
                         px: 1.5,
                         py: 0.9,
                         cursor: 'pointer',
@@ -437,6 +467,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
                         '&:hover': { bgcolor: c.bg.elevated },
                       }}
                     >
+                      <TerminalIcon sx={{ fontSize: 14, color: c.text.ghost, flexShrink: 0 }} />
                       <Typography
                         sx={{
                           fontSize: '0.82rem',
@@ -449,27 +480,126 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
                           minWidth: 0,
                         }}
                       >
-                        {entry.name}
+                        {entry.first_message || entry.id.slice(0, 8)}
                       </Typography>
-                      <Typography
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+                        <Tooltip title="Open in CLI" placement="top">
+                          <Box
+                            component="span"
+                            onClick={async (e: React.MouseEvent) => {
+                              e.stopPropagation();
+                              const openswarm = (window as any).openswarm;
+                              if (openswarm?.openInCli) {
+                                await openswarm.openInCli(entry.id, entry.cwd);
+                              } else {
+                                await fetch(`${API_BASE}/agents/open-in-cli`, {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({ cli_session_id: entry.id, cwd: entry.cwd }),
+                                });
+                              }
+                            }}
+                            sx={{
+                              display: 'inline-flex',
+                              cursor: 'pointer',
+                              borderRadius: '4px',
+                              p: '2px',
+                              '&:hover': { bgcolor: c.border.subtle },
+                            }}
+                          >
+                            <TerminalIcon sx={{ fontSize: 13, color: c.text.ghost }} />
+                          </Box>
+                        </Tooltip>
+                        <Typography sx={{ fontSize: '0.68rem', color: c.text.ghost }}>
+                          {entry.total_messages} msgs
+                        </Typography>
+                        {entry.in_openswarm && (
+                          <Typography sx={{ fontSize: '0.62rem', color: c.accent.primary, fontWeight: 600 }}>
+                            OS
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  ))
+                )
+              ) : (
+                /* ── OpenSwarm history ── */
+                historySearch.results.length === 0 && !historySearch.loading ? (
+                  <Box sx={{ px: 2, py: 3, textAlign: 'center' }}>
+                    <Typography sx={{ fontSize: '0.82rem', color: c.text.muted }}>
+                      {historyQuery ? 'No matching chats' : 'No chat history yet'}
+                    </Typography>
+                  </Box>
+                ) : (
+                  <>
+                    {historySearch.results.map((entry) => (
+                      <Box
+                        key={entry.id}
+                        onClick={() => handleHistorySelect(entry.id)}
                         sx={{
-                          fontSize: '0.7rem',
-                          color: c.text.ghost,
-                          flexShrink: 0,
-                          whiteSpace: 'nowrap',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: 1.5,
+                          px: 1.5,
+                          py: 0.9,
+                          cursor: 'pointer',
+                          transition: 'background-color 0.1s',
+                          '&:hover': { bgcolor: c.bg.elevated },
                         }}
                       >
-                        {formatRelativeTime(entry.closed_at)}
-                      </Typography>
-                    </Box>
-                  ))}
-                  {historySearch.loading && historySearch.results.length > 0 && (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 1.5 }}>
-                      <CircularProgress size={16} sx={{ color: c.text.muted }} />
-                    </Box>
-                  )}
-                </>
+                        <Typography
+                          sx={{
+                            fontSize: '0.82rem',
+                            fontWeight: 500,
+                            color: c.text.primary,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            flex: 1,
+                            minWidth: 0,
+                          }}
+                        >
+                          {entry.name}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            fontSize: '0.7rem',
+                            color: c.text.ghost,
+                            flexShrink: 0,
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {formatRelativeTime(entry.closed_at)}
+                        </Typography>
+                      </Box>
+                    ))}
+                    {historySearch.loading && historySearch.results.length > 0 && (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', py: 1.5 }}>
+                        <CircularProgress size={16} sx={{ color: c.text.muted }} />
+                      </Box>
+                    )}
+                  </>
+                )
               )}
+            </Box>
+            <Box sx={{ borderTop: `1px solid ${c.border.subtle}`, px: 1.5, py: 0.5 }}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={showCliSessions}
+                    onChange={(e) => setShowCliSessions(e.target.checked)}
+                    sx={{ p: 0.5, '& .MuiSvgIcon-root': { fontSize: 16 } }}
+                  />
+                }
+                label={
+                  <Typography sx={{ fontSize: '0.75rem', color: c.text.muted }}>
+                    Show CLI sessions {selectedFolder ? `in ${selectedFolder.split(/[\\/]/).pop()}` : ''}
+                  </Typography>
+                }
+                sx={{ mx: 0 }}
+              />
             </Box>
           </div>
         ) : viewPickerOpen ? (

--- a/frontend/src/app/pages/Dashboard/ToolbarStatusBar.tsx
+++ b/frontend/src/app/pages/Dashboard/ToolbarStatusBar.tsx
@@ -1,0 +1,471 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Popover from '@mui/material/Popover';
+import Checkbox from '@mui/material/Checkbox';
+import InputBase from '@mui/material/InputBase';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import AddIcon from '@mui/icons-material/Add';
+import CheckIcon from '@mui/icons-material/Check';
+import SearchIcon from '@mui/icons-material/Search';
+import ComputerIcon from '@mui/icons-material/Computer';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import { API_BASE } from '@/shared/config';
+
+const LS_FOLDER_KEY = 'openswarm:lastFolder';
+const LS_RECENT_KEY = 'openswarm:recentFolders';
+const MAX_RECENT = 8;
+
+interface GitInfo {
+  is_git: boolean;
+  branch?: string;
+  branches?: string[];
+  remote_url?: string;
+  repo_name?: string;
+}
+
+interface Props {
+  folder: string | null;
+  onFolderChange: (folder: string) => void;
+}
+
+function folderDisplayName(p: string): string {
+  const sep = p.includes('\\') ? '\\' : '/';
+  const parts = p.split(sep).filter(Boolean);
+  return parts[parts.length - 1] || p;
+}
+
+function truncatePath(p: string, maxLen = 50): string {
+  if (p.length <= maxLen) return p;
+  const sep = p.includes('\\') ? '\\' : '/';
+  const parts = p.split(sep).filter(Boolean);
+  if (parts.length <= 2) return p;
+  return parts[0] + sep + '...' + sep + parts.slice(-2).join(sep);
+}
+
+export function loadLastFolder(): string | null {
+  try {
+    return localStorage.getItem(LS_FOLDER_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function loadRecentFolders(): string[] {
+  try {
+    const raw = localStorage.getItem(LS_RECENT_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveFolder(folder: string) {
+  try {
+    localStorage.setItem(LS_FOLDER_KEY, folder);
+    const recent = loadRecentFolders().filter((f) => f !== folder);
+    recent.unshift(folder);
+    localStorage.setItem(LS_RECENT_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  } catch {
+    // ignore
+  }
+}
+
+const BranchIcon: React.FC<{ size?: number; color?: string }> = ({ size = 14, color }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+    <circle cx="5" cy="4" r="1.5" stroke={color} strokeWidth="1.3" />
+    <circle cx="5" cy="12" r="1.5" stroke={color} strokeWidth="1.3" />
+    <circle cx="11" cy="7" r="1.5" stroke={color} strokeWidth="1.3" />
+    <path d="M5 5.5V10.5" stroke={color} strokeWidth="1.3" />
+    <path d="M5 5.5C5 5.5 5 7 7 7H9.5" stroke={color} strokeWidth="1.3" />
+  </svg>
+);
+
+const ToolbarStatusBar: React.FC<Props> = ({ folder, onFolderChange }) => {
+  const c = useClaudeTokens();
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
+  const [folderAnchor, setFolderAnchor] = useState<HTMLElement | null>(null);
+  const [branchAnchor, setBranchAnchor] = useState<HTMLElement | null>(null);
+  const [envAnchor, setEnvAnchor] = useState<HTMLElement | null>(null);
+  const [branchSearch, setBranchSearch] = useState('');
+  const [worktree, setWorktree] = useState(false);
+  const branchSearchRef = useRef<HTMLInputElement>(null);
+
+  // Fetch git info when folder changes
+  useEffect(() => {
+    if (!folder) {
+      setGitInfo(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${API_BASE}/settings/git-info?path=${encodeURIComponent(folder)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled) setGitInfo(data);
+      })
+      .catch(() => {
+        if (!cancelled) setGitInfo(null);
+      });
+    return () => { cancelled = true; };
+  }, [folder]);
+
+  useEffect(() => {
+    if (branchAnchor) {
+      setTimeout(() => branchSearchRef.current?.focus(), 60);
+    }
+  }, [branchAnchor]);
+
+  const recentFolders = loadRecentFolders();
+
+  const handlePickFolder = useCallback(async () => {
+    setFolderAnchor(null);
+    const openswarm = (window as any).openswarm;
+    if (openswarm?.showFolderDialog) {
+      const picked = await openswarm.showFolderDialog(folder || undefined);
+      if (picked) {
+        saveFolder(picked);
+        onFolderChange(picked);
+      }
+    } else {
+      // Fallback: prompt
+      const input = window.prompt('Enter folder path:', folder || '');
+      if (input) {
+        saveFolder(input);
+        onFolderChange(input);
+      }
+    }
+  }, [folder, onFolderChange]);
+
+  const handleSelectRecent = useCallback(
+    (f: string) => {
+      setFolderAnchor(null);
+      saveFolder(f);
+      onFolderChange(f);
+    },
+    [onFolderChange],
+  );
+
+  const handleSelectBranch = useCallback(
+    (branch: string) => {
+      setBranchAnchor(null);
+      setBranchSearch('');
+      if (!folder) return;
+      fetch(`${API_BASE}/settings/git-checkout`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: folder, branch }),
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.success) {
+            setGitInfo((prev) => (prev ? { ...prev, branch } : prev));
+          }
+        })
+        .catch(() => {});
+    },
+    [folder],
+  );
+
+  const filteredBranches = (gitInfo?.branches || []).filter((b) =>
+    !branchSearch || b.toLowerCase().includes(branchSearch.toLowerCase()),
+  );
+
+  const itemSx = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 0.75,
+    px: 1.25,
+    py: 0.5,
+    cursor: 'pointer',
+    borderRadius: `${c.radius.sm}px`,
+    transition: 'background-color 0.1s',
+    '&:hover': { bgcolor: c.bg.elevated },
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        px: 1.5,
+        py: 0.5,
+        borderTop: `1px solid ${c.border.subtle}`,
+        minHeight: 30,
+      }}
+    >
+      {/* Left side: folder + git branch */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0, flex: 1 }}>
+        {/* Folder display */}
+        <Box
+          onClick={(e) => setFolderAnchor(e.currentTarget)}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            cursor: 'pointer',
+            borderRadius: `${c.radius.sm}px`,
+            px: 0.75,
+            py: 0.25,
+            '&:hover': { bgcolor: c.bg.secondary },
+            minWidth: 0,
+          }}
+        >
+          <FolderOutlinedIcon sx={{ fontSize: 14, color: c.text.ghost, flexShrink: 0 }} />
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: c.text.muted,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: 240,
+            }}
+          >
+            {folder ? folderDisplayName(folder) : 'Select folder...'}
+          </Typography>
+        </Box>
+
+        {/* Git branch display */}
+        {gitInfo?.is_git && (
+          <Box
+            onClick={(e) => setBranchAnchor(e.currentTarget)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.4,
+              cursor: 'pointer',
+              borderRadius: `${c.radius.sm}px`,
+              px: 0.75,
+              py: 0.25,
+              '&:hover': { bgcolor: c.bg.secondary },
+            }}
+          >
+            <BranchIcon size={14} color={c.text.ghost} />
+            <Typography sx={{ fontSize: '0.75rem', color: c.text.muted }}>
+              {gitInfo.branch || 'HEAD'}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      {/* Right side: worktree + environment */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.25,
+            cursor: 'pointer',
+            borderRadius: `${c.radius.sm}px`,
+            px: 0.5,
+            py: 0.25,
+            '&:hover': { bgcolor: c.bg.secondary },
+          }}
+          onClick={() => setWorktree(!worktree)}
+        >
+          <Checkbox
+            checked={worktree}
+            size="small"
+            sx={{
+              p: 0,
+              color: c.text.ghost,
+              '&.Mui-checked': { color: c.accent.primary },
+              '& .MuiSvgIcon-root': { fontSize: 16 },
+            }}
+          />
+          <Typography sx={{ fontSize: '0.72rem', color: c.text.muted }}>worktree</Typography>
+        </Box>
+
+        <Box
+          onClick={(e) => setEnvAnchor(e.currentTarget)}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.4,
+            cursor: 'pointer',
+            borderRadius: `${c.radius.sm}px`,
+            px: 0.75,
+            py: 0.25,
+            '&:hover': { bgcolor: c.bg.secondary },
+          }}
+        >
+          <ComputerIcon sx={{ fontSize: 14, color: c.text.ghost }} />
+          <Typography sx={{ fontSize: '0.72rem', color: c.text.muted }}>Local</Typography>
+          <Typography sx={{ fontSize: '0.6rem', color: c.text.ghost, ml: -0.25 }}>▾</Typography>
+        </Box>
+      </Box>
+
+      {/* Folder Picker Popover */}
+      <Popover
+        open={!!folderAnchor}
+        anchorEl={folderAnchor}
+        onClose={() => setFolderAnchor(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              bgcolor: c.bg.surface,
+              border: `1px solid ${c.border.subtle}`,
+              borderRadius: `${c.radius.lg}px`,
+              boxShadow: c.shadow.lg,
+              minWidth: 280,
+              maxWidth: 400,
+              py: 0.5,
+            },
+          },
+        }}
+      >
+        {recentFolders.length > 0 && (
+          <>
+            <Typography
+              sx={{ fontSize: '0.7rem', color: c.text.ghost, fontWeight: 600, px: 1.5, py: 0.5, textTransform: 'uppercase', letterSpacing: '0.05em' }}
+            >
+              Recent
+            </Typography>
+            {recentFolders.map((f) => (
+              <Box key={f} onClick={() => handleSelectRecent(f)} sx={itemSx}>
+                <FolderOutlinedIcon sx={{ fontSize: 14, color: c.text.ghost, flexShrink: 0 }} />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography sx={{ fontSize: '0.8rem', color: c.text.primary, fontWeight: 500 }}>
+                    {folderDisplayName(f)}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.68rem',
+                      color: c.text.ghost,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {truncatePath(f)}
+                  </Typography>
+                </Box>
+                {f === folder && <CheckIcon sx={{ fontSize: 16, color: c.accent.primary, flexShrink: 0 }} />}
+              </Box>
+            ))}
+            <Box sx={{ borderTop: `1px solid ${c.border.subtle}`, my: 0.5 }} />
+          </>
+        )}
+        <Box onClick={handlePickFolder} sx={itemSx}>
+          <AddIcon sx={{ fontSize: 16, color: c.text.muted }} />
+          <Typography sx={{ fontSize: '0.8rem', color: c.text.primary }}>
+            Choose a different folder
+          </Typography>
+        </Box>
+      </Popover>
+
+      {/* Branch Picker Popover */}
+      <Popover
+        open={!!branchAnchor}
+        anchorEl={branchAnchor}
+        onClose={() => { setBranchAnchor(null); setBranchSearch(''); }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              bgcolor: c.bg.surface,
+              border: `1px solid ${c.border.subtle}`,
+              borderRadius: `${c.radius.lg}px`,
+              boxShadow: c.shadow.lg,
+              minWidth: 240,
+              maxWidth: 340,
+              py: 0.5,
+            },
+          },
+        }}
+      >
+        <Box sx={{ px: 1, py: 0.5 }}>
+          <InputBase
+            inputRef={branchSearchRef}
+            value={branchSearch}
+            onChange={(e) => setBranchSearch(e.target.value)}
+            placeholder="Search branches"
+            sx={{
+              width: '100%',
+              fontSize: '0.82rem',
+              color: c.text.primary,
+              fontFamily: c.font.sans,
+              border: `1px solid ${c.border.medium}`,
+              borderRadius: `${c.radius.sm}px`,
+              px: 1,
+              py: 0.25,
+              '& input::placeholder': { color: c.text.ghost, opacity: 1 },
+            }}
+          />
+        </Box>
+        <Box sx={{ maxHeight: 240, overflow: 'auto', py: 0.25 }}>
+          {filteredBranches.map((b) => (
+            <Box key={b} onClick={() => handleSelectBranch(b)} sx={itemSx}>
+              <Typography sx={{ fontSize: '0.8rem', color: c.text.primary, flex: 1 }}>{b}</Typography>
+              {b === gitInfo?.branch && <CheckIcon sx={{ fontSize: 16, color: c.accent.primary }} />}
+            </Box>
+          ))}
+          {filteredBranches.length === 0 && (
+            <Typography sx={{ fontSize: '0.78rem', color: c.text.ghost, px: 1.5, py: 1, textAlign: 'center' }}>
+              No branches found
+            </Typography>
+          )}
+        </Box>
+      </Popover>
+
+      {/* Environment Popover */}
+      <Popover
+        open={!!envAnchor}
+        anchorEl={envAnchor}
+        onClose={() => setEnvAnchor(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: {
+              bgcolor: c.bg.surface,
+              border: `1px solid ${c.border.subtle}`,
+              borderRadius: `${c.radius.lg}px`,
+              boxShadow: c.shadow.lg,
+              minWidth: 220,
+              py: 0.5,
+            },
+          },
+        }}
+      >
+        <Box onClick={() => setEnvAnchor(null)} sx={itemSx}>
+          <ComputerIcon sx={{ fontSize: 14, color: c.text.ghost }} />
+          <Typography sx={{ fontSize: '0.8rem', color: c.text.primary, flex: 1 }}>Local</Typography>
+          <CheckIcon sx={{ fontSize: 16, color: c.accent.primary }} />
+        </Box>
+        <Box sx={itemSx} onClick={() => setEnvAnchor(null)}>
+          <AddIcon sx={{ fontSize: 16, color: c.text.muted }} />
+          <Box>
+            <Typography sx={{ fontSize: '0.8rem', color: c.text.primary }}>Add SSH connection</Typography>
+          </Box>
+        </Box>
+        <Box sx={{ borderTop: `1px solid ${c.border.subtle}`, my: 0.5 }} />
+        <Typography
+          sx={{ fontSize: '0.7rem', color: c.text.ghost, fontWeight: 600, px: 1.5, py: 0.25, textTransform: 'uppercase', letterSpacing: '0.05em' }}
+        >
+          Remote control
+        </Typography>
+        <Box sx={itemSx} onClick={() => setEnvAnchor(null)}>
+          <AddIcon sx={{ fontSize: 16, color: c.text.muted }} />
+          <Typography sx={{ fontSize: '0.8rem', color: c.text.primary }}>Add remote control</Typography>
+        </Box>
+        <Box sx={{ borderTop: `1px solid ${c.border.subtle}`, my: 0.5 }} />
+        <Typography
+          sx={{ fontSize: '0.7rem', color: c.text.ghost, fontWeight: 600, px: 1.5, py: 0.25, textTransform: 'uppercase', letterSpacing: '0.05em' }}
+        >
+          Cloud environments
+        </Typography>
+        <Box sx={itemSx} onClick={() => setEnvAnchor(null)}>
+          <AddIcon sx={{ fontSize: 16, color: c.text.muted }} />
+          <Typography sx={{ fontSize: '0.8rem', color: c.text.primary }}>Add environment</Typography>
+        </Box>
+      </Popover>
+    </Box>
+  );
+};
+
+export default ToolbarStatusBar;

--- a/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
+++ b/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
@@ -8,6 +8,9 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 import { createSchedule, updateSchedule, fetchSchedules } from '@/shared/state/schedulesSlice';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
@@ -51,6 +54,7 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
   const [model, setModel] = useState('sonnet');
   const [mode, setMode] = useState('agent');
   const [systemPrompt, setSystemPrompt] = useState('');
+  const [targetDirectory, setTargetDirectory] = useState('');
   const [configSource, setConfigSource] = useState<'template' | 'inline'>('inline');
 
   useEffect(() => {
@@ -68,6 +72,7 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
       setModel(existing.model || 'sonnet');
       setMode(existing.mode || 'agent');
       setSystemPrompt(existing.system_prompt || '');
+      setTargetDirectory(existing.target_directory || '');
       setConfigSource(existing.template_id ? 'template' : 'inline');
     } else {
       setName('');
@@ -83,6 +88,7 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
       setModel('sonnet');
       setMode('agent');
       setSystemPrompt('');
+      setTargetDirectory('');
       setConfigSource('inline');
     }
   }, [existing, open]);
@@ -120,6 +126,8 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
       body.mode = mode;
       if (systemPrompt) body.system_prompt = systemPrompt;
     }
+
+    if (targetDirectory) body.target_directory = targetDirectory;
 
     if (scheduleId) {
       await dispatch(updateSchedule({ id: scheduleId, ...body }));
@@ -207,6 +215,37 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
           />
         )}
 
+        <TextField
+          label="Working Directory"
+          value={targetDirectory}
+          onChange={(e) => setTargetDirectory(e.target.value)}
+          fullWidth
+          size="small"
+          sx={inputSx}
+          placeholder="Leave empty for default"
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    onClick={async () => {
+                      const openswarm = (window as any).openswarm;
+                      if (openswarm?.showFolderDialog) {
+                        const picked = await openswarm.showFolderDialog(targetDirectory || undefined);
+                        if (picked) setTargetDirectory(picked);
+                      }
+                    }}
+                    sx={{ color: c.text.muted }}
+                  >
+                    <FolderOpenIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+
         {actionType === 'new_session' && (
           <>
             <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Agent Config</Typography>
@@ -236,9 +275,10 @@ const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
                   onChange={(e) => setModel(e.target.value)} fullWidth size="small" sx={inputSx}
                   SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
                 >
-                  <MenuItem value="sonnet">Sonnet</MenuItem>
-                  <MenuItem value="haiku">Haiku</MenuItem>
-                  <MenuItem value="opus">Opus</MenuItem>
+                  <MenuItem value="sonnet">Sonnet 4.6</MenuItem>
+                  <MenuItem value="opus">Opus 4.6</MenuItem>
+                  <MenuItem value="opus-1m">Opus 4.6 1M</MenuItem>
+                  <MenuItem value="haiku">Haiku 3.5</MenuItem>
                 </TextField>
 
                 <TextField

--- a/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
+++ b/frontend/src/app/pages/Schedules/ScheduleEditor.tsx
@@ -1,0 +1,269 @@
+import React, { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import { createSchedule, updateSchedule, fetchSchedules } from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+
+interface Props {
+  open: boolean;
+  scheduleId: string | null;
+  onClose: () => void;
+}
+
+const TRIGGER_TYPES = [
+  { value: 'cron', label: 'Cron Expression' },
+  { value: 'interval', label: 'Interval' },
+  { value: 'once', label: 'One-shot' },
+];
+
+const ACTION_TYPES = [
+  { value: 'new_session', label: 'Create New Session' },
+  { value: 'message_existing', label: 'Message Existing Session' },
+];
+
+const ScheduleEditor: React.FC<Props> = ({ open, scheduleId, onClose }) => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const existing = useAppSelector((s) => scheduleId ? s.schedules.items[scheduleId] : null);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const templates = useAppSelector((s) => s.templates.items);
+  const dashboardList = Object.values(dashboards);
+  const templateList = Object.values(templates);
+
+  const [name, setName] = useState('');
+  const [dashboardId, setDashboardId] = useState('');
+  const [triggerType, setTriggerType] = useState('cron');
+  const [cronExpression, setCronExpression] = useState('');
+  const [intervalSeconds, setIntervalSeconds] = useState(3600);
+  const [runAt, setRunAt] = useState('');
+  const [actionType, setActionType] = useState('new_session');
+  const [prompt, setPrompt] = useState('');
+  const [targetSessionId, setTargetSessionId] = useState('');
+  const [templateId, setTemplateId] = useState('');
+  const [model, setModel] = useState('sonnet');
+  const [mode, setMode] = useState('agent');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [configSource, setConfigSource] = useState<'template' | 'inline'>('inline');
+
+  useEffect(() => {
+    if (existing) {
+      setName(existing.name);
+      setDashboardId(existing.dashboard_id);
+      setTriggerType(existing.trigger_type);
+      setCronExpression(existing.cron_expression || '');
+      setIntervalSeconds(existing.interval_seconds || 3600);
+      setRunAt(existing.run_at || '');
+      setActionType(existing.action_type);
+      setPrompt(existing.prompt);
+      setTargetSessionId(existing.target_session_id || '');
+      setTemplateId(existing.template_id || '');
+      setModel(existing.model || 'sonnet');
+      setMode(existing.mode || 'agent');
+      setSystemPrompt(existing.system_prompt || '');
+      setConfigSource(existing.template_id ? 'template' : 'inline');
+    } else {
+      setName('');
+      setDashboardId(dashboardList[0]?.id || '');
+      setTriggerType('cron');
+      setCronExpression('');
+      setIntervalSeconds(3600);
+      setRunAt('');
+      setActionType('new_session');
+      setPrompt('');
+      setTargetSessionId('');
+      setTemplateId('');
+      setModel('sonnet');
+      setMode('agent');
+      setSystemPrompt('');
+      setConfigSource('inline');
+    }
+  }, [existing, open]);
+
+  const inputSx = {
+    '& .MuiOutlinedInput-root': {
+      color: c.text.primary,
+      '& fieldset': { borderColor: c.border.strong },
+      '&:hover fieldset': { borderColor: c.text.tertiary },
+      '&.Mui-focused fieldset': { borderColor: c.accent.primary },
+    },
+    '& .MuiInputLabel-root': { color: c.text.tertiary },
+    '& .MuiInputLabel-root.Mui-focused': { color: c.accent.primary },
+  };
+
+  const handleSave = async () => {
+    const body: any = {
+      name: name || 'Untitled Schedule',
+      dashboard_id: dashboardId,
+      trigger_type: triggerType,
+      action_type: actionType,
+      prompt,
+    };
+
+    if (triggerType === 'cron') body.cron_expression = cronExpression;
+    if (triggerType === 'interval') body.interval_seconds = intervalSeconds;
+    if (triggerType === 'once') body.run_at = runAt;
+
+    if (actionType === 'message_existing') {
+      body.target_session_id = targetSessionId;
+    } else if (configSource === 'template') {
+      body.template_id = templateId;
+    } else {
+      body.model = model;
+      body.mode = mode;
+      if (systemPrompt) body.system_prompt = systemPrompt;
+    }
+
+    if (scheduleId) {
+      await dispatch(updateSchedule({ id: scheduleId, ...body }));
+    } else {
+      await dispatch(createSchedule(body));
+    }
+
+    dispatch(fetchSchedules());
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { bgcolor: c.bg.surface, borderRadius: 4, border: `1px solid ${c.border.subtle}` } }}
+    >
+      <DialogTitle sx={{ color: c.text.primary, fontWeight: 700 }}>
+        {scheduleId ? 'Edit Schedule' : 'New Schedule'}
+      </DialogTitle>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} fullWidth size="small" sx={inputSx} />
+
+        <TextField
+          select label="Dashboard" value={dashboardId}
+          onChange={(e) => setDashboardId(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {dashboardList.map((d) => <MenuItem key={d.id} value={d.id}>{d.name}</MenuItem>)}
+        </TextField>
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Trigger</Typography>
+
+        <TextField
+          select label="Type" value={triggerType}
+          onChange={(e) => setTriggerType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {TRIGGER_TYPES.map((t) => <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>)}
+        </TextField>
+
+        {triggerType === 'cron' && (
+          <TextField
+            label="Cron Expression" value={cronExpression}
+            onChange={(e) => setCronExpression(e.target.value)} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 0 9 * * * (every day at 9am)"
+          />
+        )}
+        {triggerType === 'interval' && (
+          <TextField
+            label="Interval (seconds)" type="number" value={intervalSeconds}
+            onChange={(e) => setIntervalSeconds(Number(e.target.value))} fullWidth size="small" sx={inputSx}
+            helperText="e.g. 3600 = every hour"
+          />
+        )}
+        {triggerType === 'once' && (
+          <TextField
+            label="Run At" type="datetime-local" value={runAt}
+            onChange={(e) => setRunAt(e.target.value)} fullWidth size="small" sx={inputSx}
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
+        )}
+
+        <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Action</Typography>
+
+        <TextField
+          select label="Action Type" value={actionType}
+          onChange={(e) => setActionType(e.target.value)} fullWidth size="small" sx={inputSx}
+          SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+        >
+          {ACTION_TYPES.map((a) => <MenuItem key={a.value} value={a.value}>{a.label}</MenuItem>)}
+        </TextField>
+
+        <TextField
+          label="Prompt" value={prompt} onChange={(e) => setPrompt(e.target.value)}
+          fullWidth size="small" multiline minRows={3} sx={inputSx}
+        />
+
+        {actionType === 'message_existing' && (
+          <TextField
+            label="Target Session ID" value={targetSessionId}
+            onChange={(e) => setTargetSessionId(e.target.value)} fullWidth size="small" sx={inputSx}
+          />
+        )}
+
+        {actionType === 'new_session' && (
+          <>
+            <Typography variant="subtitle2" sx={{ color: c.text.secondary, mt: 1 }}>Agent Config</Typography>
+
+            <TextField
+              select label="Config Source" value={configSource}
+              onChange={(e) => setConfigSource(e.target.value as 'template' | 'inline')}
+              fullWidth size="small" sx={inputSx}
+              SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+            >
+              <MenuItem value="inline">Configure Inline</MenuItem>
+              <MenuItem value="template">Use Template</MenuItem>
+            </TextField>
+
+            {configSource === 'template' ? (
+              <TextField
+                select label="Template" value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)} fullWidth size="small" sx={inputSx}
+                SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+              >
+                {templateList.map((t) => <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>)}
+              </TextField>
+            ) : (
+              <>
+                <TextField
+                  select label="Model" value={model}
+                  onChange={(e) => setModel(e.target.value)} fullWidth size="small" sx={inputSx}
+                  SelectProps={{ MenuProps: { PaperProps: { sx: { bgcolor: c.bg.surface } } } }}
+                >
+                  <MenuItem value="sonnet">Sonnet</MenuItem>
+                  <MenuItem value="haiku">Haiku</MenuItem>
+                  <MenuItem value="opus">Opus</MenuItem>
+                </TextField>
+
+                <TextField
+                  label="Mode" value={mode}
+                  onChange={(e) => setMode(e.target.value)} fullWidth size="small" sx={inputSx}
+                />
+
+                <TextField
+                  label="System Prompt (optional)" value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  fullWidth size="small" multiline minRows={2} sx={inputSx}
+                />
+              </>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ color: c.text.muted }}>Cancel</Button>
+        <Button variant="contained" onClick={handleSave} disabled={!prompt || !dashboardId} sx={{ bgcolor: c.accent.primary }}>
+          {scheduleId ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ScheduleEditor;

--- a/frontend/src/app/pages/Schedules/Schedules.tsx
+++ b/frontend/src/app/pages/Schedules/Schedules.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -59,10 +60,22 @@ const Schedules: React.FC = () => {
     (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
   );
 
+  const location = useLocation();
+
   useEffect(() => {
     dispatch(fetchSchedules());
     dispatch(clearUnread());
   }, [dispatch]);
+
+  // Auto-open editor when navigated with ?edit=<schedule_id>
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const editId = params.get('edit');
+    if (editId) {
+      setEditingId(editId);
+      setEditorOpen(true);
+    }
+  }, [location.search]);
 
   const handleEdit = (id: string) => {
     setEditingId(id);

--- a/frontend/src/app/pages/Schedules/Schedules.tsx
+++ b/frontend/src/app/pages/Schedules/Schedules.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import {
+  fetchSchedules,
+  deleteSchedule,
+  toggleSchedule,
+  clearUnread,
+  Schedule,
+} from '@/shared/state/schedulesSlice';
+import { useClaudeTokens } from '@/shared/styles/ThemeContext';
+import ScheduleEditor from './ScheduleEditor';
+
+function formatTrigger(s: Schedule): string {
+  if (s.trigger_type === 'cron' && s.cron_expression) return `Cron: ${s.cron_expression}`;
+  if (s.trigger_type === 'interval' && s.interval_seconds) {
+    if (s.interval_seconds >= 3600) return `Every ${Math.round(s.interval_seconds / 3600)}h`;
+    if (s.interval_seconds >= 60) return `Every ${Math.round(s.interval_seconds / 60)}m`;
+    return `Every ${s.interval_seconds}s`;
+  }
+  if (s.trigger_type === 'once' && s.run_at) return `Once: ${new Date(s.run_at).toLocaleString()}`;
+  return s.trigger_type;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+const Schedules: React.FC = () => {
+  const c = useClaudeTokens();
+  const dispatch = useAppDispatch();
+  const items = useAppSelector((s) => s.schedules.items);
+  const dashboards = useAppSelector((s) => s.dashboards.items);
+  const loading = useAppSelector((s) => s.schedules.loading);
+  const [editorOpen, setEditorOpen] = React.useState(false);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [deleteError, setDeleteError] = React.useState<string | null>(null);
+
+  const scheduleList = Object.values(items).sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+  );
+
+  useEffect(() => {
+    dispatch(fetchSchedules());
+    dispatch(clearUnread());
+  }, [dispatch]);
+
+  const handleEdit = (id: string) => {
+    setEditingId(id);
+    setEditorOpen(true);
+  };
+
+  const handleCreate = () => {
+    setEditingId(null);
+    setEditorOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await dispatch(deleteSchedule(id)).unwrap();
+    } catch (e: any) {
+      setDeleteError(e.message || 'Failed to delete schedule');
+    }
+  };
+
+  const handleToggle = (id: string) => {
+    dispatch(toggleSchedule(id));
+  };
+
+  return (
+    <Box sx={{ width: '100%', height: '100%', bgcolor: c.bg.page, color: c.text.primary, p: 3, overflow: 'auto' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>Schedules</Typography>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreate} sx={{ bgcolor: c.accent.primary }}>
+          New Schedule
+        </Button>
+      </Box>
+
+      {scheduleList.length === 0 && !loading ? (
+        <Typography sx={{ color: c.text.muted }}>No schedules yet. Create one to get started.</Typography>
+      ) : (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Trigger</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Dashboard</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Next Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Last Run</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }}>Runs</TableCell>
+                <TableCell sx={{ color: c.text.secondary, fontWeight: 600 }} align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {scheduleList.map((s) => (
+                <TableRow key={s.id} hover>
+                  <TableCell sx={{ color: c.text.primary }}>{s.name}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatTrigger(s)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>
+                    {dashboards[s.dashboard_id]?.name || s.dashboard_id.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>
+                    {s.last_error ? (
+                      <Tooltip title={s.last_error}>
+                        <Chip label="Error" size="small" sx={{ bgcolor: c.status.errorBg, color: c.status.error, fontWeight: 600 }} />
+                      </Tooltip>
+                    ) : s.enabled ? (
+                      <Chip label="Active" size="small" sx={{ bgcolor: c.status.successBg, color: c.status.success, fontWeight: 600 }} />
+                    ) : (
+                      <Chip label="Paused" size="small" sx={{ bgcolor: c.status.warningBg, color: c.status.warning, fontWeight: 600 }} />
+                    )}
+                  </TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.next_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted, fontSize: '0.85rem' }}>{formatDate(s.last_run_at)}</TableCell>
+                  <TableCell sx={{ color: c.text.muted }}>{s.run_count}</TableCell>
+                  <TableCell align="right">
+                    <Tooltip title={s.enabled ? 'Pause' : 'Resume'}>
+                      <IconButton size="small" onClick={() => handleToggle(s.id)} sx={{ color: c.text.muted }}>
+                        {s.enabled ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Edit">
+                      <IconButton size="small" onClick={() => handleEdit(s.id)} sx={{ color: c.text.muted }}>
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Delete">
+                      <IconButton size="small" onClick={() => handleDelete(s.id)} sx={{ color: c.text.muted }}>
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <ScheduleEditor
+        open={editorOpen}
+        scheduleId={editingId}
+        onClose={() => { setEditorOpen(false); setEditingId(null); }}
+      />
+
+      <Snackbar open={!!deleteError} autoHideDuration={4000} onClose={() => setDeleteError(null)}>
+        <Alert severity="error" onClose={() => setDeleteError(null)}>{deleteError}</Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default Schedules;

--- a/frontend/src/app/pages/Settings/Settings.tsx
+++ b/frontend/src/app/pages/Settings/Settings.tsx
@@ -600,6 +600,34 @@ const Settings: React.FC = () => {
           />
         </Box>
 
+        <Box sx={inlineRowSx}>
+          <Box sx={{ mr: 3 }}>
+            <Typography sx={labelSx}>Simple tool group names</Typography>
+            <Typography sx={descSx}>Derive tool group labels from tool names instead of AI-generating them with a token turn.</Typography>
+          </Box>
+          <Select
+            size="small"
+            value={form.simple_tool_group_names}
+            onChange={(e) => setForm({ ...form, simple_tool_group_names: e.target.value as 'off' | 'cli-only' | 'all' })}
+            sx={{
+              minWidth: 130,
+              fontSize: '0.82rem',
+              fontFamily: c.font.sans,
+              color: c.text.primary,
+              bgcolor: c.bg.elevated,
+              '& .MuiOutlinedInput-notchedOutline': { borderColor: c.border.subtle },
+              '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: c.border.medium },
+              '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: c.accent.primary },
+              '& .MuiSvgIcon-root': { color: c.text.muted },
+            }}
+            MenuProps={{ PaperProps: { sx: { bgcolor: c.bg.elevated, color: c.text.primary } } }}
+          >
+            <MenuItem value="off">Off</MenuItem>
+            <MenuItem value="cli-only">CLI sessions</MenuItem>
+            <MenuItem value="all">All sessions</MenuItem>
+          </Select>
+        </Box>
+
         {/* ── Browser ── */}
         <Typography sx={{ ...sectionSx, mt: 3 }}>Browser</Typography>
 

--- a/frontend/src/app/pages/Settings/Settings.tsx
+++ b/frontend/src/app/pages/Settings/Settings.tsx
@@ -389,6 +389,7 @@ const Settings: React.FC = () => {
             >
               <MenuItem value="sonnet">Sonnet 4.6</MenuItem>
               <MenuItem value="opus">Opus 4.6</MenuItem>
+              <MenuItem value="opus-1m">Opus 4.6 1M</MenuItem>
               <MenuItem value="haiku">Haiku 3.5</MenuItem>
             </Select>
           </FormControl>

--- a/frontend/src/app/pages/Views/ViewEditor.tsx
+++ b/frontend/src/app/pages/Views/ViewEditor.tsx
@@ -1539,6 +1539,8 @@ const ViewEditor: React.FC<Props> = ({ output, onClose }) => {
                       onModeChange={setAutoRunMode}
                       model={autoRunModel}
                       onModelChange={setAutoRunModel}
+                      effort="high"
+                      onEffortChange={() => {}}
                     />
                     <Button
                       variant="contained"

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -79,6 +79,7 @@ export interface AgentConfig {
   name?: string;
   model?: string;
   mode?: string;
+  effort?: string;
   system_prompt?: string;
   allowed_tools?: string[];
   max_turns?: number;

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -66,6 +66,7 @@ export interface AgentSession {
   branches: Record<string, MessageBranch>;
   active_branch_id: string;
   streamingMessage: StreamingMessage | null;
+  cwd?: string | null;
   target_directory?: string | null;
   tool_group_meta: Record<string, ToolGroupMeta>;
   dashboard_id?: string;

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -85,6 +85,7 @@ export interface AgentConfig {
   max_turns?: number;
   target_directory?: string;
   dashboard_id?: string;
+  resume_cli_session_id?: string;
 }
 
 export interface HistorySession {

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -71,6 +71,7 @@ export interface AgentSession {
   dashboard_id?: string;
   browser_id?: string | null;
   parent_session_id?: string | null;
+  schedule_id?: string | null;
 }
 
 export interface AgentConfig {

--- a/frontend/src/shared/state/schedulesSlice.ts
+++ b/frontend/src/shared/state/schedulesSlice.ts
@@ -19,6 +19,7 @@ export interface Schedule {
   model: string | null;
   mode: string | null;
   system_prompt: string | null;
+  target_directory: string | null;
   last_run_at: string | null;
   next_run_at: string | null;
   run_count: number;

--- a/frontend/src/shared/state/schedulesSlice.ts
+++ b/frontend/src/shared/state/schedulesSlice.ts
@@ -1,0 +1,140 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { API_BASE } from '@/shared/config';
+
+const SCHEDULES_API = `${API_BASE}/schedules`;
+
+export interface Schedule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  dashboard_id: string;
+  trigger_type: 'cron' | 'interval' | 'once';
+  cron_expression: string | null;
+  interval_seconds: number | null;
+  run_at: string | null;
+  action_type: 'new_session' | 'message_existing';
+  prompt: string;
+  target_session_id: string | null;
+  template_id: string | null;
+  model: string | null;
+  mode: string | null;
+  system_prompt: string | null;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  run_count: number;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SchedulesState {
+  items: Record<string, Schedule>;
+  loading: boolean;
+  unreadCount: number;
+}
+
+const initialState: SchedulesState = {
+  items: {},
+  loading: false,
+  unreadCount: 0,
+};
+
+export const fetchSchedules = createAsyncThunk(
+  'schedules/fetchAll',
+  async (dashboardId?: string) => {
+    const url = dashboardId
+      ? `${SCHEDULES_API}/list?dashboard_id=${dashboardId}`
+      : `${SCHEDULES_API}/list`;
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.schedules as Schedule[];
+  },
+);
+
+export const createSchedule = createAsyncThunk(
+  'schedules/create',
+  async (body: Omit<Schedule, 'id' | 'last_run_at' | 'next_run_at' | 'run_count' | 'last_error' | 'created_at' | 'updated_at' | 'enabled'> & { name?: string }) => {
+    const res = await fetch(`${SCHEDULES_API}/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const updateSchedule = createAsyncThunk(
+  'schedules/update',
+  async ({ id, ...body }: { id: string } & Partial<Schedule>) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return (await res.json()) as Schedule;
+  },
+);
+
+export const deleteSchedule = createAsyncThunk(
+  'schedules/delete',
+  async (id: string) => {
+    await fetch(`${SCHEDULES_API}/${id}`, { method: 'DELETE' });
+    return id;
+  },
+);
+
+export const toggleSchedule = createAsyncThunk(
+  'schedules/toggle',
+  async (id: string) => {
+    const res = await fetch(`${SCHEDULES_API}/${id}/toggle`, { method: 'POST' });
+    return (await res.json()) as Schedule;
+  },
+);
+
+const schedulesSlice = createSlice({
+  name: 'schedules',
+  initialState,
+  reducers: {
+    incrementUnread(state) {
+      state.unreadCount += 1;
+    },
+    clearUnread(state) {
+      state.unreadCount = 0;
+    },
+    scheduleUpdatedFromWs(state, action: PayloadAction<{ schedule_id: string }>) {
+      state.unreadCount += 1;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSchedules.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchSchedules.fulfilled, (state, action) => {
+        state.loading = false;
+        const items: Record<string, Schedule> = {};
+        for (const s of action.payload) {
+          items[s.id] = s;
+        }
+        state.items = items;
+      })
+      .addCase(fetchSchedules.rejected, (state) => {
+        state.loading = false;
+      })
+      .addCase(createSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(updateSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      })
+      .addCase(deleteSchedule.fulfilled, (state, action) => {
+        delete state.items[action.payload];
+      })
+      .addCase(toggleSchedule.fulfilled, (state, action) => {
+        state.items[action.payload.id] = action.payload;
+      });
+  },
+});
+
+export const { incrementUnread, clearUnread, scheduleUpdatedFromWs } = schedulesSlice.actions;
+export default schedulesSlice.reducer;

--- a/frontend/src/shared/state/settingsSlice.ts
+++ b/frontend/src/shared/state/settingsSlice.ts
@@ -25,6 +25,7 @@ export interface AppSettings {
   auto_select_mode_on_new_agent: boolean;
   expand_new_chats_in_dashboard: boolean;
   auto_reveal_sub_agents: boolean;
+  simple_tool_group_names: 'off' | 'cli-only' | 'all';
   dev_mode: boolean;
 }
 
@@ -57,6 +58,7 @@ const initialState: SettingsState = {
     auto_select_mode_on_new_agent: false,
     expand_new_chats_in_dashboard: false,
     auto_reveal_sub_agents: true,
+    simple_tool_group_names: 'cli-only',
     dev_mode: false,
   },
   loading: false,

--- a/frontend/src/shared/state/store.ts
+++ b/frontend/src/shared/state/store.ts
@@ -12,6 +12,7 @@ import outputsReducer from './outputsSlice';
 import dashboardLayoutReducer from './dashboardLayoutSlice';
 import dashboardsReducer from './dashboardsSlice';
 import updateReducer from './updateSlice';
+import schedulesReducer from './schedulesSlice';
 
 export const store = configureStore({
   reducer: {
@@ -28,6 +29,7 @@ export const store = configureStore({
     dashboardLayout: dashboardLayoutReducer,
     dashboards: dashboardsReducer,
     update: updateReducer,
+    schedules: schedulesReducer,
   },
 });
 

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -17,6 +17,7 @@ import {
   trackAgentNotification,
 } from '../state/agentsSlice';
 import { addBrowserCardFromBackend, setBrowserCardPosition, setGlowingBrowserCards, GRID_GAP } from '../state/dashboardLayoutSlice';
+import { incrementUnread } from '../state/schedulesSlice';
 
 type WSEvent = {
   event: string;
@@ -266,6 +267,14 @@ class WebSocketManager {
             }
           }
         }
+        break;
+
+      case 'schedule:run_complete':
+        store.dispatch(incrementUnread());
+        break;
+
+      case 'schedule:run_failed':
+        store.dispatch(incrementUnread());
         break;
     }
 

--- a/run.mjs
+++ b/run.mjs
@@ -66,7 +66,6 @@ function cleanup() {
 
 process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
-process.on('exit', cleanup);
 
 // --- Spawn with prefixed output ---
 function spawnService(name, color, cmd, args, options = {}) {

--- a/run.mjs
+++ b/run.mjs
@@ -73,6 +73,8 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
+    // .cmd files on Windows require shell: true
+    shell: isWindows,
     ...options,
   });
   children.push(child);

--- a/run.mjs
+++ b/run.mjs
@@ -73,8 +73,6 @@ function spawnService(name, color, cmd, args, options = {}) {
     stdio: ['ignore', 'pipe', 'pipe'],
     // On Unix, create a process group so we can kill the whole tree
     detached: !isWindows,
-    // .cmd files on Windows require shell: true
-    shell: isWindows,
     ...options,
   });
   children.push(child);
@@ -132,7 +130,7 @@ try {
 
   // Wait for backend health
   console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
-  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  await waitForHealth('http://localhost:8324/api/health/check', 'Backend', 120000);
   console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
 
   // Start frontend
@@ -157,6 +155,7 @@ try {
   const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
     cwd: join(__dirname, 'electron'),
     env: { ...process.env, ELECTRON_DEV: '1' },
+    shell: isWindows,
   });
 
   electron.on('exit', (code) => {

--- a/run.mjs
+++ b/run.mjs
@@ -1,0 +1,177 @@
+// run.mjs
+import { spawn, execFileSync } from 'child_process';
+import { get } from 'http';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const isWindows = process.platform === 'win32';
+
+// --- Colors ---
+const BLUE = '\x1b[1;34m';
+const GREEN = '\x1b[1;32m';
+const RED = '\x1b[1;31m';
+const YELLOW = '\x1b[1;33m';
+const MAGENTA = '\x1b[1;35m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+let shuttingDown = false;
+const children = [];
+
+// --- Process tree kill ---
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill with /T kills the process tree, /F forces it
+      // child.pid is a numeric PID from Node's child_process — safe to interpolate
+      execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch {
+    // process already exited
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n${YELLOW}${BOLD}Gracefully shutting down all services...${RESET}`);
+
+  for (const child of children) {
+    killChild(child);
+  }
+
+  // Force-kill after 5 seconds
+  setTimeout(() => {
+    for (const child of children) {
+      if (child && child.exitCode === null) {
+        try {
+          if (isWindows) {
+            execFileSync('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' });
+          } else {
+            process.kill(-child.pid, 'SIGKILL');
+          }
+        } catch {
+          // already dead
+        }
+      }
+    }
+    console.log(`${GREEN}${BOLD}All services stopped.${RESET}`);
+    process.exit(0);
+  }, 5000);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+process.on('exit', cleanup);
+
+// --- Spawn with prefixed output ---
+function spawnService(name, color, cmd, args, options = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    // On Unix, create a process group so we can kill the whole tree
+    detached: !isWindows,
+    ...options,
+  });
+  children.push(child);
+
+  const prefix = `${color}${BOLD}[${name}]${RESET} `;
+
+  child.stdout.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stdout.write(`${prefix}${line}\n`);
+    }
+  });
+  child.stderr.on('data', (data) => {
+    for (const line of data.toString().split('\n')) {
+      if (line) process.stderr.write(`${prefix}${line}\n`);
+    }
+  });
+
+  return child;
+}
+
+// --- Health check ---
+function waitForHealth(url, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function check() {
+      if (shuttingDown) return reject(new Error('shutting down'));
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`${label} did not become ready within ${timeoutMs / 1000}s`));
+      }
+      get(url, (res) => {
+        if (res.statusCode >= 200 && res.statusCode < 400) {
+          resolve();
+        } else {
+          setTimeout(check, 2000);
+        }
+        res.resume();
+      }).on('error', () => setTimeout(check, 2000));
+    }
+    check();
+  });
+}
+
+// --- Main ---
+try {
+  // Start backend
+  console.log(`${BLUE}${BOLD}[backend]${RESET}  Starting backend server...`);
+  const backend = spawnService('backend', BLUE, process.execPath, [join(__dirname, 'backend', 'run.mjs')]);
+
+  backend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Backend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for backend health
+  console.log(`${YELLOW}${BOLD}Waiting for backend (http://localhost:8324) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:8324/', 'Backend', 120000);
+  console.log(`${GREEN}${BOLD}Backend is ready!${RESET}`);
+
+  // Start frontend
+  console.log(`${GREEN}${BOLD}[frontend]${RESET} Starting frontend dev server...`);
+  const frontend = spawnService('frontend', GREEN, process.execPath, [join(__dirname, 'frontend', 'run.mjs')]);
+
+  frontend.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${RED}${BOLD}Frontend process exited unexpectedly (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  // Wait for frontend health
+  console.log(`${YELLOW}${BOLD}Waiting for frontend (http://localhost:3000) to be ready...${RESET}`);
+  await waitForHealth('http://localhost:3000/', 'Frontend', 60000);
+  console.log(`${GREEN}${BOLD}Frontend is ready!${RESET}`);
+
+  // Start Electron
+  const npmCmd = isWindows ? 'npm.cmd' : 'npm';
+  console.log(`${MAGENTA}${BOLD}[electron]${RESET} Launching Electron dev shell...`);
+  const electron = spawnService('electron', MAGENTA, npmCmd, ['run', 'dev'], {
+    cwd: join(__dirname, 'electron'),
+    env: { ...process.env, ELECTRON_DEV: '1' },
+  });
+
+  electron.on('exit', (code) => {
+    if (!shuttingDown) {
+      console.log(`${YELLOW}${BOLD}Electron process exited (code ${code}). Shutting down...${RESET}`);
+      cleanup();
+    }
+  });
+
+  console.log('');
+  console.log(`${BOLD}All services are running. Press Ctrl+C to stop.${RESET}`);
+  console.log(`  Backend:  ${BLUE}http://localhost:8324${RESET}`);
+  console.log(`  Frontend: ${GREEN}http://localhost:3000${RESET}`);
+  console.log(`  Electron: ${MAGENTA}dev shell${RESET}`);
+  console.log('');
+} catch (err) {
+  console.error(`${RED}${BOLD}${err.message}${RESET}`);
+  cleanup();
+}


### PR DESCRIPTION
## Summary

- Browse Claude CLI session history from the dashboard toolbar's history panel via "Show CLI sessions" toggle
- Click any CLI session to open it inside OpenSwarm as a full agent card with message history (user, assistant, tool calls, tool results) — all rendered with native OpenSwarm formatting
- Optional "Open in CLI" terminal icon on each session row and on dashboard agent cards to resume in an external terminal instead
- CLI internal messages (slash commands, system reminders, task notifications) wrapped as collapsible tool groups rather than raw XML
- New "Simple tool group names" setting (off / CLI sessions / all) — derives tool group labels from tool names and inputs instead of spending a haiku turn per group
- Generalized `/open-in-cli` endpoint accepting both OpenSwarm and CLI session IDs

## Test plan

- [ ] Open dashboard history, toggle "Show CLI sessions", verify sessions from `~/.claude/projects/` appear
- [ ] Click a CLI session — verify it opens as an agent card with full message history and correct tool call formatting
- [ ] Click the terminal icon on a CLI session row — verify it opens in external CLI, not inside OpenSwarm
- [ ] Send a message in a resumed CLI session — verify it continues the conversation via SDK resume
- [ ] Toggle "Simple tool group names" to "All sessions" in settings — verify new tool groups get derived labels without LLM calls
- [ ] Verify the "Open in CLI" button appears on dashboard agent cards with an `sdk_session_id`