### PR TITLE
[codex] Reduce first-turn agent payload

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -198,6 +198,40 @@ FULL_TOOLS = [
     "ToolSearch",
 ]
 
+CORE_FIRST_TURN_TOOLS = [
+    "Read", "Edit", "Write", "Bash", "Glob", "Grep", "AskUserQuestion",
+    "ToolSearch",
+]
+
+WEB_INTENT_RE = re.compile(
+    r"\b(web|search|google|browse|fetch|url|http[s]?://|latest|recent|today|"
+    r"current|news|documentation|docs|website)\b",
+    re.IGNORECASE,
+)
+BROWSER_INTENT_RE = re.compile(
+    r"\b(browser|click|type into|login|log in|form|navigate|screenshot|"
+    r"visual|page|site|website|http[s]?://)\b",
+    re.IGNORECASE,
+)
+MCP_INTENT_RE = re.compile(
+    r"\b(email|gmail|calendar|drive|slack|discord|notion|linear|github|"
+    r"airtable|hubspot|reddit|integration|connector|mcp|crm|workspace)\b",
+    re.IGNORECASE,
+)
+OUTPUT_INTENT_RE = re.compile(
+    r"\b(view|output|render|dashboard|chart|graph|visualization|visualise|"
+    r"visualize|table|report|widget)\b",
+    re.IGNORECASE,
+)
+INVOKE_INTENT_RE = re.compile(
+    r"\b(invoke|another agent|other agent|agent card|sub[- ]?agent|parallel agent)\b",
+    re.IGNORECASE,
+)
+CRON_INTENT_RE = re.compile(
+    r"\b(schedule|scheduled|recurring|cron|every (day|hour|week|month)|remind)\b",
+    re.IGNORECASE,
+)
+
 def _get_denied_tool_names(tool) -> set[str]:
     """Return the set of MCP sub-tool names whose permission is 'deny'."""
     return {
@@ -739,6 +773,202 @@ class AgentManager:
     def _compose_system_prompt(self, default_prompt: str | None, mode_prompt: str | None, session_prompt: str | None, connected_tools_ctx: str | None = None, outputs_ctx: str | None = None, browser_ctx: str | None = None, mcp_registry_ctx: str | None = None) -> str | None:
         parts = [p for p in (default_prompt, mode_prompt, session_prompt, connected_tools_ctx, mcp_registry_ctx, outputs_ctx, browser_ctx) if p]
         return "\n\n".join(parts) if parts else None
+
+    @staticmethod
+    def _prompt_text_for_routing(prompt_content) -> str:
+        """Extract text only. Images stay out of the cheap local router."""
+        if isinstance(prompt_content, str):
+            return prompt_content
+        if isinstance(prompt_content, list):
+            chunks: list[str] = []
+            for block in prompt_content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    chunks.append(str(block.get("text") or ""))
+            return "\n".join(chunks)
+        return str(prompt_content or "")
+
+    @staticmethod
+    def _is_first_user_turn(session: AgentSession) -> bool:
+        return (
+            not session.sdk_session_id
+            and sum(1 for m in session.messages if m.role == "user") <= 1
+        )
+
+    def _select_turn_surface(
+        self,
+        session: AgentSession,
+        prompt_text: str,
+        *,
+        forced_tools: list[str] | None = None,
+        images: list | None = None,
+        context_paths: list | None = None,
+        attached_skills: list | None = None,
+        selected_browser_ids: list[str] | None = None,
+    ) -> dict:
+        """Choose the first-turn tool/context surface with a local router.
+
+        The expensive default path is still used after turn one, for non-agent
+        modes, or when disabled via OPENSWARM_DISABLE_FIRST_TURN_MINIMAL=1.
+        For the first plain agent turn, attach optional surfaces only when the
+        prompt or UI context asks for them. This cuts first-token overhead
+        without adding an extra model call or delaying tasks that need tools.
+        """
+        first_turn = self._is_first_user_turn(session)
+        disabled = os.environ.get("OPENSWARM_DISABLE_FIRST_TURN_MINIMAL") == "1"
+        full_surface = (not first_turn) or disabled or session.mode != "agent"
+
+        allowed = list(session.allowed_tools)
+        forced = list(forced_tools or [])
+        forced_set = set(forced)
+        prompt = prompt_text or ""
+
+        has_active_mcp = bool(session.active_mcps)
+        has_active_output = bool(session.active_outputs)
+        wants_web = bool(WEB_INTENT_RE.search(prompt))
+        wants_browser = bool(selected_browser_ids or images or BROWSER_INTENT_RE.search(prompt))
+        wants_mcp = has_active_mcp or bool(MCP_INTENT_RE.search(prompt))
+        wants_output = has_active_output or bool(OUTPUT_INTENT_RE.search(prompt))
+        wants_invoke = bool(INVOKE_INTENT_RE.search(prompt))
+        wants_cron = bool(CRON_INTENT_RE.search(prompt))
+        wants_web = wants_web or bool(forced_set & {"WebSearch", "WebFetch"})
+        wants_browser = wants_browser or bool(forced_set & {"CreateBrowserAgent", "BrowserAgent", "BrowserAgents"})
+        wants_output = wants_output or bool(forced_set & {"RenderOutput", "OutputSearch", "OutputActivate"})
+        wants_invoke = wants_invoke or bool(forced_set & {"InvokeAgent", "Agent"})
+        wants_cron = wants_cron or bool(forced_set & {"CronCreate", "CronList", "CronDelete"})
+        wants_mcp = wants_mcp or any(t.startswith("mcp:") or t.startswith("mcp__") for t in forced_set)
+
+        # Context/skills already ship extra prompt content; preserve the core
+        # file/search/edit surface but do not automatically enable unrelated
+        # browser/MCP/output servers.
+        if full_surface:
+            turn_allowed = allowed
+        else:
+            selected = set(CORE_FIRST_TURN_TOOLS)
+            if wants_web:
+                selected.update({"WebSearch", "WebFetch"})
+            if wants_output:
+                selected.add("RenderOutput")
+            if wants_invoke:
+                selected.update({"InvokeAgent", "Agent"})
+            if wants_cron:
+                selected.update({"CronCreate", "CronList", "CronDelete"})
+            if wants_browser:
+                selected.update({"CreateBrowserAgent", "BrowserAgent", "BrowserAgents"})
+            if wants_mcp:
+                # Keep connected MCP identifiers in allowed_tools so the
+                # registry summary can mention them, but activation still gates
+                # their real schemas through active_mcps.
+                selected.update(t for t in allowed if t.startswith("mcp:"))
+            selected.update(forced)
+            turn_allowed = [t for t in allowed if t in selected or (t.startswith("mcp:") and wants_mcp)]
+            # Forced tools may include names not present in the mode list.
+            for tool in forced:
+                if tool not in turn_allowed:
+                    turn_allowed.append(tool)
+
+        return {
+            "optimized": not full_surface,
+            "first_turn": first_turn,
+            "allowed_tools": turn_allowed,
+            "include_mcp_meta": full_surface or wants_mcp or has_active_mcp,
+            "include_mcp_registry": full_surface or wants_mcp or has_active_mcp,
+            "include_outputs_meta": full_surface or wants_output or has_active_output,
+            "include_outputs_context": full_surface or wants_output or has_active_output,
+            "include_browser_tools": full_surface or wants_browser,
+            "include_browser_context": full_surface or wants_browser,
+            "include_invoke_tools": full_surface or wants_invoke,
+            "include_web_tools": full_surface or wants_web,
+            "intent": {
+                "web": wants_web,
+                "browser": wants_browser,
+                "mcp": wants_mcp,
+                "outputs": wants_output,
+                "invoke": wants_invoke,
+                "cron": wants_cron,
+                "context": bool(context_paths or attached_skills),
+            },
+        }
+
+    @staticmethod
+    def _payload_chars(value) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, str):
+            return len(value)
+        return len(json.dumps(value, sort_keys=True, default=str))
+
+    @staticmethod
+    def _estimate_local_mcp_tool_schema_chars(mcp_servers: dict) -> int:
+        """Estimate tool-schema chars for OpenSwarm's bundled stdio MCPs.
+
+        External MCP schemas are only known after their subprocess starts, so
+        this intentionally returns 0 for those. The always-on OpenSwarm MCPs
+        were the avoidable first-turn overhead; those are measurable here.
+        """
+        total = 0
+        for name in mcp_servers:
+            try:
+                if name == "openswarm-mcp-meta":
+                    from backend.apps.agents.mcp_meta_server import TOOLS
+                elif name == "openswarm-outputs-meta":
+                    from backend.apps.agents.outputs_meta_server import TOOLS
+                elif name == "openswarm-browser-agent":
+                    from backend.apps.agents.browser_agent_mcp_server import TOOLS
+                elif name == "openswarm-invoke-agent":
+                    from backend.apps.agents.invoke_agent_mcp_server import TOOLS
+                elif name == "openswarm-web":
+                    from backend.apps.agents.web_mcp_server import TOOLS
+                else:
+                    continue
+                total += len(json.dumps(TOOLS, sort_keys=True, default=str))
+            except Exception:
+                continue
+        return total
+
+    def _build_prompt_payload_ledger(
+        self,
+        *,
+        prompt_content,
+        composed_prompt: str | None,
+        mcp_servers: dict,
+        effective_allowed: list[str],
+        effective_disallowed: list[str],
+        surface: dict,
+    ) -> dict:
+        """Character ledger for the dummy connector/tests and UI diagnostics."""
+        prompt_chars = self._payload_chars(prompt_content)
+        system_chars = self._payload_chars(composed_prompt)
+        mcp_config_chars = self._payload_chars({"mcpServers": mcp_servers}) if mcp_servers else 0
+        mcp_schema_chars = self._estimate_local_mcp_tool_schema_chars(mcp_servers)
+        allowed_chars = self._payload_chars(effective_allowed)
+        disallowed_chars = self._payload_chars(effective_disallowed)
+        total_visible_chars = (
+            prompt_chars + system_chars + mcp_config_chars
+            + mcp_schema_chars + allowed_chars + disallowed_chars
+        )
+        return {
+            "optimized": bool(surface.get("optimized")),
+            "first_turn": bool(surface.get("first_turn")),
+            "intent": surface.get("intent", {}),
+            "chars": {
+                "prompt": prompt_chars,
+                "system_append": system_chars,
+                "mcp_config": mcp_config_chars,
+                "local_mcp_tool_schemas": mcp_schema_chars,
+                "allowed_tools": allowed_chars,
+                "disallowed_tools": disallowed_chars,
+                "visible_total": total_visible_chars,
+            },
+            "approx_tokens": {
+                "visible_total": max(1, total_visible_chars // 4),
+                "framework_estimate": 16_000 + 12_000 + max(0, system_chars // 4) + 600 * len(mcp_servers),
+            },
+            "counts": {
+                "mcp_servers": len(mcp_servers),
+                "allowed_tools": len(effective_allowed),
+                "disallowed_tools": len(effective_disallowed),
+            },
+        }
 
     async def launch_agent(self, config: AgentConfig) -> AgentSession:
         session_id = uuid4().hex
@@ -1481,9 +1711,27 @@ class AgentManager:
             #   instruction. Enforce that at the Discord MCP server's
             #   tool-call layer instead — prompt rules are not a security
             #   boundary.
+            prompt_route_text = self._prompt_text_for_routing(prompt_content)
+            turn_surface = self._select_turn_surface(
+                session,
+                prompt_route_text,
+                forced_tools=forced_tools,
+                images=images,
+                context_paths=context_paths,
+                attached_skills=attached_skills,
+                selected_browser_ids=selected_browser_ids,
+            )
+            turn_allowed_tools = turn_surface["allowed_tools"]
+
             connected_tools_ctx = None
-            outputs_ctx = self._build_outputs_context(session.active_outputs)
-            browser_ctx = self._build_browser_context(session.dashboard_id, selected_browser_ids=selected_browser_ids)
+            outputs_ctx = (
+                self._build_outputs_context(session.active_outputs)
+                if turn_surface["include_outputs_context"] else None
+            )
+            browser_ctx = (
+                self._build_browser_context(session.dashboard_id, selected_browser_ids=selected_browser_ids)
+                if turn_surface["include_browser_context"] else None
+            )
 
             # Reconcile active_mcps against currently-enabled tools (Phase 3).
             # If the user toggled a server off in the Tools page mid-session,
@@ -1509,7 +1757,10 @@ class AgentManager:
             except Exception:
                 logger.exception("active_mcps reconciliation failed; proceeding")
 
-            mcp_registry_ctx = self._build_mcp_registry_summary(session.allowed_tools, session.active_mcps)
+            mcp_registry_ctx = (
+                self._build_mcp_registry_summary(turn_allowed_tools, session.active_mcps)
+                if turn_surface["include_mcp_registry"] else None
+            )
             global_settings = load_settings()
             composed_prompt = self._compose_system_prompt(
                 global_settings.default_system_prompt,
@@ -1542,7 +1793,8 @@ class AgentManager:
             # no MCP tools shipped to the SDK; the model must MCPSearch and
             # MCPActivate first. The product invariant lives here at the
             # dispatch layer (see _build_mcp_servers docstring).
-            mcp_servers = await self._build_mcp_servers(session.allowed_tools, session.active_mcps)
+            mcp_servers = await self._build_mcp_servers(turn_allowed_tools, session.active_mcps)
+            backend_port = os.environ.get("OPENSWARM_PORT", "8324")
 
             _browser_delegation_tools = ["CreateBrowserAgent", "BrowserAgent", "BrowserAgents"]
             _browser_all_denied = all(
@@ -1550,11 +1802,10 @@ class AgentManager:
                 for t in _browser_delegation_tools
             )
 
-            if not _browser_all_denied:
+            if turn_surface["include_browser_tools"] and not _browser_all_denied:
                 browser_agent_server_path = os.path.join(
                     os.path.dirname(__file__), "browser_agent_mcp_server.py"
                 )
-                backend_port = os.environ.get("OPENSWARM_PORT", "8324")
                 pre_selected_bids = self._get_pre_selected_browser_ids(session.dashboard_id)
                 from backend.auth import get_auth_token as _get_auth_token
                 _auth_tok = _get_auth_token()
@@ -1578,11 +1829,10 @@ class AgentManager:
                 for t in _invoke_agent_tools
             )
 
-            if not _invoke_all_denied:
+            if turn_surface["include_invoke_tools"] and not _invoke_all_denied:
                 invoke_agent_server_path = os.path.join(
                     os.path.dirname(__file__), "invoke_agent_mcp_server.py"
                 )
-                backend_port = os.environ.get("OPENSWARM_PORT", "8324")
                 from backend.auth import get_auth_token as _get_auth_token2
                 mcp_servers["openswarm-invoke-agent"] = {
                     "command": sys.executable,
@@ -1601,39 +1851,41 @@ class AgentManager:
             # runtime. The activation gate (active_mcps filter in
             # _build_mcp_servers above) ensures the model cannot reach any
             # other MCP server's tools without going through this layer first.
-            mcp_meta_server_path = os.path.join(
-                os.path.dirname(__file__), "mcp_meta_server.py"
-            )
             from backend.auth import get_auth_token as _get_auth_token3
-            mcp_servers["openswarm-mcp-meta"] = {
-                "command": sys.executable,
-                "args": [mcp_meta_server_path],
-                "env": {
-                    "OPENSWARM_PORT": os.environ.get("OPENSWARM_PORT", "8324"),
-                    "OPENSWARM_AUTH_TOKEN": _get_auth_token3(),
-                    "OPENSWARM_PARENT_SESSION_ID": session.id,
-                },
-                "type": "stdio",
-            }
+            if turn_surface["include_mcp_meta"]:
+                mcp_meta_server_path = os.path.join(
+                    os.path.dirname(__file__), "mcp_meta_server.py"
+                )
+                mcp_servers["openswarm-mcp-meta"] = {
+                    "command": sys.executable,
+                    "args": [mcp_meta_server_path],
+                    "env": {
+                        "OPENSWARM_PORT": os.environ.get("OPENSWARM_PORT", "8324"),
+                        "OPENSWARM_AUTH_TOKEN": _get_auth_token3(),
+                        "OPENSWARM_PARENT_SESSION_ID": session.id,
+                    },
+                    "type": "stdio",
+                }
 
             # Outputs/Views activation gate (Phase 2). Same shape as the
             # MCP meta-server but for Outputs. The model only sees a
             # one-line index of available Outputs in the system prompt
             # (see _build_outputs_context); to load any specific
             # Output's full input_schema, it must call OutputActivate.
-            outputs_meta_server_path = os.path.join(
-                os.path.dirname(__file__), "outputs_meta_server.py"
-            )
-            mcp_servers["openswarm-outputs-meta"] = {
-                "command": sys.executable,
-                "args": [outputs_meta_server_path],
-                "env": {
-                    "OPENSWARM_PORT": os.environ.get("OPENSWARM_PORT", "8324"),
-                    "OPENSWARM_AUTH_TOKEN": _get_auth_token3(),
-                    "OPENSWARM_PARENT_SESSION_ID": session.id,
-                },
-                "type": "stdio",
-            }
+            if turn_surface["include_outputs_meta"]:
+                outputs_meta_server_path = os.path.join(
+                    os.path.dirname(__file__), "outputs_meta_server.py"
+                )
+                mcp_servers["openswarm-outputs-meta"] = {
+                    "command": sys.executable,
+                    "args": [outputs_meta_server_path],
+                    "env": {
+                        "OPENSWARM_PORT": os.environ.get("OPENSWARM_PORT", "8324"),
+                        "OPENSWARM_AUTH_TOKEN": _get_auth_token3(),
+                        "OPENSWARM_PARENT_SESSION_ID": session.id,
+                    },
+                    "type": "stdio",
+                }
 
             # The CLI's built-in WebSearch/WebFetch wraps Anthropic's
             # web_search_20250305. For non-Claude primaries the CLI
@@ -1678,7 +1930,7 @@ class AgentManager:
             )
 
             _need_web_mcp = not _has_anthropic_path
-            if _need_web_mcp:
+            if _need_web_mcp and turn_surface["include_web_tools"]:
                 web_mcp_server_path = os.path.join(
                     os.path.dirname(__file__), "web_mcp_server.py"
                 )
@@ -1707,7 +1959,7 @@ class AgentManager:
                 )
 
             effective_allowed = [
-                t for t in session.allowed_tools
+                t for t in turn_allowed_tools
                 if t in FULL_TOOLS and _builtin_perms.get(t, "always_allow") == "always_allow"
             ]
 
@@ -1771,7 +2023,7 @@ class AgentManager:
             # WebSearch/WebFetch are guaranteed to fail (no Anthropic
             # backend). Suppress them so the model picks our MCP variants
             # and doesn't waste a turn on a broken tool.
-            if _need_web_mcp:
+            if _need_web_mcp and turn_surface["include_web_tools"]:
                 effective_allowed = [t for t in effective_allowed if t not in ("WebSearch", "WebFetch")]
                 for _bt in ("WebSearch", "WebFetch"):
                     if _bt not in effective_disallowed:
@@ -2023,6 +2275,30 @@ class AgentManager:
                     "preset": "claude_code",
                     "exclude_dynamic_sections": True,
                 }
+
+            prompt_ledger = self._build_prompt_payload_ledger(
+                prompt_content=prompt_content,
+                composed_prompt=composed_prompt,
+                mcp_servers=mcp_servers,
+                effective_allowed=effective_allowed,
+                effective_disallowed=effective_disallowed,
+                surface=turn_surface,
+            )
+            session.framework_overhead_tokens = prompt_ledger["approx_tokens"]["framework_estimate"]
+            logger.info(
+                "[PROMPT-LEDGER] optimized=%s chars=%s approx_tokens=%s",
+                prompt_ledger["optimized"],
+                prompt_ledger["chars"],
+                prompt_ledger["approx_tokens"],
+            )
+            try:
+                await ws_manager.send_to_session(session_id, "agent:prompt_ledger", {
+                    "session_id": session_id,
+                    **prompt_ledger,
+                })
+            except Exception:
+                logger.exception("Failed to emit agent:prompt_ledger")
+
             if session.max_turns:
                 options_kwargs["max_turns"] = session.max_turns
 

--- a/backend/scripts/benchmark_first_turn_payload.py
+++ b/backend/scripts/benchmark_first_turn_payload.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Benchmark first-turn prompt payload size with a dummy connector.
+
+This does not contact Claude, Codex, Gemini, or 9Router. It exercises the same
+local first-turn surface selector and ledger used by the backend, then prints
+the character payload the dummy connector would receive for optimized vs.
+legacy first-turn behavior.
+
+Run from the repository root:
+    PYTHONPATH=. python backend/scripts/benchmark_first_turn_payload.py
+"""
+
+from __future__ import annotations
+
+import json
+import contextlib
+import io
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from typing import Any
+
+os.environ.setdefault("OPENSWARM_DATA_DIR", tempfile.mkdtemp(prefix="openswarm-bench-"))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DEBUGGER = os.path.join(ROOT, "debugger")
+if DEBUGGER not in sys.path:
+    sys.path.insert(0, DEBUGGER)
+
+
+@contextmanager
+def env(name: str, value: str | None):
+    old = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = old
+
+
+class DummyAgentConnector:
+    def send(self, *, prompt_content: Any, composed_prompt: str | None, mcp_servers: dict,
+             allowed_tools: list[str], disallowed_tools: list[str], surface: dict) -> dict:
+        with contextlib.redirect_stdout(io.StringIO()):
+            from backend.apps.agents.agent_manager import AgentManager
+
+        return AgentManager()._build_prompt_payload_ledger(
+            prompt_content=prompt_content,
+            composed_prompt=composed_prompt,
+            mcp_servers=mcp_servers,
+            effective_allowed=allowed_tools,
+            effective_disallowed=disallowed_tools,
+            surface=surface,
+        )
+
+
+def mcp_config(script: str) -> dict:
+    return {
+        "command": "python",
+        "args": [script],
+        "env": {
+            "OPENSWARM_PORT": "8324",
+            "OPENSWARM_AUTH_TOKEN": "dummy",
+            "OPENSWARM_PARENT_SESSION_ID": "benchmark",
+        },
+        "type": "stdio",
+    }
+
+
+def make_session():
+    with contextlib.redirect_stdout(io.StringIO()):
+        from backend.apps.agents.models import AgentSession, Message
+        from backend.apps.agents.agent_manager import get_all_tool_names
+
+    session = AgentSession(
+        id="benchmark",
+        name="Benchmark",
+        model="sonnet",
+        mode="agent",
+        allowed_tools=get_all_tool_names(),
+        cwd="/tmp",
+    )
+    session.messages.append(Message(role="user", content="placeholder"))
+    return session
+
+
+def measure(prompt: str, *, legacy: bool) -> dict:
+    with contextlib.redirect_stdout(io.StringIO()):
+        from backend.apps.agents.agent_manager import AgentManager
+        from backend.apps.settings.models import DEFAULT_SYSTEM_PROMPT
+
+    mgr = AgentManager()
+    session = make_session()
+
+    with env("OPENSWARM_DISABLE_FIRST_TURN_MINIMAL", "1" if legacy else None):
+        surface = mgr._select_turn_surface(session, prompt)
+        outputs_ctx = "<available_views>\n- demo **Demo view**\n</available_views>" if surface["include_outputs_context"] else None
+        mcp_registry_ctx = "<mcp_servers>\n- `gmail` - Gmail integration\n</mcp_servers>" if surface["include_mcp_registry"] else None
+        composed_prompt = mgr._compose_system_prompt(
+            DEFAULT_SYSTEM_PROMPT,
+            None,
+            None,
+            None,
+            outputs_ctx,
+            None,
+            mcp_registry_ctx,
+        )
+
+        mcp_servers = {}
+        if surface["include_browser_tools"]:
+            mcp_servers["openswarm-browser-agent"] = mcp_config("browser_agent_mcp_server.py")
+        if surface["include_invoke_tools"]:
+            mcp_servers["openswarm-invoke-agent"] = mcp_config("invoke_agent_mcp_server.py")
+        if surface["include_mcp_meta"]:
+            mcp_servers["openswarm-mcp-meta"] = mcp_config("mcp_meta_server.py")
+        if surface["include_outputs_meta"]:
+            mcp_servers["openswarm-outputs-meta"] = mcp_config("outputs_meta_server.py")
+
+        allowed = [t for t in surface["allowed_tools"] if not t.startswith("mcp:")]
+        for name in mcp_servers:
+            if name == "openswarm-browser-agent":
+                allowed.extend([
+                    "mcp__openswarm-browser-agent__CreateBrowserAgent",
+                    "mcp__openswarm-browser-agent__BrowserAgent",
+                    "mcp__openswarm-browser-agent__BrowserAgents",
+                ])
+            elif name == "openswarm-invoke-agent":
+                allowed.append("mcp__openswarm-invoke-agent__InvokeAgent")
+            else:
+                allowed.append(f"mcp__{name}__*")
+
+        return DummyAgentConnector().send(
+            prompt_content=prompt,
+            composed_prompt=composed_prompt,
+            mcp_servers=mcp_servers,
+            allowed_tools=allowed,
+            disallowed_tools=[],
+            surface=surface,
+        )
+
+
+def main():
+    prompts = [
+        "Summarize the repository structure.",
+        "Search the web for current pricing.",
+        "Send an email through Gmail.",
+        "Open the browser and click the login button.",
+        "Render this as a dashboard view.",
+    ]
+    rows = []
+    for prompt in prompts:
+        optimized = measure(prompt, legacy=False)
+        legacy = measure(prompt, legacy=True)
+        opt_chars = optimized["chars"]["visible_total"]
+        leg_chars = legacy["chars"]["visible_total"]
+        rows.append({
+            "prompt": prompt,
+            "optimized_chars": opt_chars,
+            "legacy_chars": leg_chars,
+            "saved_chars": leg_chars - opt_chars,
+            "saved_pct": round((leg_chars - opt_chars) / leg_chars * 100, 1) if leg_chars else 0,
+            "optimized_mcp_servers": optimized["counts"]["mcp_servers"],
+            "legacy_mcp_servers": legacy["counts"]["mcp_servers"],
+            "optimized_intent": optimized["intent"],
+        })
+    print(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_first_turn_payload.py
+++ b/backend/tests/test_first_turn_payload.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+_TMPROOT = tempfile.mkdtemp(prefix="openswarm-first-turn-payload-")
+os.environ.setdefault("OPENSWARM_DATA_DIR", _TMPROOT)
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_DEBUGGER = os.path.join(_ROOT, "debugger")
+if _DEBUGGER not in sys.path:
+    sys.path.insert(0, _DEBUGGER)
+
+
+@contextmanager
+def _env(name: str, value: str | None):
+    old = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = old
+
+
+class DummyAgentConnector:
+    """Fake connector that reports how many chars the agent turn receives."""
+
+    def send(self, *, prompt_content: Any, composed_prompt: str | None, mcp_servers: dict,
+             allowed_tools: list[str], disallowed_tools: list[str], surface: dict) -> dict:
+        from backend.apps.agents.agent_manager import AgentManager
+
+        return AgentManager()._build_prompt_payload_ledger(
+            prompt_content=prompt_content,
+            composed_prompt=composed_prompt,
+            mcp_servers=mcp_servers,
+            effective_allowed=allowed_tools,
+            effective_disallowed=disallowed_tools,
+            surface=surface,
+        )
+
+
+def _session():
+    from backend.apps.agents.models import AgentSession, Message
+    from backend.apps.agents.agent_manager import get_all_tool_names
+
+    s = AgentSession(
+        id="s1",
+        name="Test",
+        model="sonnet",
+        mode="agent",
+        allowed_tools=get_all_tool_names(),
+        cwd="/tmp",
+    )
+    s.messages.append(Message(role="user", content="placeholder"))
+    return s
+
+
+def _mcp_config(name: str) -> dict:
+    return {
+        "command": "python",
+        "args": [f"{name}.py"],
+        "env": {
+            "OPENSWARM_PORT": "8324",
+            "OPENSWARM_AUTH_TOKEN": "dummy",
+            "OPENSWARM_PARENT_SESSION_ID": "s1",
+        },
+        "type": "stdio",
+    }
+
+
+def _payload_for(prompt: str, *, legacy: bool = False, selected_browser_ids: list[str] | None = None):
+    from backend.apps.agents.agent_manager import AgentManager
+    from backend.apps.settings.models import DEFAULT_SYSTEM_PROMPT
+
+    mgr = AgentManager()
+    s = _session()
+    connector = DummyAgentConnector()
+
+    with _env("OPENSWARM_DISABLE_FIRST_TURN_MINIMAL", "1" if legacy else None):
+        surface = mgr._select_turn_surface(
+            s,
+            prompt,
+            selected_browser_ids=selected_browser_ids,
+        )
+        outputs_ctx = "<available_views>\n- demo **Demo view**\n</available_views>" if surface["include_outputs_context"] else None
+        browser_ctx = mgr._build_browser_context("missing-dashboard", selected_browser_ids=selected_browser_ids) if surface["include_browser_context"] else None
+        mcp_registry_ctx = "<mcp_servers>\n- `gmail` - Gmail integration\n</mcp_servers>" if surface["include_mcp_registry"] else None
+        composed = mgr._compose_system_prompt(
+            DEFAULT_SYSTEM_PROMPT,
+            None,
+            None,
+            None,
+            outputs_ctx,
+            browser_ctx,
+            mcp_registry_ctx,
+        )
+        mcp_servers = {}
+        if surface["include_browser_tools"]:
+            mcp_servers["openswarm-browser-agent"] = _mcp_config("browser_agent_mcp_server")
+        if surface["include_invoke_tools"]:
+            mcp_servers["openswarm-invoke-agent"] = _mcp_config("invoke_agent_mcp_server")
+        if surface["include_mcp_meta"]:
+            mcp_servers["openswarm-mcp-meta"] = _mcp_config("mcp_meta_server")
+        if surface["include_outputs_meta"]:
+            mcp_servers["openswarm-outputs-meta"] = _mcp_config("outputs_meta_server")
+
+        builtin_perms = {}
+        allowed = [t for t in surface["allowed_tools"] if not t.startswith("mcp:") and builtin_perms.get(t, "always_allow") == "always_allow"]
+        disallowed = []
+        for name in mcp_servers:
+            if name == "openswarm-browser-agent":
+                allowed.extend([
+                    "mcp__openswarm-browser-agent__CreateBrowserAgent",
+                    "mcp__openswarm-browser-agent__BrowserAgent",
+                    "mcp__openswarm-browser-agent__BrowserAgents",
+                ])
+            elif name == "openswarm-invoke-agent":
+                allowed.append("mcp__openswarm-invoke-agent__InvokeAgent")
+            else:
+                allowed.append(f"mcp__{name}__*")
+
+        return connector.send(
+            prompt_content=prompt,
+            composed_prompt=composed,
+            mcp_servers=mcp_servers,
+            allowed_tools=allowed,
+            disallowed_tools=disallowed,
+            surface=surface,
+        )
+
+
+def test_plain_first_message_uses_minimal_surface_and_reduces_chars():
+    prompt = "Summarize the repository structure."
+    optimized = _payload_for(prompt)
+    legacy = _payload_for(prompt, legacy=True)
+
+    assert optimized["optimized"] is True
+    assert optimized["counts"]["mcp_servers"] == 0
+    assert legacy["counts"]["mcp_servers"] >= 4
+    assert optimized["chars"]["visible_total"] < legacy["chars"]["visible_total"] * 0.55
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected"),
+    [
+        ("Search the web for current pricing", {"web"}),
+        ("Send an email through Gmail", {"mcp"}),
+        ("Render this as a dashboard view", {"outputs"}),
+        ("Open the browser and click the login button", {"browser"}),
+        ("Run this every day at 9am", {"cron"}),
+        ("Ask another agent to inspect this", {"invoke"}),
+    ],
+)
+def test_router_preserves_relevant_capability_on_first_turn(prompt, expected):
+    payload = _payload_for(prompt)
+    intent = {k for k, v in payload["intent"].items() if v}
+    assert expected <= intent
+
+    if expected & {"mcp", "outputs", "browser", "invoke"}:
+        assert payload["counts"]["mcp_servers"] >= 1
+
+
+def test_followup_turn_keeps_full_surface_for_compatibility():
+    from backend.apps.agents.models import Message
+    from backend.apps.agents.agent_manager import AgentManager
+
+    mgr = AgentManager()
+    s = _session()
+    s.sdk_session_id = "sdk-session"
+    s.messages.append(Message(role="assistant", content="ok"))
+    surface = mgr._select_turn_surface(s, "Continue")
+    assert surface["optimized"] is False
+    assert surface["include_browser_tools"] is True
+    assert surface["include_mcp_meta"] is True
+    assert surface["include_outputs_meta"] is True
+
+
+def test_forced_tools_pull_in_matching_lazy_surface():
+    from backend.apps.agents.agent_manager import AgentManager
+
+    mgr = AgentManager()
+    s = _session()
+    surface = mgr._select_turn_surface(s, "Do this", forced_tools=["RenderOutput", "BrowserAgent"])
+    assert surface["optimized"] is True
+    assert surface["include_outputs_meta"] is True
+    assert surface["include_browser_tools"] is True
+    assert "RenderOutput" in surface["allowed_tools"]
+    assert "BrowserAgent" in surface["allowed_tools"]


### PR DESCRIPTION
## Summary

- Add a local first-turn surface router so ordinary first messages keep the core file/search/edit tool set without preloading optional OpenSwarm MCP surfaces.
- Lazy-load MCP activation, Outputs, BrowserAgent, InvokeAgent, fallback web, and cron surfaces only when the prompt, selected context, or forced tools indicate they are needed.
- Emit an `agent:prompt_ledger` event with character and approximate-token buckets for prompt, system append, MCP config/schema, and tool allow/deny lists.
- Add dummy connector tests plus a benchmark script comparing optimized first-turn payloads against legacy always-on behavior.

## Root Cause

New sessions always attached broad OpenSwarm tool/context surfaces on the first turn, even for plain coding or summarization prompts. That made first messages pay for optional MCP/meta schemas and discovery context before the user needed those capabilities.

## Impact

This does not remove the fixed Claude Code preset overhead, and it does not save much when the very first turn genuinely needs every feature. It reduces avoidable first-turn payload for common prompts by loading optional surfaces on demand.

Dummy connector benchmark from `PYTHONPATH=. python3 backend/scripts/benchmark_first_turn_payload.py`:

| Prompt | Optimized chars | Legacy chars | Saved |
| --- | ---: | ---: | ---: |
| Summarize the repository structure | 1,751 | 8,695 | 79.9% |
| Search the web for current pricing | 1,776 | 8,695 | 79.6% |
| Send an email through Gmail | 3,358 | 8,688 | 61.3% |
| Open the browser and click the login button | 4,110 | 8,704 | 52.8% |
| Render this as a dashboard view | 3,606 | 8,692 | 58.5% |

## Validation

- `PYTHONPATH=. python3 -m pytest backend/tests/test_first_turn_payload.py -q` -> 9 passed
- `PYTHONPATH=.:debugger python3 -m pytest backend/tests -q` -> 782 passed
- `PYTHONPATH=. python3 -m py_compile backend/apps/agents/agent_manager.py backend/tests/test_first_turn_payload.py backend/scripts/benchmark_first_turn_payload.py`
