### PR TITLE
[karthik] fix: resolve debugger filepath-not-found on Linux

### DIFF
--- a/debugger/debugger_backend/Debugleton.py
+++ b/debugger/debugger_backend/Debugleton.py
@@ -1,5 +1,6 @@
 # Haik: sorry bout the filename
 
+import sys
 import threading
 from debugger_backend.project_scanner import update_debug_toggles
 from debugger_backend.Directory import Directory
@@ -75,12 +76,15 @@ class Debugleton:
         return self.sync_lock.locked()
 
     def find_file_info(self, filepath: str):
-        filepath = filepath.lower()
         # print(f"Finding file info for {filepath}")
         if self.needs_resync():
             self.sync_to_saved()
         try:
-            filepath_id = self.abspaths.index(filepath)
+            if sys.platform == "darwin":
+                abspaths = [p.lower() for p in self.abspaths]
+                filepath_id = abspaths.index(filepath.lower())
+            else:
+                filepath_id = self.abspaths.index(filepath)
             match = self.instances[filepath_id]
             return match.color, match.is_toggled, match.emoji
         except ValueError:

--- a/debugger/debugger_backend/Directory.py
+++ b/debugger/debugger_backend/Directory.py
@@ -41,7 +41,7 @@ class Directory:
             ordered_abspaths.append({"abspath": full_path, "instance": dir})
             # print(f"\t[construct_ordered_abspaths]: Full path: {full_path}")
             for child in dir.children:
-                child_abspath = os.path.join(root_dir, child.path).lower()
+                child_abspath = os.path.join(root_dir, child.path)
                 if os.path.isdir(child_abspath):
                     construct_ordered_abspaths(child, ordered_abspaths)
                 elif os.path.isfile(child_abspath):


### PR DESCRIPTION
## What

Fixes `Filepath not found: <lowercase-path>` spam on Linux startup, and the debugger failing to index any mixed-case file (e.g. `Apps.py`, `Directory.py`).

Closes #58.

## Root cause

Two `.lower()` calls interacted to silently break the debugger on Linux:

**`debugger/debugger_backend/Directory.py:44`**
```python
# Before
child_abspath = os.path.join(root_dir, child.path).lower()
if os.path.isfile(child_abspath):   # Always False on Linux for mixed-case names
    ordered_abspaths.append(...)    # Never reached → file not indexed
```
`os.path.isfile("apps.py")` returns `False` on Linux when the real file is `Apps.py`. Files are silently dropped from the index.

**`debugger/debugger_backend/Debugleton.py:78`**
```python
# Before
filepath = filepath.lower()
filepath_id = self.abspaths.index(filepath)  # No match → "Filepath not found"
```

macOS HFS+/APFS is case-insensitive so both sides match regardless — the bug is invisible there.

## Fix

Store real filesystem paths always. On `darwin` only, lowercase both the stored list and the lookup at compare time.

```python
# Directory.py — remove .lower() before existence check
child_abspath = os.path.join(root_dir, child.path)

# Debugleton.py — platform-aware comparison
if sys.platform == "darwin":
    abspaths = [p.lower() for p in self.abspaths]
    filepath_id = abspaths.index(filepath.lower())
else:
    filepath_id = self.abspaths.index(filepath)
```

## Test

Run `bash backend/run.sh` on Linux — no more `Filepath not found` lines on startup.