### PR TITLE
feat: implement SSRF guard to block private/internal IP fetches and a…

### DIFF
--- a/backend/apps/agents/tools/ssrf_guard.py
+++ b/backend/apps/agents/tools/ssrf_guard.py
@@ -1,0 +1,82 @@
+"""SSRF guard: block fetches to private/internal IP ranges.
+
+Resolves the target hostname to an IP address and rejects any URL whose
+resolved address falls within loopback, LAN, link-local, or cloud-metadata
+ranges (CVE class: CWE-918).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Private / reserved networks that must never be reachable via user URLs
+# ---------------------------------------------------------------------------
+_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.ip_network("127.0.0.0/8"),       # IPv4 loopback
+    ipaddress.ip_network("169.254.0.0/16"),    # link-local / cloud metadata (AWS IMDSv1, GCP, Azure)
+    ipaddress.ip_network("10.0.0.0/8"),        # RFC-1918 private
+    ipaddress.ip_network("172.16.0.0/12"),     # RFC-1918 private
+    ipaddress.ip_network("192.168.0.0/16"),    # RFC-1918 private
+    ipaddress.ip_network("100.64.0.0/10"),     # carrier-grade NAT (RFC 6598)
+    ipaddress.ip_network("0.0.0.0/8"),         # "this" network
+    ipaddress.ip_network("192.0.0.0/24"),      # IETF protocol assignments
+    ipaddress.ip_network("198.18.0.0/15"),     # benchmarking (RFC 2544)
+    ipaddress.ip_network("198.51.100.0/24"),   # TEST-NET-2 (RFC 5737)
+    ipaddress.ip_network("203.0.113.0/24"),    # TEST-NET-3 (RFC 5737)
+    ipaddress.ip_network("240.0.0.0/4"),       # reserved (RFC 1112)
+    ipaddress.ip_network("255.255.255.255/32"),  # broadcast
+    ipaddress.ip_network("::1/128"),           # IPv6 loopback
+    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
+    ipaddress.ip_network("fc00::/7"),          # IPv6 unique-local (ULA, RFC 4193)
+    ipaddress.ip_network("::/128"),            # IPv6 unspecified
+]
+
+
+class SSRFBlockedError(ValueError):
+    """Raised when a URL resolves to a blocked (private/internal) address."""
+
+
+def _resolve_hostname(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Resolve *hostname* to an IP address object.
+
+    Raises ``socket.gaierror`` on DNS failure.
+    """
+    addr_str = socket.gethostbyname(hostname)
+    return ipaddress.ip_address(addr_str)
+
+
+def is_safe_url(url: str) -> bool:
+    """Return True iff *url* is safe to fetch (does not target a private address)."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        addr = _resolve_hostname(hostname)
+        return not any(addr in net for net in _BLOCKED_NETWORKS)
+    except Exception:
+        return False
+
+
+def assert_safe_url(url: str) -> None:
+    """Raise :class:`SSRFBlockedError` if *url* resolves to a private/internal address.
+
+    Also rejects URLs with missing or unresolvable hostnames.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFBlockedError(f"Invalid or missing hostname in URL: {url!r}")
+    try:
+        addr = _resolve_hostname(hostname)
+    except socket.gaierror as exc:
+        raise SSRFBlockedError(f"DNS resolution failed for {hostname!r}: {exc}") from exc
+    for net in _BLOCKED_NETWORKS:
+        if addr in net:
+            raise SSRFBlockedError(
+                f"URL {url!r} resolves to {addr}, which is in blocked range {net} — "
+                "fetching private/internal addresses is not allowed"
+            )

--- a/backend/apps/agents/tools/web.py
+++ b/backend/apps/agents/tools/web.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import html
 import re
 from typing import Any
+from urllib.parse import urljoin
 
 import httpx
 
 from backend.apps.agents.tools.base import BaseTool, ToolContext
+from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
 
 _HTTP_TIMEOUT = 30
 _MAX_OUTPUT_BYTES = 250 * 1024  # ~250 KB covers ~95% of articles/wikis/docs.
@@ -32,6 +34,37 @@ def _strip_html(raw_html: str) -> str:
     text = re.sub(r"[ \t]+", " ", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
+
+
+_MAX_REDIRECTS = 10
+_REDIRECT_CODES = frozenset({301, 302, 303, 307, 308})
+
+
+async def _safe_fetch(url: str) -> httpx.Response:
+    """Fetch *url* with SSRF protection and manual redirect following.
+
+    Each hop (initial URL + every ``Location`` header) is validated against
+    the private-address blocklist before the request is made, so a public URL
+    that 30x-redirects to an internal address is still blocked.
+    """
+    assert_safe_url(url)
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT,
+        follow_redirects=False,  # we follow manually so we can re-validate
+        headers={"User-Agent": _USER_AGENT},
+    ) as client:
+        for _ in range(_MAX_REDIRECTS + 1):
+            resp = await client.get(url)
+            if resp.status_code not in _REDIRECT_CODES:
+                return resp
+            location = resp.headers.get("location", "").strip()
+            if not location:
+                return resp
+            if not location.startswith(("http://", "https://")):
+                location = urljoin(str(resp.url), location)
+            assert_safe_url(location)
+            url = location
+        raise httpx.TooManyRedirects(f"Exceeded {_MAX_REDIRECTS} redirects")
 
 
 class WebSearchTool(BaseTool):
@@ -168,13 +201,10 @@ class WebFetchTool(BaseTool):
         prompt: str | None = input_data.get("prompt")
 
         try:
-            async with httpx.AsyncClient(
-                timeout=_HTTP_TIMEOUT,
-                follow_redirects=True,
-                headers={"User-Agent": _USER_AGENT},
-            ) as client:
-                resp = await client.get(url)
-                resp.raise_for_status()
+            resp = await _safe_fetch(url)
+            resp.raise_for_status()
+        except SSRFBlockedError as exc:
+            return [{"type": "text", "text": f"Blocked: {exc}"}]
         except httpx.HTTPStatusError as exc:
             return [{"type": "text", "text": f"HTTP error {exc.response.status_code} fetching {url}"}]
         except Exception as exc:

--- a/backend/apps/agents/web_mcp_server.py
+++ b/backend/apps/agents/web_mcp_server.py
@@ -15,9 +15,21 @@ FETCH_URL = f"http://127.0.0.1:{BACKEND_PORT}/api/web/fetch"
 # Primary-provider hint from agent_manager; backend picks the native search tool (googleSearch/web_search_preview) so searches use the user's existing budget.
 PRIMARY_HINT = os.environ.get("OPENSWARM_PRIMARY_API", "") or None
 
+# ---------------------------------------------------------------------------
+# SSRF guard — import from shared module; fail closed if unavailable
+# ---------------------------------------------------------------------------
+try:
+    from backend.apps.agents.tools.ssrf_guard import is_safe_url as _is_safe_url
+except ImportError:
+    # If the backend package is not on sys.path (unusual), deny all fetches
+    # rather than silently skipping the check.
+    def _is_safe_url(url: str) -> bool:  # type: ignore[misc]
+        return False
+
+
+# ---------------------------------------------------------------------------
 TOOLS = [
     {
-        "name": "WebSearch",
         "description": (
             "Search the web using DuckDuckGo and return titles, URLs, and "
             "snippets for the top results. Works on any model primary, "
@@ -121,6 +133,8 @@ def handle_tool_call(tool_name: str, arguments: dict) -> dict:
             return {"content": [{"type": "text", "text": "Error: url is required"}], "isError": True}
         if not url.startswith(("http://", "https://")):
             return {"content": [{"type": "text", "text": f"Error: url must start with http:// or https:// (got {url!r})"}], "isError": True}
+        if not _is_safe_url(url):
+            return {"content": [{"type": "text", "text": f"Error: URL {url!r} is blocked — fetching private or internal addresses is not allowed"}], "isError": True}
         prompt = arguments.get("prompt") or None
         body = {"url": url}
         if prompt:

--- a/backend/apps/web/web.py
+++ b/backend/apps/web/web.py
@@ -18,6 +18,8 @@ from typeguard import typechecked
 
 import debug
 
+from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
 from backend.config.Apps import SubApp
 
 
@@ -503,6 +505,11 @@ async def search(body: SearchBody) -> dict:
 @typechecked
 async def fetch(body: FetchBody) -> dict:
     """Fetch a URL, primary-aware. Mirrors /search cascade logic."""
+    try:
+        assert_safe_url(body.url)
+    except SSRFBlockedError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
     gemini_key = _resolve_gemini_api_key()
     openai_key = _resolve_openai_api_key()
     primary = (body.primary or "").lower()

--- a/backend/tests/test_ssrf_guard.py
+++ b/backend/tests/test_ssrf_guard.py
@@ -1,0 +1,335 @@
+"""Tests for SSRF protection (CWE-918).
+
+Covers:
+- ssrf_guard.is_safe_url / assert_safe_url
+- WebFetchTool.execute blocks private targets
+- /api/web/fetch endpoint rejects blocked URLs
+- Redirect-pivot attack is blocked
+- web_mcp_server _is_safe_url inline guard
+
+Run:
+    cd /home/anushkrishna/Documents/Projects/openswarm
+    python -m pytest backend/tests/test_ssrf_guard.py -v
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the project root is importable
+# ---------------------------------------------------------------------------
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+_tmpdir = tempfile.mkdtemp()
+os.environ.setdefault("OPENSWARM_DATA_DIR", _tmpdir)
+
+
+# ===========================================================================
+# ssrf_guard module
+# ===========================================================================
+
+class TestIsBlockedNetworks:
+    """is_safe_url returns False for every category of private address."""
+
+    @pytest.mark.parametrize("url,reason", [
+        ("http://127.0.0.1/", "IPv4 loopback"),
+        ("http://127.1.2.3/", "loopback range"),
+        ("http://169.254.169.254/latest/meta-data/", "AWS IMDSv1"),
+        ("http://169.254.0.1/", "link-local"),
+        ("http://10.0.0.1/", "RFC-1918 10.x"),
+        ("http://10.255.255.255/", "RFC-1918 10.x boundary"),
+        ("http://172.16.0.1/", "RFC-1918 172.16.x"),
+        ("http://172.31.255.254/", "RFC-1918 172.31.x boundary"),
+        ("http://192.168.1.1/admin", "RFC-1918 192.168.x"),
+        ("http://192.168.0.0/", "RFC-1918 192.168.0 network"),
+        ("http://100.64.0.1/", "carrier-grade NAT"),
+        ("http://0.0.0.1/", "this-network range"),
+        ("http://240.0.0.1/", "reserved range"),
+        ("http://255.255.255.255/", "broadcast"),
+    ])
+    def test_blocked_ipv4(self, url, reason):
+        from backend.apps.agents.tools.ssrf_guard import is_safe_url
+
+        hostname = url.split("//")[1].split("/")[0]
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address(hostname)
+            assert is_safe_url(url) is False, f"Expected {url!r} ({reason}) to be blocked"
+
+    @pytest.mark.parametrize("url,addr,reason", [
+        ("http://[::1]/", "::1", "IPv6 loopback"),
+        ("http://[fe80::1]/", "fe80::1", "IPv6 link-local"),
+        ("http://[fc00::1]/", "fc00::1", "IPv6 ULA"),
+        ("http://[fd12:3456::1]/", "fd12:3456::1", "IPv6 ULA fd-prefix"),
+        ("http://[::]/", "::", "IPv6 unspecified"),
+    ])
+    def test_blocked_ipv6(self, url, addr, reason):
+        from backend.apps.agents.tools.ssrf_guard import is_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address(addr)
+            assert is_safe_url(url) is False, f"Expected {url!r} ({reason}) to be blocked"
+
+    @pytest.mark.parametrize("url,addr", [
+        ("https://example.com/", "93.184.216.34"),
+        ("https://github.com/", "140.82.121.3"),
+        ("http://1.1.1.1/", "1.1.1.1"),
+        ("https://8.8.8.8/", "8.8.8.8"),
+    ])
+    def test_public_urls_allowed(self, url, addr):
+        from backend.apps.agents.tools.ssrf_guard import is_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address(addr)
+            assert is_safe_url(url) is True
+
+    def test_missing_hostname_blocked(self):
+        from backend.apps.agents.tools.ssrf_guard import is_safe_url
+
+        assert is_safe_url("http:///path") is False
+        assert is_safe_url("not-a-url") is False
+
+    def test_dns_failure_blocked(self):
+        import socket
+        from backend.apps.agents.tools.ssrf_guard import is_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   side_effect=socket.gaierror("NXDOMAIN")):
+            assert is_safe_url("http://does-not-exist.invalid/") is False
+
+
+class TestAssertSafeUrl:
+    """assert_safe_url raises SSRFBlockedError for blocked targets."""
+
+    def test_raises_for_loopback(self):
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("127.0.0.1")
+            with pytest.raises(SSRFBlockedError, match="blocked range"):
+                assert_safe_url("http://127.0.0.1/")
+
+    def test_raises_for_metadata(self):
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("169.254.169.254")
+            with pytest.raises(SSRFBlockedError, match="blocked range"):
+                assert_safe_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_raises_for_lan(self):
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("192.168.1.1")
+            with pytest.raises(SSRFBlockedError, match="blocked range"):
+                assert_safe_url("http://192.168.1.1/admin")
+
+    def test_raises_for_missing_hostname(self):
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
+        with pytest.raises(SSRFBlockedError, match="missing hostname"):
+            assert_safe_url("http:///no-host")
+
+    def test_raises_for_dns_failure(self):
+        import socket
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError, assert_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   side_effect=socket.gaierror("NXDOMAIN")):
+            with pytest.raises(SSRFBlockedError, match="DNS resolution failed"):
+                assert_safe_url("http://nonexistent.invalid/")
+
+    def test_passes_for_public(self):
+        from backend.apps.agents.tools.ssrf_guard import assert_safe_url
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("93.184.216.34")
+            assert_safe_url("https://example.com/")  # must not raise
+
+
+# ===========================================================================
+# WebFetchTool — SSRF checks in execute()
+# ===========================================================================
+
+class TestWebFetchToolSSRF:
+    """WebFetchTool.execute must block private URLs."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_loopback(self):
+        from backend.apps.agents.tools.ssrf_guard import SSRFBlockedError
+        from backend.apps.agents.tools.web import WebFetchTool
+
+        tool = WebFetchTool()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("127.0.0.1")
+            result = await tool.execute({"url": "http://127.0.0.1:8080/"}, context=None)
+
+        assert result[0]["type"] == "text"
+        assert "Blocked" in result[0]["text"] or "blocked" in result[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_blocks_cloud_metadata(self):
+        from backend.apps.agents.tools.web import WebFetchTool
+
+        tool = WebFetchTool()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("169.254.169.254")
+            result = await tool.execute(
+                {"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+                context=None,
+            )
+
+        text = result[0]["text"].lower()
+        assert "block" in text or "not allowed" in text
+
+    @pytest.mark.asyncio
+    async def test_blocks_private_lan(self):
+        from backend.apps.agents.tools.web import WebFetchTool
+
+        tool = WebFetchTool()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname") as mock_resolve:
+            mock_resolve.return_value = ipaddress.ip_address("192.168.1.1")
+            result = await tool.execute({"url": "http://192.168.1.1/admin"}, context=None)
+
+        text = result[0]["text"].lower()
+        assert "block" in text or "not allowed" in text
+
+    @pytest.mark.asyncio
+    async def test_redirect_pivot_blocked(self):
+        """A public URL that 301-redirects to an internal address must be blocked."""
+        import httpx
+        from backend.apps.agents.tools.web import WebFetchTool
+
+        tool = WebFetchTool()
+
+        redirect_response = MagicMock(spec=httpx.Response)
+        redirect_response.status_code = 301
+        redirect_response.headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+        redirect_response.url = "https://attacker.com/r"
+
+        public_addr = ipaddress.ip_address("203.0.113.1")
+        metadata_addr = ipaddress.ip_address("169.254.169.254")
+
+        def resolve_side_effect(hostname):
+            if "attacker" in hostname:
+                return public_addr
+            return metadata_addr
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   side_effect=resolve_side_effect):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client.get = AsyncMock(return_value=redirect_response)
+                mock_client_cls.return_value = mock_client
+
+                result = await tool.execute(
+                    {"url": "https://attacker.com/r"}, context=None
+                )
+
+        text = result[0]["text"].lower()
+        assert "block" in text or "not allowed" in text
+
+    @pytest.mark.asyncio
+    async def test_public_url_fetched_normally(self):
+        """Public URLs still work — guard does not block legitimate fetches."""
+        import httpx
+        from backend.apps.agents.tools.web import WebFetchTool
+
+        tool = WebFetchTool()
+        public_addr = ipaddress.ip_address("93.184.216.34")
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/plain"}
+        mock_resp.text = "Hello, world!"
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=public_addr):
+            with patch("httpx.AsyncClient") as mock_client_cls:
+                mock_client = AsyncMock()
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_client.get = AsyncMock(return_value=mock_resp)
+                mock_client_cls.return_value = mock_client
+
+                result = await tool.execute(
+                    {"url": "https://example.com/"}, context=None
+                )
+
+        assert result[0]["type"] == "text"
+        assert "Hello, world!" in result[0]["text"]
+
+
+# ===========================================================================
+# web_mcp_server — inline _is_safe_url guard
+# ===========================================================================
+
+class TestMCPServerSSRFGuard:
+    """The standalone MCP server's _is_safe_url must reject private addresses."""
+
+    def _import_mcp(self):
+        import importlib
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "web_mcp_server",
+            os.path.join(_PROJECT_ROOT, "backend/apps/agents/web_mcp_server.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_loopback_blocked(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("127.0.0.1")):
+            assert mod._is_safe_url("http://127.0.0.1/") is False
+
+    def test_metadata_blocked(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("169.254.169.254")):
+            assert mod._is_safe_url("http://169.254.169.254/") is False
+
+    def test_lan_blocked(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("192.168.1.1")):
+            assert mod._is_safe_url("http://192.168.1.1/admin") is False
+
+    def test_public_allowed(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("93.184.216.34")):
+            assert mod._is_safe_url("https://example.com/") is True
+
+    def test_handle_tool_call_blocks_private(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("127.0.0.1")):
+            result = mod.handle_tool_call("WebFetch", {"url": "http://127.0.0.1/"})
+        assert result.get("isError") is True
+        assert "blocked" in result["content"][0]["text"].lower()
+
+    def test_handle_tool_call_blocks_metadata(self):
+        mod = self._import_mcp()
+        with patch("backend.apps.agents.tools.ssrf_guard._resolve_hostname",
+                   return_value=ipaddress.ip_address("169.254.169.254")):
+            result = mod.handle_tool_call(
+                "WebFetch",
+                {"url": "http://169.254.169.254/latest/meta-data/"},
+            )
+        assert result.get("isError") is True
+        assert "blocked" in result["content"][0]["text"].lower()


### PR DESCRIPTION
Closes #47 
 
 Fixes CWE-918 (Server-Side Request Forgery) in the WebFetch tool.
 
 ## Problem
 WebFetch performed zero host/IP validation before fetching URLs. Any
 http:// URL — including http://169.254.169.254/ (cloud metadata) and
 RFC-1918 LAN addresses — passed through. `follow_redirects=True` made
 it worse: a public URL redirecting to an internal address bypassed any
 hypothetical scheme-only check entirely.
 
 ## Changes
 - **`tools/ssrf_guard.py`** (new): single source of truth for the
   blocked-network list (loopback, link-local/cloud-metadata, RFC-1918,
   CGN, IPv6 ULA). Exposes `is_safe_url()` and `assert_safe_url()` /
   `SSRFBlockedError`.
 - **`tools/web.py`**: replaced `follow_redirects=True` with a manual
   `_safe_fetch()` that calls `assert_safe_url()` on the initial URL
   **and** every `Location` header before following it.
 - **`apps/web/web.py`**: `/api/web/fetch` calls `assert_safe_url()`
   before any cascade — returns HTTP 422 if blocked.
 - **`web_mcp_server.py`**: imports `is_safe_url` from `ssrf_guard`
   (fail-closed fallback if package unavailable); checks URL after the
   scheme guard.
 
 ## Tests
 42 new tests in `tests/test_ssrf_guard.py` covering:
 - Every blocked range (loopback, 169.254.x, RFC-1918, CGN, IPv6)
 - DNS failure → blocked
 - Missing hostname → blocked
 - Public URLs still allowed
 - Redirect-pivot attack blocked (public → internal 301)
 - MCP shim guard
 - Zero regressions against existing suite