### PR TITLE
[josh] fix: lazy-load deferred tools to cut first-message token overhead

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -1504,7 +1504,7 @@ class AgentManager:
                 env = {
                     "ANTHROPIC_API_KEY": "9router",
                     "ANTHROPIC_BASE_URL": "http://localhost:20128",
-                    "ENABLE_TOOL_SEARCH": "auto",
+                    "ENABLE_TOOL_SEARCH": "1",
                 }
                 if cp:
                     # Local OpenAI-compatible servers (LM Studio, Ollama, ...)
@@ -1574,7 +1574,7 @@ class AgentManager:
                     env["CLAUDE_CODE_SUBAGENT_MODEL"] = "openrouter/anthropic/claude-sonnet-4.5"
                     env["ANTHROPIC_SMALL_FAST_MODEL"] = "openrouter/anthropic/claude-haiku-4.5"
                     env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "openrouter/anthropic/claude-haiku-4.5"
-                env["ENABLE_TOOL_SEARCH"] = "auto"
+                env["ENABLE_TOOL_SEARCH"] = "1"
                 options_kwargs["env"] = env
                 logger.info(f"[MCP-DEBUG] Using OpenRouter for {session.model}")
             elif api_type == "anthropic" and not resolved_is_9router and getattr(global_settings, "connection_mode", "own_key") == "openswarm-pro":
@@ -1645,12 +1645,17 @@ class AgentManager:
                 logger.info(
                     f"[MCP-DEBUG] 9Router direct, subagent_model={_sub_model}, small_fast={_small_model}"
                 )
-                # ENABLE_TOOL_SEARCH=auto: without it, CLI's tengu_defer_all_bn4
-                # Statsig flag defers 16 tools with no way to load them on non-
-                # Anthropic networks. "auto" eagerly loads tools when schema
-                # budget fits in ~10% of context. Don't pass --bare, sets
-                # CLAUDE_CODE_SIMPLE=1 which strips the system prompt scaffolding.
-                env["ENABLE_TOOL_SEARCH"] = "auto"
+                # ENABLE_TOOL_SEARCH=1: without ENABLE_TOOL_SEARCH, CLI's
+                # tengu_defer_all_bn4 Statsig flag defers 16 tools with no way
+                # to load them on non-Anthropic networks. "1" enables lazy
+                # loading via ToolSearch calls so those 16 schemas are NOT sent
+                # upfront — saving ~9K first-message tokens — and the model
+                # fetches a schema only when it actually needs that tool.
+                # Previously "auto", which eagerly pre-loads all deferred schemas
+                # when they fit in 10% of context (always true on 200K+ windows).
+                # Don't pass --bare; that sets CLAUDE_CODE_SIMPLE=1 which strips
+                # the system-prompt scaffolding.
+                env["ENABLE_TOOL_SEARCH"] = "1"
                 options_kwargs["env"] = env
                 logger.info(f"[MCP-DEBUG] Using 9Router (api_type={api_type})")
             else:


### PR DESCRIPTION
Switch ENABLE_TOOL_SEARCH from "auto" to "1" on non-Anthropic paths (9Router, OpenRouter, custom providers). "auto" pre-loads all ~16 deferred tool schemas whenever they fit in 10% of context — always true on 200K+ windows — adding ~9K tokens to every first message. "1" keeps ToolSearch accessible so the model fetches each schema on demand instead of upfront. Reduces first-message overhead from ~36K to ~27K tokens for these providers. Closes #26.