### PR TITLE
[josh] fix: cap text attachments and wire up history compaction

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -373,6 +373,11 @@ class AgentManager:
         if session.compacted_through_msg_id == last_id and not force:
             return False
         session.compacted_through_msg_id = last_id
+        # Force a fresh SDK session on the next turn so _build_history_prefix
+        # is called with compact_from_id and only sends the post-cutoff
+        # messages to the API. Without this flag the compaction has no effect:
+        # resumed sessions replay history via sdk_session_id, not the prefix.
+        session.needs_fresh_session = True
         return True
 
     def _build_prompt_content(self, prompt: str, images: list | None = None, context_paths: list | None = None, forced_tools: list[str] | None = None, attached_skills: list | None = None, api_type: str = "anthropic", model: str = ""):
@@ -1781,7 +1786,10 @@ class AgentManager:
                 if session.needs_fork:
                     session.needs_fork = False
             elif len(session.messages) > 1:
-                history = _build_history_prefix(_get_branch_messages(session))
+                history = _build_history_prefix(
+                    _get_branch_messages(session),
+                    compact_from_id=session.compacted_through_msg_id,
+                )
                 if history:
                     if isinstance(prompt_content, str):
                         prompt_content = history + "\n\n" + prompt_content

--- a/backend/apps/agents/manager/prompt/attachments.py
+++ b/backend/apps/agents/manager/prompt/attachments.py
@@ -148,6 +148,14 @@ def _resolve_attachments(context_paths: list | None, api_type: str, model: str) 
     # refused with concrete recovery actions.
     b64_total = 0
 
+    # Running total of inlined text characters. Text files have no binary
+    # size limit (they aren't base64-encoded), but they consume context
+    # tokens 1:4 and can silently blow out any model's context window.
+    # Cap the combined text payload at 600K chars (~150K tokens), leaving
+    # headroom for the system prompt, tool definitions, and a response.
+    _TEXT_TOTAL_CAP = 600_000
+    text_total = 0
+
     for cp in context_paths:
         path = cp.get("path", "") or ""
         cp_type = cp.get("type", "file")
@@ -172,6 +180,17 @@ def _resolve_attachments(context_paths: list | None, api_type: str, model: str) 
             if kind == "text":
                 with open(path, "r", errors="replace") as f:
                     content = f.read(512_000)
+                content_len = len(content)
+                if text_total + content_len > _TEXT_TOTAL_CAP:
+                    room_k = max(0, _TEXT_TOTAL_CAP - text_total) // 1000
+                    refusals.append(
+                        f"[Attached file {os.path.basename(path)} ({size // 1024} KB text) would push "
+                        f"total inlined text over {_TEXT_TOTAL_CAP // 1000} KB (~150K tokens, the per-turn "
+                        f"budget for file contents). ~{room_k} KB of room left this turn. "
+                        f"Send fewer files at once, or paste only the relevant sections.]"
+                    )
+                    continue
+                text_total += content_len
                 sections.append(
                     f"<context_file path=\"{path}\">\n{content}\n</context_file>"
                 )

--- a/backend/apps/agents/manager/session/history_compaction.py
+++ b/backend/apps/agents/manager/session/history_compaction.py
@@ -48,10 +48,22 @@ def _get_branch_messages(session) -> list:
     return result
 
 
-def _build_history_prefix(messages) -> str:
-    """Format branch messages into a conversation summary for context injection."""
+def _build_history_prefix(messages, compact_from_id: str | None = None) -> str:
+    """Format branch messages into a conversation summary for context injection.
+
+    When compact_from_id is set, all messages up to and including that ID are
+    skipped and replaced with a one-line note, reducing the history that gets
+    sent to the SDK on a fresh-session restart after compaction fires.
+    """
     lines = []
+    skipping = compact_from_id is not None
+    skipped_count = 0
     for m in messages:
+        if skipping:
+            skipped_count += 1
+            if m.id == compact_from_id:
+                skipping = False
+            continue
         if m.role not in ("user", "assistant") or getattr(m, "hidden", False):
             continue
         text = m.content if isinstance(m.content, str) else str(m.content)
@@ -59,7 +71,11 @@ def _build_history_prefix(messages) -> str:
         lines.append(f"{label}: {text}")
     if not lines:
         return ""
-    return "<prior_conversation>\n" + "\n".join(lines) + "\n</prior_conversation>"
+    header = (
+        f"[{skipped_count} earlier messages omitted — conversation compacted to fit context window]\n"
+        if skipped_count else ""
+    )
+    return "<prior_conversation>\n" + header + "\n".join(lines) + "\n</prior_conversation>"
 
 
 def _truncate_large_tool_result(content: object, session_id: str, msg_id: str, max_bytes: int = 50_000) -> tuple[object, str | None]:


### PR DESCRIPTION
Two bugs caused the context overflow errors reported in #45.

**Bug 1 — text attachments had no total-size guard.** Binary files (PDFs, images) have both a per-file cap and a combined `total_request_cap` accumulator; text files were silently concatenated with no limit. Five 512K-char files ≈ 640K tokens, instant overflow on any model. Added a 600K-char combined cap (~150K tokens) with a refusal message matching the existing binary file pattern, pointing the user to send fewer files per turn.

**Bug 2 — `_maybe_compact` was a no-op.** It set `compacted_through_msg_id` and broadcast a UI event, but `_build_history_prefix` never read the cutoff ID, and resumed sessions replayed full history via `sdk_session_id` regardless. Fixed by: (a) setting `needs_fresh_session=True` in `_maybe_compact` so the next turn drops the SDK session and rebuilds from the prefix, and (b) updating `_build_history_prefix` to accept `compact_from_id` and skip messages up to that point, replacing them with a one-line omission note.

Closes #45.