### PR TITLE
fix: enable dev mode on Windows by exposing install token to frontend

### DIFF
--- a/backend/apps/auth/router.py
+++ b/backend/apps/auth/router.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 from backend.config.Apps import SubApp
 from backend.apps.settings.credentials import OPENSWARM_DEFAULT_PROXY_URL
 from backend.apps.settings.settings import load_settings, save_settings_async
+from backend.config.install_id import get_install_id
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +268,7 @@ async def identity_status():
         }
 
     # Not signed in; defer to cloud for install-age + grace-window math.
-    install_id = getattr(settings_obj, "installation_id", None)
+    install_id = getattr(settings_obj, "installation_id", None) or get_install_id()
     if not install_id:
         # No install_id yet (very fresh install before first sync); hard gate.
         return {"authed": False, "hard_gate": True, "install_age_days": 0, "deadline_ts": None}

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -186,6 +186,7 @@ _AUTH_EXEMPT_EXACT = {
     # public api.openswarm.com/api/oauth/google/refresh doesn't already
     # do for any internet caller, so no new attack surface.
     "/api/tools/google-oauth-token",
+    "/api/dev/token",
 }
 
 _AUTH_EXEMPT_PREFIX = (

--- a/backend/config/Apps.py
+++ b/backend/config/Apps.py
@@ -1,6 +1,7 @@
 import os
 
 from fastapi import FastAPI, APIRouter
+from fastapi.middleware.cors import CORSMiddleware 
 import debug
 from uuid import uuid4
 from typing import List
@@ -37,6 +38,13 @@ class MainApp:
                 yield
                 
         self.app = FastAPI(lifespan=lifespan)
+        self.app.add_middleware(
+            CORSMiddleware , 
+            allow_origins = ["http://localhost:3000"] , 
+            allow_credentials=True , 
+            allow_methods=["*"],
+            allow_headers=["*"], 
+        )
 
         for sub_app in sub_apps:
             self.app.include_router(

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,8 @@ from backend.auth import (
     is_origin_allowed,
 )
 init_auth_token()
+
+
 # Install the log scrubber AFTER the token exists so any log line that
 # accidentally embeds it (subprocess env dumps, urllib retry traces,
 # proxied-request error bodies) gets redacted before hitting handlers.
@@ -384,6 +386,16 @@ async def browser_command(request: Request):
     request_id = uuid4().hex
     result = await ws_manager.send_browser_command(request_id, action, browser_id, params, tab_id=tab_id)
     return JSONResponse(result)
+
+
+@app.get("/api/dev/token")
+async def dev_token(request: Request):
+    """Return the install token for dev mode only.
+    Disabled in packaged builds. Localhost binding is the security gate."""
+    if os.environ.get("OPENSWARM_PACKAGED") == "1":
+        return JSONResponse({"error": "not available"}, status_code=404)
+    from backend.auth import get_auth_token
+    return JSONResponse({"token": get_auth_token()})
 
 
 @app.get("/api/subscriptions/pending/{state}")

--- a/frontend/src/shared/config.ts
+++ b/frontend/src/shared/config.ts
@@ -10,6 +10,19 @@ export const OPENSWARM_DEFAULT_PROXY_URL = 'https://api.openswarm.com';
 let _authTokenCache: string = '';
 let _authTokenPromise: Promise<string> | null = null;
 
+// Dev mode fallback: seed token from env variable when not running in Electron
+if (!(window as any).openswarm) {
+  fetch(`http://${host}:${port}/api/dev/token`)
+    .then(r => r.json())
+    .then(data => {
+      if (data.token) {
+        _authTokenCache = data.token;
+      }
+    })
+    .catch(() => {});
+}
+
+
 export function getAuthToken(): string {
   return _authTokenCache;
 }


### PR DESCRIPTION
## Problem
Dev mode is completely broken on Windows. Two symptoms:

1. Google OAuth throws `install_id must be 8-128 chars` immediately
2. Email OTP verification silently fails on first attempt, then returns "code expired" on retry

# Root Cause 

The per-install auth token is generated by backend and passed to the frontend via 'window.openswarm.getAuthToken()' which is a function injected by the Electron preload script. In dev mode ( split ports , no Electron ) , 'window.openswarm' doesn't exist, so the '_authtokenCache' remains empty and every request goes without a bearer token , getting rejected.

# Fix 
 - Added `/api/dev/token` exempt endpoint that returns the install token 
  when `OPENSWARM_PACKAGED != 1` (localhost binding is the security gate)
- Frontend Fetches the token on startup when 'window.openswarm' is absent 
-  Added `/api/dev/token` to `_AUTH_EXEMPT_EXACT` in `auth.py`

# Testing 

Tested on my windows 11 in dev mode , auth gate clears and dashboards renders nicely with me logged in 

# Files changed : 
- `backend/main.py` — added `/api/dev/token` endpoint
- `backend/auth.py` — added `/api/dev/token` to exempt paths
- `frontend/src/shared/config.ts` — fetch token on startup in dev mode
- `backend/config/Apps.py` — added CORS middleware (cleanup)
- `backend/apps/auth/router.py` — fallback to `get_install_id()` when `installation_id` is None
