### PR TITLE
[aidan] chat: improvements to text loading

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -1768,27 +1768,20 @@ class AgentManager:
             except Exception as e:
                 logger.debug(f"thinking_level param injection skipped: {e}")
 
-            # MCPActivate fresh-restart path: when the session has prior
-            # turns AND the user just activated a new MCP, the bundled CLI
-            # won't re-read mcp_servers from a `resume + fork_session`
-            # combo (the transport snapshot from the original launch is
-            # what serves tool schemas). Symptom: model calls hallucinated
-            # names like `Searchgmail`/`Listemails` instead of the real
-            # `mcp__google-workspace__query_gmail_emails` because it
-            # never received the schemas. Soft restart: drop resume +
-            # sdk_session_id, replay history via the prompt, let the SDK
-            # build a clean transport with the activated server in its
-            # mcp_servers dict from the start. Costs one cold-start TTFT
-            # (~200-400ms) on the auto-continuation turn; that turn is
-            # already happening anyway because pending_continuation fires
-            # right after MCPActivate.
-            if session.needs_fresh_session and session.sdk_session_id:
-                logger.info(
-                    f"[MCP-DEBUG] Fresh-session restart for {session_id}: dropping "
-                    f"sdk_session_id={session.sdk_session_id} so the new MCP servers "
-                    f"({session.active_mcps}) take effect."
-                )
-                session.sdk_session_id = None
+            # Fresh-restart path: some session changes must not reuse the
+            # CLI's resume transcript. MCPActivate needs a new transport so
+            # tool schemas are reread; branch edits/switches need the model
+            # to see only _get_branch_messages(session), not facts from the
+            # old branch's SDK transcript. Soft restart: drop resume +
+            # sdk_session_id, replay local history via the prompt, let the
+            # SDK build a clean session from the current app state.
+            if session.needs_fresh_session:
+                if session.sdk_session_id:
+                    logger.info(
+                        f"Fresh-session restart for {session_id}: dropping "
+                        f"sdk_session_id={session.sdk_session_id}; active_mcps={session.active_mcps}"
+                    )
+                    session.sdk_session_id = None
                 session.needs_fresh_session = False
                 session.needs_fork = False  # superseded by the fresh restart
 
@@ -3569,6 +3562,7 @@ class AgentManager:
         )
         session.branches[new_branch_id] = new_branch
         session.active_branch_id = new_branch_id
+        session.needs_fresh_session = True
 
 
         edited_msg = Message(
@@ -3617,6 +3611,7 @@ class AgentManager:
         if branch_id not in session.branches:
             raise ValueError(f"Branch {branch_id} not found")
         session.active_branch_id = branch_id
+        session.needs_fresh_session = True
         await ws_manager.send_to_session(session_id, "agent:branch_switched", {
             "session_id": session_id,
             "active_branch_id": branch_id,

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -1759,7 +1759,10 @@ class AgentManager:
                     level = "off"
                 if api_type == "anthropic":
                     if level == "off":
-                        options_kwargs["thinking"] = {"type": "disabled"}
+                        # Fable 5 400s on an explicit thinking:disabled; you turn it
+                        # off there by omitting the param (off is Fable's default).
+                        if not (isinstance(resolved_model, str) and "fable" in resolved_model):
+                            options_kwargs["thinking"] = {"type": "disabled"}
                     elif level in ("low", "medium", "high"):
                         options_kwargs["effort"] = level
             except Exception as e:

--- a/backend/apps/agents/agents.py
+++ b/backend/apps/agents/agents.py
@@ -628,6 +628,10 @@ async def list_models():
             # by the subscription, not pay-per-use.
             for r in rows:
                 r["billing_kind"] = "subscription"
+            # Sub-only models with no adaptive twin (Fable 5) won't ride the relabeled rows, so add their cc/ entry.
+            adaptive_ids = {m.get("model_id") for m in adaptive}
+            cc_only = [m for m in cc_variants if m.get("model_id") not in adaptive_ids]
+            rows = _serialize(cc_only) + rows
         # With BOTH a key and a sub the adaptive rows above run on the key, so also surface the
         # subscription (cc) variants; they route via 9router's cc/ lane and stay selectable, the
         # way OpenAI/Gemini show both a subscription row and an API-key row.

--- a/backend/apps/agents/agents.py
+++ b/backend/apps/agents/agents.py
@@ -618,6 +618,11 @@ async def list_models():
                     r["label"] += " (API key)"
                 r["billing_kind"] = "api_key"
                 r["is_free"] = False
+            # Models that only exist on the API-key route (Fable 5, whose sub route 404s
+            # on our pinned 9Router) have no adaptive twin to relabel, so add them or they vanish.
+            adaptive_ids = {m.get("model_id") for m in adaptive}
+            api_only = [m for m in api_variants if m.get("model_id") not in adaptive_ids]
+            rows = _serialize(api_only) + rows
         elif has_claude_sub:
             # Only a sub: the adaptive rows route through 9router's cc/ lane, so they're covered
             # by the subscription, not pay-per-use.

--- a/backend/apps/agents/providers/pricing.py
+++ b/backend/apps/agents/providers/pricing.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 # open / strong sub, 3 solid mid, 2 small specialised, 1 nano.
 MODEL_TIERS: dict[str, tuple[int, int, int]] = {
     # Anthropic
+    "claude-fable-5":               (5, 2, 5),
+    "anthropic/claude-fable-5":     (5, 2, 5),
     "claude-opus-4-8":              (5, 2, 5),
     "claude-opus-4.8":              (5, 2, 5),
     "anthropic/claude-opus-4.8":    (5, 2, 5),

--- a/backend/apps/agents/providers/registry.py
+++ b/backend/apps/agents/providers/registry.py
@@ -67,9 +67,11 @@ BUILTIN_MODELS: dict[str, list[dict[str, Any]]] = {
          "model_id": "claude-haiku-4-5", "router_model_id": "cc/claude-haiku-4-5-20251001", "api": "anthropic", "reasoning": True, "route": "cc"},
 
         # Fable 5 (released 2026-05-28): new flagship tier ABOVE Opus, 1M ctx,
-        # 128k out, $10/$50. API-key route only: a brand-new id 404s on our pinned
-        # 9Router 0.3.60 sub route (same as GPT-5.5's cx entry), and Claude-sub
-        # serving of Fable is unverified, add the cc/ entry once it's proven live.
+        # 128k out, $10/$50. The cc/ sub row is on trial: brand-new ids have 404'd
+        # our pinned 9Router 0.3.60 before (GPT-5.5's cx entry did) and Claude-sub
+        # serving of Fable is unverified, so pull this row if it errors live.
+        {"value": "fable-5-cc", "label": "Claude Fable 5", "context_window": 1_000_000,
+         "model_id": "claude-fable-5", "router_model_id": "cc/claude-fable-5", "api": "anthropic", "reasoning": True, "route": "cc"},
         {"value": "fable-5-api", "label": "Claude Fable 5 (API key)", "context_window": 1_000_000,
          "model_id": "claude-fable-5", "router_model_id": "claude-fable-5", "api": "anthropic", "reasoning": True, "route": "api"},
         {"value": "opus-4-8-api", "label": "Claude Opus 4.8 (API key)", "context_window": 1_000_000,

--- a/backend/apps/agents/providers/registry.py
+++ b/backend/apps/agents/providers/registry.py
@@ -66,6 +66,12 @@ BUILTIN_MODELS: dict[str, list[dict[str, Any]]] = {
         {"value": "haiku-cc", "label": "Claude Haiku 4.5", "context_window": 200_000,
          "model_id": "claude-haiku-4-5", "router_model_id": "cc/claude-haiku-4-5-20251001", "api": "anthropic", "reasoning": True, "route": "cc"},
 
+        # Fable 5 (released 2026-05-28): new flagship tier ABOVE Opus, 1M ctx,
+        # 128k out, $10/$50. API-key route only: a brand-new id 404s on our pinned
+        # 9Router 0.3.60 sub route (same as GPT-5.5's cx entry), and Claude-sub
+        # serving of Fable is unverified, add the cc/ entry once it's proven live.
+        {"value": "fable-5-api", "label": "Claude Fable 5 (API key)", "context_window": 1_000_000,
+         "model_id": "claude-fable-5", "router_model_id": "claude-fable-5", "api": "anthropic", "reasoning": True, "route": "api"},
         {"value": "opus-4-8-api", "label": "Claude Opus 4.8 (API key)", "context_window": 1_000_000,
          "model_id": "claude-opus-4-8", "router_model_id": "claude-opus-4-8", "api": "anthropic", "reasoning": True, "route": "api"},
         {"value": "opus-4-7-api", "label": "Claude Opus 4.7 (API key)", "context_window": 1_000_000,

--- a/backend/apps/agents/providers/registry.py
+++ b/backend/apps/agents/providers/registry.py
@@ -406,6 +406,7 @@ COST_PER_1M_TOKENS: dict[tuple[str, str], tuple[float, float]] = {
     ("Anthropic", "opus"): (5.0, 25.0),
     ("Anthropic", "opus-4-7"): (5.0, 25.0),
     ("Anthropic", "opus-4-8"): (5.0, 25.0),
+    ("Anthropic", "fable-5-api"): (10.0, 50.0),
     ("Anthropic", "haiku"): (1.0, 5.0),
     # OpenAI; Codex subscription path, user pays nothing per token
     ("OpenAI", "gpt-5.5"): (0.0, 0.0),

--- a/backend/apps/agents/providers/thinking.py
+++ b/backend/apps/agents/providers/thinking.py
@@ -20,6 +20,10 @@ def thinking_params_for(api: str, level: str, model_id: str = "") -> dict | None
 
     if level == "off":
         if api == "anthropic":
+            # Fable 5 400s on an explicit thinking:disabled; omit the param to
+            # turn thinking off (off is its default). Other Claude models accept it.
+            if "fable" in model_id:
+                return None
             return {"thinking": {"type": "disabled"}}
         if api == "codex":
             return {"reasoning": {"effort": "none"}}

--- a/backend/apps/auth/router.py
+++ b/backend/apps/auth/router.py
@@ -47,6 +47,17 @@ def _proxy_url() -> str:
     return url.rstrip("/")
 
 
+async def _sync_pro_routing(settings_obj) -> None:
+    """Mirror connection state into 9Router's Claude lane; sign-in can flip a
+    paying user into pro mode and sign-out must tear the lane down so a
+    revoked bearer doesn't linger in the router."""
+    try:
+        from backend.apps.nine_router import sync_pro_routing
+        await sync_pro_routing(settings_obj)
+    except Exception as e:
+        logger.debug("pro routing sync skipped: %s", e)
+
+
 def _sync_identity_to_service(settings_obj) -> None:
     """Push user_id + email + signin_method into the service-sync identify
     pipeline so every event from this user has the right Person properties."""
@@ -147,6 +158,7 @@ async def signin_activate(body: SigninActivateRequest):
 
     await save_settings_async(settings_obj)
     _sync_identity_to_service(settings_obj)
+    await _sync_pro_routing(settings_obj)
 
     return {
         "ok": True,
@@ -234,4 +246,5 @@ async def signout():
     settings_obj.openswarm_usage_cached = None
     await save_settings_async(settings_obj)
     _sync_identity_to_service(settings_obj)
+    await _sync_pro_routing(settings_obj)
     return {"ok": True}

--- a/backend/apps/nine_router/__init__.py
+++ b/backend/apps/nine_router/__init__.py
@@ -46,6 +46,7 @@ from .sync_custom import (
     normalize_openai_compat_base_url,
     sync_custom_providers,
     sync_openswarm_pro_as_claude,
+    sync_pro_routing,
 )
 from .oauth import (
     exchange_oauth,
@@ -81,5 +82,6 @@ __all__ = [
     "sync_openrouter_api_key",
     "sync_custom_providers",
     "sync_openswarm_pro_as_claude",
+    "sync_pro_routing",
     "normalize_openai_compat_base_url",
 ]

--- a/backend/apps/nine_router/sync_custom.py
+++ b/backend/apps/nine_router/sync_custom.py
@@ -323,3 +323,20 @@ async def sync_openswarm_pro_as_claude(bearer_token: str | None, proxy_url: str 
                     logger.info("9Router: removed OpenSwarm Pro → Claude connection")
     except Exception as e:
         logger.warning(f"9Router OpenSwarm-Pro Claude sync failed: {e}")
+
+
+async def sync_pro_routing(settings_obj) -> None:
+    """Mirror the settings' pro-mode state into the 9Router Claude lane.
+    Call after any flow that changes connection_mode or the bearer
+    (activate, sign-in, sign-out, disconnect). Never raises."""
+    try:
+        pro = getattr(settings_obj, "connection_mode", None) == "openswarm-pro"
+        bearer = getattr(settings_obj, "openswarm_bearer_token", None)
+        proxy = getattr(settings_obj, "openswarm_proxy_url", None) or "https://api.openswarm.com"
+        active = bool(pro and bearer)
+        await sync_openswarm_pro_as_claude(
+            bearer if active else None,
+            proxy if active else None,
+        )
+    except Exception as e:
+        logger.warning(f"OpenSwarm-Pro → Claude sync failed: {e}")

--- a/backend/apps/outputs/outputs.py
+++ b/backend/apps/outputs/outputs.py
@@ -547,7 +547,11 @@ async def create_output(body: OutputCreate):
 @outputs.router.put("/{output_id}")
 async def update_output(output_id: str, body: OutputUpdate):
     output = _load(output_id)
-    for k, v in body.model_dump(exclude_none=True).items():
+    # exclude_unset, NOT exclude_none: a PUT that explicitly sends session_id=null
+    # (the Apps stale-link self-heal) must clear the field. exclude_none silently
+    # dropped that null, so the dead pointer never cleared and the app 404'd on
+    # every open, forever. Unset fields stay untouched; only what the client sent applies.
+    for k, v in body.model_dump(exclude_unset=True).items():
         setattr(output, k, v)
     now = datetime.now().isoformat()
     output.updated_at = now

--- a/backend/apps/outputs/runtime.py
+++ b/backend/apps/outputs/runtime.py
@@ -86,6 +86,11 @@ class AppRuntime:
         # so the preview pane doesn't try to navigate to an unbound port
         # and show a "Site can't be reached" error mid-npm-install.
         self._frontend_ready: bool = False
+        # True while the process tree is SIGSTOP'd in the idle pool. A frozen
+        # vite still holds its port but can't answer it, so frontend_url must
+        # stay null while suspended (else the webview loads a dead port = the
+        # ERR_FAILED on fast app-switching).
+        self._suspended: bool = False
         self.process: Optional[asyncio.subprocess.Process] = None
         self.log_buffer: deque[LogLine] = deque(maxlen=_LOG_BUFFER_LINES)
         self._subscribers: set[LogSubscriber] = set()
@@ -130,7 +135,9 @@ class AppRuntime:
         # Also gated on `running`: a vite that crashed or got orphaned still
         # has _frontend_ready=True, and handing the webview that dead port is
         # the ERR_FAILED you see on reopen. No live process, no URL.
-        if self.frontend_port and self._frontend_ready and self.running:
+        # And gated on `not _suspended`: a SIGSTOP'd idle runtime is "running"
+        # (returncode is None) but frozen, so its port won't answer.
+        if self.frontend_port and self._frontend_ready and self.running and not self._suspended:
             return f"http://127.0.0.1:{self.frontend_port}/"
         return None
 
@@ -527,6 +534,7 @@ class AppRuntimeManager:
                     # SIGCONT the process tree if A2 had it paused while
                     # idle. Pair with the SIGSTOP in detach() below.
                     _resume_process_tree(rt.process)
+                    rt._suspended = False
                 else:
                     if idle_rt is not None:
                         # Stale idle entry; process died while idling.
@@ -574,6 +582,7 @@ class AppRuntimeManager:
                 self._idle_lru[workspace_id] = rt
                 self._idle_lru.move_to_end(workspace_id)
                 _suspend_process_tree(rt.process)
+                rt._suspended = True
                 while len(self._idle_lru) > _MAX_IDLE_RUNTIMES:
                     _, old_rt = self._idle_lru.popitem(last=False)
                     # Reaping a stopped process: SIGCONT first so the

--- a/backend/apps/outputs/runtime.py
+++ b/backend/apps/outputs/runtime.py
@@ -127,7 +127,10 @@ class AppRuntime:
         # over once Vite is actually accepting connections. Without
         # this, the editor flashes a "Site can't be reached" error
         # while `npm install` is running.
-        if self.frontend_port and self._frontend_ready:
+        # Also gated on `running`: a vite that crashed or got orphaned still
+        # has _frontend_ready=True, and handing the webview that dead port is
+        # the ERR_FAILED you see on reopen. No live process, no URL.
+        if self.frontend_port and self._frontend_ready and self.running:
             return f"http://127.0.0.1:{self.frontend_port}/"
         return None
 
@@ -477,6 +480,10 @@ class AppRuntime:
         if not self.process:
             return
         rc = await self.process.wait()
+        # Unclean death (vite crash, OOM, orphaned parent) must drop readiness;
+        # otherwise frontend_url keeps advertising a dead port and the preview
+        # navigates into ERR_FAILED. stop() already does this for clean stops.
+        self._frontend_ready = False
         self._broadcast(LogLine("runtime", f"[runtime] backend exited with code {rc}"))
 
 

--- a/backend/apps/service/buffer.py
+++ b/backend/apps/service/buffer.py
@@ -72,17 +72,21 @@ def enqueue(spool_path: str, kind: str, payload: dict, *, now: float) -> None:
             target = int(_MAX_BYTES * _TRIM_TARGET_FRACTION)
             # Delete oldest rows until we're back under target. Use a
             # reasonable batch size so we don't block forever.
+            dropped = 0
             for _ in range(64):
                 row = c.execute("SELECT id FROM spool ORDER BY id ASC LIMIT 1").fetchone()
                 if not row:
                     break
                 c.execute("DELETE FROM spool WHERE id = ?", (row[0],))
+                dropped += 1
                 try:
                     new_size = os.path.getsize(spool_path)
                 except OSError:
                     new_size = 0
                 if new_size <= target:
                     break
+            if dropped:
+                logger.warning("Spool over %d MB cap; dropped %d oldest entries", _MAX_BYTES // (1024 * 1024), dropped)
             # VACUUM is expensive; only run if we still appear oversized after
             # trimming, otherwise free pages get reused on next insert.
             try:

--- a/backend/apps/service/client.py
+++ b/backend/apps/service/client.py
@@ -192,15 +192,24 @@ def _base_url() -> str:
         return _DEFAULT_BASE
 
 
-async def _post(path: str, body: dict) -> bool:
+async def _post(path: str, body: dict) -> int | None:
     url = f"{_base_url()}{path}"
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as c:
             r = await c.post(url, json=body)
-        return 200 <= r.status_code < 500
+        return r.status_code
     except Exception as e:
         logger.debug("service POST %s failed: %s", path, e)
-        return False
+        return None
+
+
+def _delivered(status: int | None) -> bool:
+    return status is not None and 200 <= status < 300
+
+
+# 429/timeouts/5xx/network are worth retrying; other 4xx means the payload itself is rejected and retrying forever would just poison the spool.
+def _retryable(status: int | None) -> bool:
+    return status is None or status >= 500 or status in (408, 429)
 
 
 async def _post_or_spool(path: str, body: dict, kind: str) -> None:
@@ -217,9 +226,11 @@ async def _post_or_spool(path: str, body: dict, kind: str) -> None:
             return
         _inflight += 1
     try:
-        ok = await _post(path, body)
-        if not ok:
+        status = await _post(path, body)
+        if _retryable(status):
             buffer.enqueue(_spool_path(), f"{kind}:{path}", body, now=time.time())
+        elif not _delivered(status):
+            logger.warning("service POST %s rejected with HTTP %s; payload dropped", path, status)
     finally:
         async with _inflight_lock:
             _inflight = max(0, _inflight - 1)
@@ -236,11 +247,14 @@ async def drain_spool(batch_size: int = 50) -> int:
             if not path:
                 succeeded.append(rid)
                 continue
-            ok = await _post(path, body)
-            if ok:
+            status = await _post(path, body)
+            if _delivered(status):
                 succeeded.append(rid)
-            else:
+            elif _retryable(status):
                 break
+            else:
+                logger.warning("service replay %s rejected with HTTP %s; dropping spooled row", path, status)
+                succeeded.append(rid)
         if succeeded:
             buffer.acknowledge(_spool_path(), succeeded)
         return len(succeeded)

--- a/backend/apps/settings/settings.py
+++ b/backend/apps/settings/settings.py
@@ -114,11 +114,31 @@ async def get_settings():
     return load_settings().model_dump()
 
 
+# Written only by their dedicated flows (Stripe activate, sign-in, signout, OAuth connects);
+# a full-object PUT from a stale renderer snapshot must never revert or forge them.
+SERVER_OWNED_FIELDS = (
+    "connection_mode",
+    "openswarm_bearer_token",
+    "openswarm_proxy_url",
+    "openswarm_subscription_plan",
+    "openswarm_subscription_expires",
+    "openswarm_usage_cached",
+    "user_id",
+    "signin_method",
+    "installation_id",
+    "claude_subscription_token",
+    "openai_subscription_token",
+    "gemini_subscription_token",
+)
+
+
 @settings.router.put("")
 async def update_settings(body: AppSettings):
     from backend.apps.service.client import sync as _sync
 
     old = load_settings()
+    for k in SERVER_OWNED_FIELDS:
+        setattr(body, k, getattr(old, k, None))
 
     secret_keys = {"anthropic_api_key", "openai_api_key", "google_api_key", "openrouter_api_key",
                    "claude_subscription_token", "openai_subscription_token", "gemini_subscription_token",
@@ -219,22 +239,6 @@ async def update_settings(body: AppSettings):
             custom_providers_changed,
             any_keyed_added,
         ))
-
-    # On pro-mode/bearer change, register a `claude` apikey connection in 9Router so CLI WebSearch works on non-Claude primaries.
-    pro_mode_old = getattr(old, "connection_mode", None) == "openswarm-pro"
-    pro_mode_new = getattr(body, "connection_mode", None) == "openswarm-pro"
-    bearer_old = getattr(old, "openswarm_bearer_token", None)
-    bearer_new = getattr(body, "openswarm_bearer_token", None)
-    if pro_mode_old != pro_mode_new or bearer_old != bearer_new:
-        try:
-            from backend.apps.nine_router import sync_openswarm_pro_as_claude
-            proxy_url = getattr(body, "openswarm_proxy_url", None) or "https://api.openswarm.com"
-            await sync_openswarm_pro_as_claude(
-                bearer_new if pro_mode_new else None,
-                proxy_url if pro_mode_new else None,
-            )
-        except Exception as e:
-            logger.warning(f"OpenSwarm-Pro → Claude sync failed: {e}")
 
     return {"ok": True, "settings": body.model_dump()}
 

--- a/backend/apps/subscription/router.py
+++ b/backend/apps/subscription/router.py
@@ -36,6 +36,17 @@ def _proxy_url() -> str:
     return url.rstrip("/")
 
 
+async def _sync_pro_routing(settings_obj) -> None:
+    """Mirror connection state into 9Router's Claude lane (WebSearch on
+    non-Claude primaries). PUT /api/settings no longer carries these fields,
+    so the state-change endpoints here are the only trigger left."""
+    try:
+        from backend.apps.nine_router import sync_pro_routing
+        await sync_pro_routing(settings_obj)
+    except Exception as e:
+        logger.debug("pro routing sync skipped: %s", e)
+
+
 async def _clear_subscription(settings_obj, *, drop_bearer: bool = True) -> None:
     """Revert to own_key mode and drop OpenSwarm Pro routing state.
 
@@ -57,6 +68,7 @@ async def _clear_subscription(settings_obj, *, drop_bearer: bool = True) -> None
     settings_obj.openswarm_usage_cached = None
     await save_settings_async(settings_obj)
     _sync_subscription_identity(settings_obj)
+    await _sync_pro_routing(settings_obj)
 
 
 def _sync_subscription_identity(settings_obj) -> None:
@@ -155,6 +167,7 @@ async def activate(body: ActivateRequest):
 
     await save_settings_async(settings_obj)
     _sync_subscription_identity(settings_obj)
+    await _sync_pro_routing(settings_obj)
     return {"ok": True, "plan": settings_obj.openswarm_subscription_plan}
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -381,7 +381,13 @@ async def websocket_dashboard(websocket: WebSocket):
             event = msg.get("event")
             payload = msg.get("data", {})
             
-            if event == "agent:approval_response":
+            if event == "client:ping":
+                # No pong here meant the client heartbeat force-closed this socket every 35s, forever.
+                await websocket.send_text(json.dumps({
+                    "event": "server:pong",
+                    "data": {"nonce": payload.get("nonce")},
+                }))
+            elif event == "agent:approval_response":
                 from backend.apps.agents.agent_manager import agent_manager
                 agent_manager.handle_approval(payload.get("request_id"), {
                     "behavior": payload.get("behavior", "deny"),

--- a/backend/tests/test_settings_server_owned.py
+++ b/backend/tests/test_settings_server_owned.py
@@ -1,0 +1,125 @@
+"""Server-owned settings fields must survive full-object PUTs from the renderer.
+
+Reproduces the production bug where a Settings save built from a pre-activation
+snapshot (the renderer PUTs the ENTIRE AppSettings object) silently wiped
+openswarm_bearer_token + connection_mode, disconnecting paying subscribers
+minutes after a successful Stripe activation. The fix: subscription/identity
+fields are written only by their dedicated endpoints (activate, signin-activate,
+signout, disconnect); PUT /api/settings preserves whatever is on disk for them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+@pytest.fixture
+def client():
+    import backend.auth as auth_mod
+    if not auth_mod._TOKEN:
+        import secrets
+        auth_mod._TOKEN = secrets.token_urlsafe(32)
+    return TestClient(app, headers={"Authorization": f"Bearer {auth_mod._TOKEN}"})
+
+
+@pytest.fixture
+def reset_settings():
+    from backend.apps.settings.settings import load_settings, _save_settings
+
+    original = load_settings().model_copy(deep=True)
+    yield
+    _save_settings(original)
+
+
+def _activate_pro(client, token="repro-bearer-0123456789abcdef"):
+    """Drive the real /api/subscription/activate with a mocked cloud /api/me."""
+    fake_me = AsyncMock()
+    fake_me.status_code = 200
+    fake_me.json = lambda: {
+        "email": "payer@example.com",
+        "plan": "pro",
+        "status": "active",
+        "current_period_end": 4102444800000,
+        "usage": {"utilization": 0},
+    }
+    with patch("httpx.AsyncClient") as MockClient:
+        instance = MockClient.return_value.__aenter__.return_value
+        instance.get = AsyncMock(return_value=fake_me)
+        r = client.post("/api/subscription/activate", json={"token": token})
+    assert r.status_code == 200, r.text
+    return token
+
+
+def test_stale_settings_put_cannot_wipe_activation(client, reset_settings):
+    """The exact production sequence: snapshot settings, activate Pro, PUT the
+    stale snapshot back (renderer Save of a pre-activation draft). The bearer
+    and pro mode must survive; the user's editable change must still apply."""
+    snapshot = client.get("/api/settings").json()
+    assert snapshot is not None
+
+    token = _activate_pro(client)
+
+    from backend.apps.settings.settings import load_settings
+    s = load_settings()
+    assert s.openswarm_bearer_token == token
+    assert s.connection_mode == "openswarm-pro"
+    assert s.openswarm_subscription_plan == "pro"
+
+    stale = dict(snapshot)
+    stale["user_name"] = "Stale Draft Save"
+    r = client.put("/api/settings", json=stale)
+    assert r.status_code == 200
+
+    s = load_settings()
+    assert s.user_name == "Stale Draft Save"
+    assert s.openswarm_bearer_token == token, "stale PUT wiped the bearer"
+    assert s.connection_mode == "openswarm-pro", "stale PUT reverted connection_mode"
+    assert s.openswarm_subscription_plan == "pro"
+    assert s.openswarm_subscription_expires is not None
+
+    body = r.json()["settings"]
+    assert body["openswarm_bearer_token"] == token
+    assert body["connection_mode"] == "openswarm-pro"
+
+
+def test_put_cannot_inject_server_owned_fields(client, reset_settings):
+    """The inverse direction: a client PUT must not be able to SET subscription
+    state either (it would imply entitlement the cloud never granted)."""
+    snapshot = client.get("/api/settings").json()
+    forged = dict(snapshot)
+    forged["connection_mode"] = "openswarm-pro"
+    forged["openswarm_bearer_token"] = "forged-bearer-fedcba9876543210"
+    forged["openswarm_subscription_plan"] = "ultra"
+    forged["user_id"] = "u-forged"
+
+    r = client.put("/api/settings", json=forged)
+    assert r.status_code == 200
+
+    from backend.apps.settings.settings import load_settings
+    s = load_settings()
+    assert s.openswarm_bearer_token == snapshot.get("openswarm_bearer_token")
+    assert s.connection_mode == snapshot.get("connection_mode")
+    assert s.openswarm_subscription_plan == snapshot.get("openswarm_subscription_plan")
+    assert s.user_id == snapshot.get("user_id")
+
+
+def test_dedicated_endpoints_still_mutate(client, reset_settings):
+    """Freezing PUT must not freeze the real owners: disconnect still reverts
+    routing, and a fresh activate still re-connects afterwards."""
+    _activate_pro(client)
+
+    r = client.post("/api/subscription/disconnect")
+    assert r.status_code == 200
+    from backend.apps.settings.settings import load_settings
+    s = load_settings()
+    assert s.connection_mode == "own_key"
+    assert s.openswarm_bearer_token is not None  # disconnect keeps sign-in
+
+    _activate_pro(client, token="second-bearer-aaaabbbbccccdddd")
+    s = load_settings()
+    assert s.connection_mode == "openswarm-pro"
+    assert s.openswarm_bearer_token == "second-bearer-aaaabbbbccccdddd"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openswarm",
-  "version": "1.2.76",
+  "version": "1.2.77",
   "description": "OpenSwarm — AI Agent Orchestrator",
   "author": "openswarm-ai",
   "main": "main.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openswarm",
-  "version": "1.2.75",
+  "version": "1.2.76",
   "description": "OpenSwarm — AI Agent Orchestrator",
   "author": "openswarm-ai",
   "main": "main.js",

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -41,7 +41,7 @@ import {
 } from '@/shared/state/agentsSlice';
 import { store } from '@/shared/state/store';
 import { fetchModes } from '@/shared/state/modesSlice';
-import { createSessionWs } from '@/shared/ws/WebSocketManager';
+import { createSessionWs, acquireSessionWs, releaseSessionWs } from '@/shared/ws/WebSocketManager';
 import StreamingBubble from './bubbles/StreamingBubble';
 import MessageBubble from './bubbles/MessageBubble';
 import CompactionMarker from './bubbles/CompactionMarker';
@@ -207,6 +207,8 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   const [model, setModel] = useState('sonnet');
 
   const wsRef = useRef<ReturnType<typeof createSessionWs> | null>(null);
+  // Current status for the WS-cleanup closure (effect deps can't include it).
+  const statusRef = useRef<string | undefined>(undefined);
   const initialContextApplied = useRef(false);
   const messageQueueRef = useRef<QueuedMessage[]>([]);
   const [queueLength, setQueueLength] = useState(0);
@@ -249,13 +251,20 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
         }
       }
       if (cancelled) return;
-      ws = createSessionWs(id);
+      // acquireSessionWs reuses a still-open socket kept alive from the last hop,
+      // so an active agent's stream resumes with no reconnect handshake. connect()
+      // is a no-op when the reused socket is already open.
+      ws = acquireSessionWs(id);
       ws.connect();
       wsRef.current = ws;
     })();
     return () => {
       cancelled = true;
-      if (ws) ws.disconnect();
+      if (ws) {
+        const st = statusRef.current;
+        const active = st === 'running' || st === 'waiting_approval';
+        releaseSessionWs(id, ws, active);
+      }
       wsRef.current = null;
     };
   }, [id, isDraft, dispatch]);
@@ -312,6 +321,8 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
         });
     }
   }, [id, isDraft, mode, model, session?.system_prompt, session?.target_directory, dispatch]);
+
+  statusRef.current = session?.status;
 
   const agentBusy = awaitingResponse || (!isDraft && (session?.status === 'running' || session?.status === 'waiting_approval'));
 

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -201,6 +201,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [showResumeBubble, setShowResumeBubble] = useState(false);
   const [awaitingResponse, setAwaitingResponse] = useState(false);
+  const [preSendActivityLabel, setPreSendActivityLabel] = useState<string | null>(null);
   const [activatingMcp, setActivatingMcp] = useState<string | null>(null);
   const [activateError, setActivateError] = useState<string | null>(null);
   const [mode, setMode] = useState('agent');
@@ -384,6 +385,18 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   // dormant during streaming; only the bubble updates per delta.
   const streamingMessageId = useAppSelector((s) => id ? s.streaming.bySession[id]?.id ?? null : null);
   const hasStreaming = !!streamingMessageId;
+
+  useEffect(() => {
+    if (
+      streamingMessageId ||
+      session?.turn_label?.label ||
+      session?.status === 'completed' ||
+      session?.status === 'error' ||
+      session?.status === 'stopped'
+    ) {
+      setPreSendActivityLabel(null);
+    }
+  }, [streamingMessageId, session?.turn_label?.label, session?.status]);
 
   useEffect(() => {
     if (reconcileTimer.current) {
@@ -1422,10 +1435,10 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                 />
               </Box>
             )}
-            {(awaitingResponse || (session.status === 'running' && !streamingMessageId)) && (
+            {(preSendActivityLabel || awaitingResponse || (session.status === 'running' && !streamingMessageId)) && (
               <Box sx={{ overflowAnchor: 'none' }}>
                 <ThinkingBubble
-                  label={session.turn_label?.label}
+                  label={preSendActivityLabel || session.turn_label?.label}
                   seedKey={`${session.id}:${session.messages?.length ?? 0}`}
                 />
               </Box>
@@ -1781,6 +1794,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                 autoFocus={autoFocus}
                 thinkingLevel={session?.thinking_level ?? 'auto'}
                 onThinkingLevelChange={handleThinkingLevelChange}
+                onActivityLabelChange={setPreSendActivityLabel}
               />
             </Box>
           </ClickAwayListener>

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -927,6 +927,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   }
 
   const isActive = session.status === 'running' || session.status === 'waiting_approval' || session.status === 'draft';
+  const branchNavLocked = agentBusy || hasStreaming;
   const statusStyle = STATUS_STYLES[session.status] || { color: c.text.tertiary, bg: c.bg.secondary };
 
   return (
@@ -1386,11 +1387,14 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                           ? {
                               currentIndex: Math.max(0, currentBranchIdx),
                               totalBranches: siblings.length,
+                              disabled: branchNavLocked,
                               onPrevious: () => {
+                                if (branchNavLocked) return;
                                 const prevBranch = siblings[Math.max(0, currentBranchIdx - 1)];
                                 if (prevBranch && id) dispatch(switchBranch({ sessionId: id, branchId: prevBranch }));
                               },
                               onNext: () => {
+                                if (branchNavLocked) return;
                                 const nextBranch = siblings[Math.min(siblings.length - 1, currentBranchIdx + 1)];
                                 if (nextBranch && id) dispatch(switchBranch({ sessionId: id, branchId: nextBranch }));
                               },

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -44,6 +44,7 @@ import { fetchModes } from '@/shared/state/modesSlice';
 import { createSessionWs, acquireSessionWs, releaseSessionWs } from '@/shared/ws/WebSocketManager';
 import StreamingBubble from './bubbles/StreamingBubble';
 import MessageBubble from './bubbles/MessageBubble';
+import { estimateRenderedTextHeight, RECHECK_VISIBILITY_EVENT } from './bubbles/markdownMeasure';
 import CompactionMarker from './bubbles/CompactionMarker';
 import MessageActionBar from './shell/MessageActionBar';
 import ToolCallBubble, { ToolPair } from './tool-bubbles/ToolCallBubble';
@@ -64,10 +65,89 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   haiku: 200_000,
 };
 
+// Only a fallback for never-rendered items; real heights are measured once on
+// screen.
+const RENDER_ITEM_ESTIMATED_HEIGHT = 140;
+// Conservative estimate for an unmeasured tool row: tool groups/pairs render
+// collapsed (~40-50px) far more often than expanded. Leaning low keeps scrollHeight
+// (and the scrollbar thumb) from jumping when a tool row measures shorter.
+const COLLAPSED_TOOL_ROW_HEIGHT = 44;
+// How many screens of real content to keep mounted on EACH side of the viewport.
+// Beyond it, items unmount and are replaced by a measured-height spacer, so
+// render/memory stays bounded no matter how long the transcript is.
+const WINDOW_BUFFER_SCREENS_PER_SIDE = 3;
+// Floor on the mounted item count so a single very tall item can't strand us with
+// an effectively empty window.
+const MIN_WINDOW_BUFFER_ITEMS = 6;
+
+// Bootstrap count for the initial bottom-anchored slice (on open and on
+// scroll-to-bottom): enough rows to cover the viewport + buffer using the same
+// row-height estimate the solver uses, floored. It's only a seed — the pixel
+// solver (computeDesiredWindow) refines the window to exact from measured heights
+// on the next frame, so this never needs to be precise.
+function initialSeedItems(viewportHeight: number): number {
+  const fillPx = (1 + WINDOW_BUFFER_SCREENS_PER_SIDE) * Math.max(1, viewportHeight);
+  return Math.max(MIN_WINDOW_BUFFER_ITEMS, Math.ceil(fillPx / RENDER_ITEM_ESTIMATED_HEIGHT));
+}
+
+// Pure window solver: given the current scroll position and a per-index height
+// accessor (measured where known, estimated otherwise), return the [start, end)
+// slice of render items that should be mounted. The buffer is measured in PIXELS
+// (N screens of real content on each side of the viewport), not item count, so a
+// few very tall messages can't blow the mounted set up to the whole transcript.
+// A huge viewport naturally yields start=0/end=total (mount all).
+function computeDesiredWindow(
+  scrollTop: number,
+  clientHeight: number,
+  total: number,
+  heightOf: (index: number) => number,
+  bufferPx: number,
+): { start: number; end: number } {
+  if (total <= 0) return { start: 0, end: 0 };
+  const keepTop = scrollTop - bufferPx;
+  const keepBottom = scrollTop + clientHeight + bufferPx;
+  let offset = 0;
+  let start = -1;
+  let end = total;
+  for (let i = 0; i < total; i++) {
+    const h = heightOf(i);
+    const itemTop = offset;
+    const itemBottom = offset + h;
+    if (start === -1 && itemBottom > keepTop) start = i;
+    if (itemTop < keepBottom) {
+      end = i + 1;
+    } else {
+      // Everything past here starts below the keep band.
+      break;
+    }
+    offset += h;
+  }
+  if (start === -1) start = Math.max(0, total - 1);
+  end = Math.min(total, Math.max(end, start + 1));
+  // Always keep at least a small floor of items mounted around the viewport so a
+  // single under-measured item can't strand us with an empty window.
+  if (end - start < MIN_WINDOW_BUFFER_ITEMS) {
+    start = Math.max(0, Math.min(start, end - MIN_WINDOW_BUFFER_ITEMS));
+  }
+  return { start: Math.max(0, start), end };
+}
+
 function stringifyContent(content: any): string {
   if (content == null) return '';
   if (typeof content === 'string') return content;
   return JSON.stringify(content);
+}
+
+// Content-aware height estimate for a render item that has never been measured.
+// Tool rows and tiny system/thinking rows keep the flat fallback; message bubbles
+// scale with their FULL text length (messages render in full once on-screen, so
+// the estimate matches both the rendered bubble and MessageBubble's placeholder
+// fallback).
+function estimateItemHeight(item: RenderItem, viewportWidth: number): number {
+  if (isToolGroup(item) || isToolPair(item)) return COLLAPSED_TOOL_ROW_HEIGHT;
+  const msg = item as AgentMessage;
+  if (msg.role === 'thinking' || msg.role === 'system') return 60;
+  return estimateRenderedTextHeight(stringifyContent(msg.content), viewportWidth);
 }
 
 const thinkingShimmerKeyframes = `
@@ -196,8 +276,25 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
   // tokens to every request; Haiku 4.5's 200K window can't hold 5+ of them.
   const toolItems = useAppSelector((state) => state.tools.items);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const lastVisibleItemRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<ChatInputHandle>(null);
   const isAtBottomRef = useRef(true);
+  const pendingInitialBottomScrollRef = useRef(false);
+  const initialBottomScrollSettledRef = useRef(false);
+  const renderItemsLengthRef = useRef(0);
+  const renderItemsRef = useRef<RenderItem[]>([]);
+  const itemHeightsRef = useRef<Map<string, number>>(new Map());
+  const estimateCacheRef = useRef<Map<string, number>>(new Map());
+  const viewportWidthRef = useRef(0);
+  const windowStartRef = useRef(0);
+  const windowEndRef = useRef(0);
+  const windowScrollRafRef = useRef<number | null>(null);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
+  const [windowStart, setWindowStart] = useState(0);
+  const [windowEnd, setWindowEnd] = useState(0);
+  const [heightVersion, setHeightVersion] = useState(0);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [showResumeBubble, setShowResumeBubble] = useState(false);
   const [awaitingResponse, setAwaitingResponse] = useState(false);
@@ -421,13 +518,130 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
 
   const SCROLL_THRESHOLD = 50;
 
+  // Reserved pixel height for a render item: the measured height once we have one,
+  // otherwise a content-aware estimate (cached per id). The spacer math and the
+  // window solver both go through this so unmounted spacers, freshly-mounted
+  // placeholders, and the real rendered bubble all reserve the same space.
+  const reservedHeightForItem = useCallback((item: RenderItem | undefined): number => {
+    if (!item) return RENDER_ITEM_ESTIMATED_HEIGHT;
+    const measured = itemHeightsRef.current.get(item.id);
+    if (measured != null) return measured;
+    const cached = estimateCacheRef.current.get(item.id);
+    if (cached != null) return cached;
+    const est = estimateItemHeight(item, viewportWidthRef.current);
+    estimateCacheRef.current.set(item.id, est);
+    return est;
+  }, []);
+
+  // Measured-or-estimated pixel height of render item at `index`, for the window
+  // solver (reads the renderItems ref so it is valid inside rAF callbacks).
+  const heightOf = useCallback((index: number): number => {
+    return reservedHeightForItem(renderItemsRef.current[index]);
+  }, [reservedHeightForItem]);
+
+  // Solve the mounted window from the live scroll position and push it to state
+  // when it changes. Scroll position itself is preserved by the container's
+  // overflow-anchor plus the measured-height spacers, so we never touch
+  // scrollTop here. Following (pinned to bottom) always keeps the newest item.
+  const applyWindowFromScroll = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    if (!initialBottomScrollSettledRef.current) return;
+    const total = renderItemsLengthRef.current;
+    const clientHeight = Math.max(1, el.clientHeight);
+    const tightPx = WINDOW_BUFFER_SCREENS_PER_SIDE * clientHeight;
+    // Mount with the tight buffer, but keep already-mounted items until
+    // they drift a full extra screen past it. Without this, an item sitting
+    // right on the buffer edge flip-flops mounted/unmounted forever: mounting it
+    // shifts content above the viewport, overflow-anchor nudges scrollTop a few px,
+    // that re-runs the solver, which now excludes it, and round it goes.
+    const loosePx = tightPx + clientHeight;
+    const tight = computeDesiredWindow(el.scrollTop, clientHeight, total, heightOf, tightPx);
+    const loose = computeDesiredWindow(el.scrollTop, clientHeight, total, heightOf, loosePx);
+    const curStart = windowStartRef.current;
+    const curEnd = windowEndRef.current;
+    // Must-mount the tight band; keep current edges only while still inside loose.
+    let start = Math.max(loose.start, Math.min(curStart, tight.start));
+    let end = Math.min(loose.end, Math.max(curEnd, tight.end));
+    if (isAtBottomRef.current) end = total;
+    start = Math.max(0, Math.min(start, Math.max(0, end - 1)));
+    if (start === curStart && end === curEnd) return;
+    windowStartRef.current = start;
+    windowEndRef.current = end;
+    setWindowStart(start);
+    setWindowEnd(end);
+  }, [heightOf]);
+
+  const scheduleWindowRecompute = useCallback(() => {
+    if (windowScrollRafRef.current != null) return;
+    windowScrollRafRef.current = requestAnimationFrame(() => {
+      windowScrollRafRef.current = null;
+      applyWindowFromScroll();
+    });
+  }, [applyWindowFromScroll]);
+
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    setScrollRoot(el);
+
+    const updateViewport = () => {
+      setViewportHeight(el.clientHeight);
+      setViewportWidth(el.clientWidth);
+      // Width drives the char-per-line estimate; drop cached estimates so they
+      // recompute at the new width (measured heights are unaffected and kept).
+      estimateCacheRef.current.clear();
+      // Resize changes the budgets and how many items fit; re-solve the window
+      // off the current scroll position WITHOUT resetting it (only session /
+      // branch changes reset). overflow-anchor holds the visible content.
+      scheduleWindowRecompute();
+    };
+
+    updateViewport();
+    const observer = new ResizeObserver(updateViewport);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (windowScrollRafRef.current != null) {
+        cancelAnimationFrame(windowScrollRafRef.current);
+        windowScrollRafRef.current = null;
+      }
+      setScrollRoot(null);
+    };
+  }, [id, session?.id, scheduleWindowRecompute]);
+
+  React.useLayoutEffect(() => {
+    const seed = initialSeedItems(viewportHeight);
+    const total = renderItemsLengthRef.current;
+    const end = total;
+    const start = Math.max(0, end - seed);
+    windowStartRef.current = start;
+    windowEndRef.current = end;
+    setWindowStart(start);
+    setWindowEnd(end);
+    itemHeightsRef.current.clear();
+    estimateCacheRef.current.clear();
+    if (initialPinRafRef.current != null) {
+      cancelAnimationFrame(initialPinRafRef.current);
+      initialPinRafRef.current = null;
+    }
+    pendingInitialBottomScrollRef.current = true;
+    initialBottomScrollSettledRef.current = false;
+    isAtBottomRef.current = true;
+    setShowScrollButton(false);
+  }, [id, session?.active_branch_id]);
+
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+    // Measure against the real content bottom, not the locked-height pad below it.
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_THRESHOLD;
     isAtBottomRef.current = atBottom;
     setShowScrollButton(!atBottom);
-  }, []);
+    // Slide the mounted window to follow the viewport (loads newer/older items
+    // and unloads ones that drifted past the buffer on either side).
+    scheduleWindowRecompute();
+  }, [scheduleWindowRecompute]);
 
   // Prevent scroll from leaking into the dashboard canvas when at boundaries
   useEffect(() => {
@@ -452,16 +666,47 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
     return () => el.removeEventListener('wheel', onWheel);
   }, []);
 
+  const scrollToBottomRafRef = useRef<number | null>(null);
   const scrollToBottom = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
     isAtBottomRef.current = true;
     setShowScrollButton(false);
+    // When scrolled far up the newest items are unmounted behind the bottom
+    // spacer (estimated height). Jump the window to the bottom slice so they
+    // actually mount, then pin across several frames: a single scrollTop=scrollHeight
+    // lands short because the spacer collapses and the freshly-mounted items
+    // replace their estimates with real measured heights, changing scrollHeight.
+    const total = renderItemsLengthRef.current;
+    const start = Math.max(0, total - initialSeedItems(el.clientHeight));
+    windowStartRef.current = start;
+    windowEndRef.current = total;
+    setWindowStart(start);
+    setWindowEnd(total);
+    if (scrollToBottomRafRef.current != null) cancelAnimationFrame(scrollToBottomRafRef.current);
+    let frame = 0;
+    const FRAMES = 16; // ~260ms, enough for the window + oversized blocks to settle
+    const pin = () => {
+      const c = scrollContainerRef.current;
+      if (!c) { scrollToBottomRafRef.current = null; return; }
+      c.scrollTop = c.scrollHeight;
+      lastScrollHeightRef.current = c.scrollHeight;
+      isAtBottomRef.current = true;
+      if (++frame < FRAMES) {
+        scrollToBottomRafRef.current = requestAnimationFrame(pin);
+      } else {
+        scrollToBottomRafRef.current = null;
+        // Jump has settled: re-evaluate oversized message / block visibility
+        // synchronously so nothing now in view is stuck as a placeholder.
+        c.dispatchEvent(new CustomEvent(RECHECK_VISIBILITY_EVENT));
+      }
+    };
+    pin();
   }, []);
 
   const scrollRafRef = useRef<number | null>(null);
   const pinRafRef = useRef<number | null>(null);
+  const initialPinRafRef = useRef<number | null>(null);
   const lastScrollHeightRef = useRef<number>(0);
   // Shared scroll-stick routine. Used both by the structural-events
   // useEffect below (new message lands / stream starts/ends) and by
@@ -565,6 +810,14 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
     if (pinRafRef.current != null) {
       cancelAnimationFrame(pinRafRef.current);
       pinRafRef.current = null;
+    }
+    if (initialPinRafRef.current != null) {
+      cancelAnimationFrame(initialPinRafRef.current);
+      initialPinRafRef.current = null;
+    }
+    if (scrollToBottomRafRef.current != null) {
+      cancelAnimationFrame(scrollToBottomRafRef.current);
+      scrollToBottomRafRef.current = null;
     }
   }, []);
 
@@ -835,6 +1088,118 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
     return items;
   }, [activeBranchMessages]);
 
+  React.useLayoutEffect(() => {
+    const total = renderItems.length;
+    renderItemsLengthRef.current = total;
+    renderItemsRef.current = renderItems;
+    const seed = initialSeedItems(viewportHeight);
+    let start = windowStartRef.current;
+    let end = windowEndRef.current;
+    if (isAtBottomRef.current || end === 0) {
+      // Following the live tail: keep the newest item mounted and unload the
+      // oldest beyond a bounded recent slice so memory stays flat as the
+      // transcript grows. The pixel solver refines this seed on the next scroll.
+      end = total;
+      start = Math.max(0, end - seed);
+    } else {
+      // Scrolled up: just keep the existing window valid against the new length.
+      end = Math.min(end, total);
+      start = Math.min(start, Math.max(0, end - 1));
+    }
+    if (start !== windowStartRef.current) { windowStartRef.current = start; setWindowStart(start); }
+    if (end !== windowEndRef.current) { windowEndRef.current = end; setWindowEnd(end); }
+  }, [id, renderItems, viewportHeight]);
+
+  const total = renderItems.length;
+  const safeWindowEnd = windowEnd > 0 ? Math.min(windowEnd, total) : total;
+  const safeWindowStart = Math.min(Math.max(0, windowStart), Math.max(0, safeWindowEnd - 1));
+  const visibleStartIndex = safeWindowStart;
+  const visibleRenderItems = useMemo(
+    () => renderItems.slice(safeWindowStart, safeWindowEnd),
+    [renderItems, safeWindowStart, safeWindowEnd]
+  );
+  const renderedVisibleItems = useMemo(
+    () => visibleRenderItems.filter((item) => !streamingMessageId || item.id !== streamingMessageId),
+    [streamingMessageId, visibleRenderItems]
+  );
+  // Keep the ref the height estimator reads in sync with the live viewport width.
+  viewportWidthRef.current = viewportWidth;
+
+  // Measure mounted item heights so the spacers that stand in for unmounted
+  // items keep the scrollbar geometry stable (no jump when unloading above).
+  React.useLayoutEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    let changed = false;
+    el.querySelectorAll<HTMLElement>('[data-window-item-id]').forEach((node) => {
+      const itemId = node.dataset.windowItemId;
+      if (!itemId) return;
+      const h = node.offsetHeight;
+      if (h <= 0) return;
+      const prev = itemHeightsRef.current.get(itemId);
+      if (prev === undefined || Math.abs(prev - h) > 1) {
+        itemHeightsRef.current.set(itemId, h);
+        changed = true;
+      }
+    });
+    // Guarded so this converges: once heights stop moving, no more version bumps.
+    if (changed) setHeightVersion((v) => v + 1);
+  });
+
+  // Spacers reserve the cumulative height of the unmounted items above/below the
+  // window. heightVersion gates recompute off the ref-held measurements; we index
+  // the render-scope renderItems directly so id->height stays correct on the
+  // frame the transcript changes.
+  const topSpacerHeight = useMemo(() => {
+    let h = 0;
+    for (let i = 0; i < safeWindowStart; i++) h += reservedHeightForItem(renderItems[i]);
+    return h;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderItems, safeWindowStart, heightVersion, reservedHeightForItem]);
+  const bottomSpacerHeight = useMemo(() => {
+    let h = 0;
+    for (let i = safeWindowEnd; i < total; i++) h += reservedHeightForItem(renderItems[i]);
+    return h;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderItems, safeWindowEnd, total, heightVersion, reservedHeightForItem]);
+
+  React.useLayoutEffect(() => {
+    if (pendingInitialBottomScrollRef.current) {
+      const el = scrollContainerRef.current;
+      if (!el || visibleRenderItems.length === 0) return;
+      let frame = 0;
+      const FRAMES = 8;
+      const pin = () => {
+        const c = scrollContainerRef.current;
+        if (!c) return;
+        lastVisibleItemRef.current?.scrollIntoView({ block: 'end' });
+        c.scrollTop = Math.max(0, Math.min(c.scrollTop, c.scrollHeight - c.clientHeight));
+        lastScrollHeightRef.current = c.scrollHeight;
+        isAtBottomRef.current = true;
+        setShowScrollButton(false);
+        if (++frame < FRAMES) {
+          initialPinRafRef.current = requestAnimationFrame(pin);
+        } else {
+          initialPinRafRef.current = null;
+          initialBottomScrollSettledRef.current = true;
+          // The open slice is sized by item COUNT; now that we're settled and
+          // measured, trim it down to the pixel-based band so tall messages high
+          // in the slice unload instead of sitting fully rendered off-screen.
+          scheduleWindowRecompute();
+          // Re-evaluate visibility now the open jump has settled, so an oversized
+          // newest message isn't left stuck as a placeholder.
+          c.dispatchEvent(new CustomEvent(RECHECK_VISIBILITY_EVENT));
+        }
+      };
+      if (initialPinRafRef.current != null) {
+        cancelAnimationFrame(initialPinRafRef.current);
+        initialPinRafRef.current = null;
+      }
+      pendingInitialBottomScrollRef.current = false;
+      pin();
+    }
+  }, [id, session?.active_branch_id, renderItems.length, renderedVisibleItems.length, visibleStartIndex]);
+
   const lastAssistantIdsInTurn = useMemo(() => {
     const ids = new Set<string>();
     let lastAssistantId: string | null = null;
@@ -939,7 +1304,6 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
     );
   }
 
-  const isActive = session.status === 'running' || session.status === 'waiting_approval' || session.status === 'draft';
   const branchNavLocked = agentBusy || hasStreaming;
   const statusStyle = STATUS_STYLES[session.status] || { color: c.text.tertiary, bg: c.bg.secondary };
 
@@ -1128,6 +1492,12 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
             sx={{
               height: '100%',
               overflow: 'auto',
+              scrollbarGutter: 'stable',
+              // Flex column + the mt:auto content wrapper below bottom-anchors the
+              // transcript: short chats sit flush above the input (no whitespace
+              // under the last message) while long chats scroll normally.
+              display: 'flex',
+              flexDirection: 'column',
               px: 2,
               py: 1,
               // Smoothness bundle (perf-only , no behavior change):
@@ -1152,12 +1522,17 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
               '&::-webkit-scrollbar-thumb': {
                 background: c.border.medium,
                 borderRadius: 3,
+                minHeight: 48,
                 '&:hover': { background: c.border.strong },
               },
               scrollbarWidth: 'thin',
               scrollbarColor: `${c.border.medium} transparent`,
             }}
           >
+            {/* mt:auto pins the transcript to the bottom when it's shorter than the
+                viewport (no empty space below the last message); collapses to 0 and
+                scrolls normally once the content overflows. */}
+            <Box sx={{ mt: 'auto' }}>
             {(session.mcp_suggestions && session.mcp_suggestions.length > 0) && (
               <Box sx={{
                 mt: 1,
@@ -1325,7 +1700,14 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                 </Box>
               );
             })()}
-            {renderItems.filter((item) => !streamingMessageId || item.id !== streamingMessageId).map((item) => {
+            {/* Stand-in for items unmounted ABOVE the window. Its measured
+                height keeps the scrollbar geometry and scroll position stable
+                while overflow-anchor pins the visible content. */}
+            {topSpacerHeight > 0 && (
+              <Box aria-hidden data-window-spacer="top" sx={{ height: topSpacerHeight, flexShrink: 0, overflowAnchor: 'none' }} />
+            )}
+            {renderedVisibleItems.map((item, itemIdx) => {
+              const isLastVisibleItem = itemIdx === renderedVisibleItems.length - 1;
               const isCompactionAnchor = !!session.compacted_through_msg_id && item.id === session.compacted_through_msg_id;
               const compactionChip = isCompactionAnchor ? (
                 <CompactionMarker
@@ -1339,19 +1721,19 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
               if (isToolGroup(item)) {
                 const groupMeta = session.tool_group_meta?.[item.id];
                 return (
-                  <React.Fragment key={item.id}>
+                  <Box key={item.id} data-window-item-id={item.id} ref={isLastVisibleItem ? lastVisibleItemRef : undefined}>
                     <ToolGroupBubble group={item} isSessionRunning={sessionRunning} meta={groupMeta} sessionId={session.id} />
                     {compactionChip}
-                  </React.Fragment>
+                  </Box>
                 );
               }
               if (isToolPair(item)) {
                 const isPending = item.result === null && sessionRunning;
                 return (
-                  <React.Fragment key={item.id}>
+                  <Box key={item.id} data-window-item-id={item.id} ref={isLastVisibleItem ? lastVisibleItemRef : undefined}>
                     <ToolCallBubble call={item.call} result={item.result} isPending={isPending} sessionId={session.id} suppressReveal={item.call.id === justStreamedId} />
                     {compactionChip}
-                  </React.Fragment>
+                  </Box>
                 );
               }
               const msg = item;
@@ -1364,8 +1746,8 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
               const rawText = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
 
               return (
-                <Box
-                  key={msg.id}
+                <Box key={msg.id} data-window-item-id={msg.id} ref={isLastVisibleItem ? lastVisibleItemRef : undefined}>
+                  <Box
                   sx={{
                     '&:hover .msg-actions': { opacity: 1 },
                     // Cheap virtualization: tells the browser to skip
@@ -1385,6 +1767,9 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                     editing={isEditing}
                     onSaveEdit={handleSaveEdit}
                     onCancelEdit={handleCancelEdit}
+                    viewportHeight={viewportHeight}
+                    viewportWidth={viewportWidth}
+                    scrollRoot={scrollRoot}
                   />
                   {!isEditing && (msg.role === 'user' || (msg.role === 'assistant' && lastAssistantIdsInTurn.has(msg.id))) && (
                     <MessageActionBar
@@ -1418,8 +1803,14 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                   )}
                   {compactionChip}
                 </Box>
+                </Box>
               );
             })}
+            {/* Stand-in for items unmounted BELOW the window (newer items not yet
+                scrolled into view). Zero while following the live tail. */}
+            {bottomSpacerHeight > 0 && (
+              <Box aria-hidden data-window-spacer="bottom" sx={{ height: bottomSpacerHeight, flexShrink: 0, overflowAnchor: 'none' }} />
+            )}
             {/* overflow-anchor: none on the two elements that grow every frame
                 (live stream + thinking dots) keeps Chromium's scroll anchoring
                 from fighting our jam-to-bottom for the scroll position. The
@@ -1471,6 +1862,7 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
                 </Box>
               </Box>
             )}
+            </Box>
           </Box>
           {showScrollButton && (
             <Tooltip title="Scroll to bottom">

--- a/frontend/src/app/pages/AgentChat/AgentChat.tsx
+++ b/frontend/src/app/pages/AgentChat/AgentChat.tsx
@@ -39,6 +39,7 @@ import {
   clearSessionMessages,
   clearMcpSuggestions,
 } from '@/shared/state/agentsSlice';
+import { store } from '@/shared/state/store';
 import { fetchModes } from '@/shared/state/modesSlice';
 import { createSessionWs } from '@/shared/ws/WebSocketManager';
 import StreamingBubble from './bubbles/StreamingBubble';
@@ -232,11 +233,20 @@ const AgentChat: React.FC<AgentChatProps> = ({ sessionId: sessionIdProp, onClose
     // out again. Awaiting fetchSession before connect makes the slice
     // authoritative before any replay event lands.
     (async () => {
-      try {
-        await dispatch(fetchSession(id));
-      } catch {
-        // Even if the REST hydrate fails, still connect , the WS resume
-        // protocol can hydrate from buffered events as a fallback.
+      // The await exists so the slice isn't EMPTY at replay time. A warm store
+      // (remount after a hop) already satisfies that, so connect immediately and
+      // let the fetch reconcile in the background; awaiting serialized a slow
+      // round trip in front of the live stream on every reopen.
+      const warm = !!store.getState().agents.sessions[id]?.messages?.length;
+      if (warm) {
+        dispatch(fetchSession(id));
+      } else {
+        try {
+          await dispatch(fetchSession(id));
+        } catch {
+          // Even if the REST hydrate fails, still connect , the WS resume
+          // protocol can hydrate from buffered events as a fallback.
+        }
       }
       if (cancelled) return;
       ws = createSessionWs(id);

--- a/frontend/src/app/pages/AgentChat/ChatInput.tsx
+++ b/frontend/src/app/pages/AgentChat/ChatInput.tsx
@@ -41,9 +41,10 @@ interface Props {
   queueLength?: number;
   thinkingLevel?: 'off' | 'low' | 'medium' | 'high' | 'auto';
   onThinkingLevelChange?: (level: 'off' | 'low' | 'medium' | 'high' | 'auto') => void;
+  onActivityLabelChange?: (label: string | null) => void;
 }
 
-const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, onModeChange, model, onModelChange, provider, onProviderChange, isRunning, onStop, autoRunMode, contextEstimate, embedded, autoFocus, sessionId, queueLength = 0, thinkingLevel = 'auto', onThinkingLevelChange }, ref) => {
+const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, onModeChange, model, onModelChange, provider, onProviderChange, isRunning, onStop, autoRunMode, contextEstimate, embedded, autoFocus, sessionId, queueLength = 0, thinkingLevel = 'auto', onThinkingLevelChange, onActivityLabelChange }, ref) => {
   const c = useClaudeTokens();
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -73,6 +74,9 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
   );
 
   const { allModelOptions, currentModelCtx, pdfSupported, imageSupported } = useChatInputModel(model);
+  const compactionInFlightRef = useRef(false);
+
+  useEffect(() => () => onActivityLabelChange?.(null), [onActivityLabelChange]);
 
   useEffect(() => {
     if (modesArr.length === 0) dispatch(fetchModes());
@@ -144,7 +148,8 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
     if (!trimmed) return;
 
     const block = computeSendBlock({
-      trimmed, currentModelCtx,
+      trimmed,
+      currentModelCtx,
       historyUsed: contextEstimate?.used ?? 0,
       contextPaths, sessionFrameworkOverhead,
     });
@@ -159,19 +164,21 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
         return;
       }
       // kind === 'compacting': history is the overflow source, which we CAN
-      // shrink. Auto-compact, capture the send intent, flash a status banner.
-      if (sessionId) {
-        pendingSendRef.current = () => { handleSend(); };
-        try {
-          const tok = (() => { try { return getAuthToken(); } catch { return ''; } })();
-          const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-          if (tok) headers['Authorization'] = `Bearer ${tok}`;
-          await fetch(`${API_BASE}/agents/sessions/${sessionId}/compact`, { method: 'POST', headers });
-        } catch (err) { console.error('[auto-compact] failed:', err); pendingSendRef.current = null; }
+      // shrink. Auto-compact invisibly, then continue this same send.
+      if (!sessionId || compactionInFlightRef.current) return;
+      compactionInFlightRef.current = true;
+      setSendBlock(null);
+      onActivityLabelChange?.('Compacting memory');
+      try {
+        const tok = (() => { try { return getAuthToken(); } catch { return ''; } })();
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (tok) headers['Authorization'] = `Bearer ${tok}`;
+        const resp = await fetch(`${API_BASE}/agents/sessions/${sessionId}/compact`, { method: 'POST', headers });
+        if (!resp.ok) throw new Error(`compact failed: ${resp.status}`);
+      } catch (err) {
+        console.error('[auto-compact] failed:', err);
       }
-      setSendBlock(block);
-      setTimeout(() => setSendBlock(null), 2000);
-      return;
+      compactionInFlightRef.current = false;
     }
 
     // Fits now (e.g. user shortened a too-long message): clear any lingering block banner.
@@ -227,7 +234,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(({ onSend, disabled, mode, 
     setAttachedSkills({});
     setHasContent(false);
     elementSelection?.clearOwnerElements(ownerId);
-  }, [disabled, images, contextPaths, forcedTools, onSend, elementSelection, ownerId, summarizingPath, summarizingAll, oversizeQueue, pendingSendRef, sessionId, currentModelCtx, contextEstimate, sessionFrameworkOverhead, setSendBlock]);
+  }, [disabled, images, contextPaths, forcedTools, onSend, elementSelection, ownerId, summarizingPath, summarizingAll, oversizeQueue, pendingSendRef, sessionId, currentModelCtx, contextEstimate, sessionFrameworkOverhead, setSendBlock, onActivityLabelChange]);
 
   const {
     picker: editorPicker, setPicker,

--- a/frontend/src/app/pages/AgentChat/ChatInput/view/SendBlockBanner.tsx
+++ b/frontend/src/app/pages/AgentChat/ChatInput/view/SendBlockBanner.tsx
@@ -9,46 +9,18 @@ interface Props {
   c: ClaudeTokens;
 }
 
-/** Two states:
- *  - 'compacting': auto-compact already fired; pulsing-dot status so the send
- *    doesn't look frozen while we free up room.
- *  - 'too_long': this single message can't fit no matter what; a plain, friendly
- *    block telling the user to shorten it (no jargon, no spinner). */
+/** Only hard-blocks render here. History compaction is shown as normal chat activity. */
 export const SendBlockBanner: React.FC<Props> = ({ sendBlock, c }) => {
-  if (sendBlock.kind === 'too_long') {
-    return (
-      <Box sx={{
-        mx: 1.5, mt: 1, mb: 0.5, px: 2, py: 1.25,
-        borderRadius: '12px',
-        bgcolor: c.bg.surface,
-        border: `1px solid ${c.border.medium}`,
-      }}>
-        <Typography sx={{ fontSize: '0.88rem', color: c.text.primary, lineHeight: 1.45 }}>
-          That message is too long to send. Try shortening it or splitting it into a few smaller ones.
-        </Typography>
-      </Box>
-    );
-  }
+  if (sendBlock.kind !== 'too_long') return null;
   return (
     <Box sx={{
       mx: 1.5, mt: 1, mb: 0.5, px: 2, py: 1.25,
       borderRadius: '12px',
       bgcolor: c.bg.surface,
       border: `1px solid ${c.border.medium}`,
-      display: 'flex', alignItems: 'center', gap: 1,
     }}>
-      <Box component="span" sx={{
-        display: 'inline-block', width: 6, height: 6, borderRadius: '50%',
-        bgcolor: c.accent.primary,
-        animation: 'osw-pulse 1.2s ease-in-out infinite',
-        '@keyframes osw-pulse': {
-          '0%, 100%': { opacity: 0.4 },
-          '50%': { opacity: 1 },
-        },
-        flexShrink: 0,
-      }} />
       <Typography sx={{ fontSize: '0.88rem', color: c.text.primary, lineHeight: 1.45 }}>
-        Making room for your message
+        That message is too long to send. Try shortening it or splitting it into a few smaller ones.
       </Typography>
     </Box>
   );

--- a/frontend/src/app/pages/AgentChat/bubbles/MessageBubble.tsx
+++ b/frontend/src/app/pages/AgentChat/bubbles/MessageBubble.tsx
@@ -18,6 +18,8 @@ import PsychologyOutlinedIcon from '@mui/icons-material/PsychologyOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import WindowedMarkdown from './WindowedMarkdown';
+import { estimateRenderedTextHeight, oversizedCharThreshold, RECHECK_VISIBILITY_EVENT } from './markdownMeasure';
 import { AgentMessage } from '@/shared/state/agentsSlice';
 import { openSettingsModal } from '@/shared/state/settingsSlice';
 import { shallowEqual } from 'react-redux';
@@ -62,6 +64,12 @@ const StreamingCursor: React.FC = () => {
 };
 
 const ELEMENT_SEPARATOR = '\n\n---\nSelected UI Elements:\n';
+
+// Remembered full-render content height per oversized message id. Module-scoped so
+// it survives the transcript window unmounting/remounting the bubble: when a big
+// message goes off-screen we reserve the exact height it had when rendered, so its
+// box doesn't collapse and the scrollbar doesn't jump as it crosses the viewport.
+const oversizedContentHeights = new Map<string, number>();
 
 interface OpenSwarmErrorInfo {
   kind: 'cap' | 'auth' | 'network' | 'too_many_tools';
@@ -833,15 +841,20 @@ interface Props {
   onCancelEdit?: () => void;
   isStreaming?: boolean;
   dynamicTurnLabel?: string | null;
+  viewportHeight?: number;
+  viewportWidth?: number;
+  scrollRoot?: Element | null;
   /** Streaming only: useSmoothText appends revealed chars into this subtree between parses. */
   revealRef?: React.RefObject<HTMLElement | null>;
 }
 
-const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, onSaveEdit, onCancelEdit, isStreaming, dynamicTurnLabel, revealRef }) => {
+const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, onSaveEdit, onCancelEdit, isStreaming, dynamicTurnLabel, viewportHeight = 0, viewportWidth = 0, scrollRoot = null, revealRef }) => {
   const c = useClaudeTokens();
   const dispatch = useAppDispatch();
   const [editText, setEditText] = useState('');
   const [pickerOpen, setPickerOpen] = useState(false);
+  const bubbleRootRef = React.useRef<HTMLDivElement | null>(null);
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
   const { role, content } = message;
 
   if (role === 'system') {
@@ -880,6 +893,18 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
   const { userMessage: displayText, elements: selectedElements } = isUser
     ? parseElementContext(rawText)
     : { userMessage: rawText, elements: [] };
+  // A message longer than ~2 screens of text gets the placeholder + block
+  // virtualization treatment (full render in view, reserved-height placeholder off).
+  const isOversizedAssistant = !isUser && !isStreaming
+    && rawText.length > oversizedCharThreshold(viewportHeight, viewportWidth);
+  const [isOversizedInViewport, setIsOversizedInViewport] = useState(false);
+  const shouldRenderMarkdown = !isOversizedAssistant || isOversizedInViewport;
+  const markdownWindow = useMemo(() => {
+    if (!shouldRenderMarkdown) {
+      return { text: '', start: rawText.length, end: rawText.length, windowed: true };
+    }
+    return { text: rawText, start: 0, end: rawText.length, windowed: false };
+  }, [rawText, shouldRenderMarkdown]);
 
   const renderedMarkdown = useMemo(() => (
     <ReactMarkdown
@@ -889,8 +914,18 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
           <a {...props} style={{ cursor: 'pointer' }}>{children}</a>
         ),
       }}
-    >{rawText}</ReactMarkdown>
-  ), [rawText]);
+    >{markdownWindow.text}</ReactMarkdown>
+  ), [markdownWindow.text]);
+
+  // Height to reserve for this message's off-screen placeholder before it has ever
+  // been measured. Estimated from the FULL text length (we render in full when in
+  // view) with the same model as AgentChat's spacer estimate, so the placeholder
+  // and the spacer reserve the same space. Once rendered, oversizedContentHeights
+  // wins over this.
+  const placeholderFallbackHeight = useMemo(
+    () => estimateRenderedTextHeight(rawText, viewportWidth),
+    [rawText, viewportWidth],
+  );
 
   const overflowCtx = useAppSelector((state) => {
     const sid = state.agents.activeSessionId;
@@ -907,6 +942,65 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
     } as OverflowContext;
   }, shallowEqual);
   const openswarmError = !isUser ? parseOpenSwarmError(rawText, overflowCtx) : null;
+
+  // Reports asynchronously, bc without this an oversized message that mounts in
+  // view (e.g. scrolling up into the agent's reply) would paint the blank
+  // placeholder box for a frame and then pop in the real markdown.
+  React.useLayoutEffect(() => {
+    if (!isOversizedAssistant) {
+      setIsOversizedInViewport(false);
+      return;
+    }
+
+    const node = bubbleRootRef.current;
+    if (!node) return;
+
+    // One-screen rootMargin so the message renders its full markdown for a screen
+    // above and below the visible area; only once it drifts a screen past the
+    // viewport does it drop to the height-reserved placeholder.
+    const bufferPx = Math.max(180, Math.round(viewportHeight || 240));
+
+    // Resolve visibility synchronously (on mount and on demand) so the correct
+    // content paints without waiting on the observer's async callback.
+    const rootEl: Element = (scrollRoot as Element) ?? document.scrollingElement ?? document.documentElement;
+    const evaluate = () => {
+      const rootRect = rootEl.getBoundingClientRect();
+      const nodeRect = node.getBoundingClientRect();
+      setIsOversizedInViewport(nodeRect.bottom >= rootRect.top - bufferPx && nodeRect.top <= rootRect.bottom + bufferPx);
+    };
+    evaluate();
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setIsOversizedInViewport(entry.isIntersecting);
+    }, {
+      root: scrollRoot ?? null,
+      rootMargin: `${bufferPx}px 0px ${bufferPx}px 0px`,
+      threshold: 0,
+    });
+
+    observer.observe(node);
+    // A programmatic jump (scroll-to-bottom / open pin) settles after this mounts;
+    // re-evaluate synchronously when it does, since the observer sometimes misses
+    // the final transition and leaves this stuck as a placeholder.
+    scrollRoot?.addEventListener(RECHECK_VISIBILITY_EVENT, evaluate);
+    return () => {
+      observer.disconnect();
+      scrollRoot?.removeEventListener(RECHECK_VISIBILITY_EVENT, evaluate);
+    };
+  }, [isOversizedAssistant, message.id, scrollRoot, viewportHeight]);
+
+  // Remember the full-render height of an oversized message while it is on-screen,
+  // so its off-screen placeholder can reserve exactly that height (see the
+  // module-level oversizedContentHeights cache). Measured on the content box only,
+  // which excludes the action bar (rendered by the parent) to avoid a feedback loop.
+  React.useLayoutEffect(() => {
+    if (!isOversizedAssistant || !shouldRenderMarkdown) return;
+    const node = contentRef.current;
+    if (!node) return;
+    const h = node.offsetHeight;
+    if (h > 0) oversizedContentHeights.set(message.id, h);
+  }, [isOversizedAssistant, shouldRenderMarkdown, message.id, markdownWindow.text]);
 
   // (message.id, kind) keys so cap card analytics fire once, not on edits.
   React.useEffect(() => {
@@ -943,6 +1037,7 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
 
   return (
     <Box
+      ref={bubbleRootRef}
       data-select-type="message"
       data-select-id={message.id}
       data-select-meta={JSON.stringify({ role, content: truncatedContent })}
@@ -958,6 +1053,11 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
         sx={{
           maxWidth: '85%',
           minWidth: 0,
+          // Oversized messages are block-virtualized, so the set of rendered
+          // blocks (and thus the widest visible content) changes as you scroll.
+          // Pin them to a stable width so the bubble doesn't shrink-to-fit and
+          // resize horizontally frame to frame. Normal messages keep shrink-to-fit.
+          ...(isOversizedAssistant ? { width: '85%' } : {}),
           bgcolor: isUser ? c.user.bubble : c.bg.surface,
           border: isUser ? (isFailed ? `1px solid ${c.status.error}` : 'none') : `1px solid ${c.border.subtle}`,
           borderRadius: isUser ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
@@ -1044,6 +1144,7 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
           )
         ) : (
           <Box
+            ref={contentRef}
             sx={{
               color: c.text.secondary,
               fontSize: '0.875rem',
@@ -1174,10 +1275,42 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
                 {/* Render markdown live (not just at the end) so code is mono,
                     bold is bold, lists/headings format from the first character.
                     Killing the old plain-text -> markdown swap removes the big
-                    layout snap at stream end, which was the "glitch" people felt.
-                    While streaming, useSmoothText appends pending chars into this
+                    Re-parse is memoized on the (smoothed) text and cheap at chat sizes.
+                    While streaming, useSmoothText appends pending chars into the reveal
                     subtree between parses, so the re-parse runs per commit, not per frame. */}
-                <Box ref={revealRef}>{renderedMarkdown}</Box>
+                {isOversizedAssistant && !isOversizedInViewport ? (
+                  <Box
+                    sx={{
+                      // Reserve the height this message had when last rendered full
+                      // (cached across unmount) so the box doesn't collapse and the
+                      // scrollbar stays put. Falls back to a content-aware estimate
+                      // (matched to the spacer estimate) until it's been measured.
+                      minHeight: oversizedContentHeights.get(message.id)
+                        || placeholderFallbackHeight
+                        || Math.min(420, Math.max(180, viewportHeight || 240)),
+                      opacity: 0,
+                      pointerEvents: 'none',
+                    }}
+                    aria-hidden="true"
+                  />
+                ) : isOversizedAssistant ? (
+                  // In view, but virtualize WITHIN the message: only blocks near the
+                  // viewport render their markdown, the rest are reserved-height
+                  // placeholders, so an extremely long message never parses/mounts
+                  // more than the on-screen portion plus a buffer.
+                  <WindowedMarkdown
+                    messageId={message.id}
+                    text={rawText}
+                    scrollRoot={scrollRoot}
+                    viewportHeight={viewportHeight}
+                    viewportWidth={viewportWidth}
+                  />
+                ) : (
+                  // Normal (non-oversized) render. Streaming always lands here
+                  // (oversized requires !isStreaming); the reveal subtree lets
+                  // useSmoothText append chars between parses.
+                  <Box ref={revealRef}>{renderedMarkdown}</Box>
+                )}
                 {isStreaming && <StreamingCursor />}
               </>
             )}

--- a/frontend/src/app/pages/AgentChat/bubbles/WindowedMarkdown.tsx
+++ b/frontend/src/app/pages/AgentChat/bubbles/WindowedMarkdown.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { estimateRenderedTextHeight, RECHECK_VISIBILITY_EVENT } from './markdownMeasure';
+
+// Intra-message virtualization for very long assistant messages. The text is split
+// into FIXED blocks (each block always covers the same character range), so unlike
+// the old growing-tail chunking nothing shifts as you scroll, and no scroll
+// correction is needed. Only blocks within a screen of the viewport actually render
+// their markdown; the rest are height-reserved placeholders, so an extremely long
+// message never parses or mounts more than the on-screen portion plus a buffer.
+
+const BLOCK_TARGET_CHARS = 4_000;
+// Remembered measured height per block (`${messageId}#${index}`). Module-scoped so
+// it survives the block unmounting/remounting as you scroll, keeping the reserved
+// placeholder heights (and thus scroll position) stable.
+const blockHeights = new Map<string, number>();
+
+// Split markdown at blank lines that sit OUTSIDE fenced code blocks, so each block
+// is a self-contained markdown fragment we can parse on its own. A fence (``` or
+// ~~~) toggles "inside code" so we never cut a code block in half. Blocks grow to
+// ~targetChars then break at the next safe boundary.
+function splitMarkdownIntoBlocks(text: string, targetChars: number): string[] {
+  if (text.length <= targetChars) return [text];
+  const lines = text.split('\n');
+  const blocks: string[] = [];
+  let cur: string[] = [];
+  let curLen = 0;
+  let inFence = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) inFence = !inFence;
+    cur.push(line);
+    curLen += line.length + 1;
+    if (curLen >= targetChars && !inFence && trimmed === '') {
+      blocks.push(cur.join('\n'));
+      cur = [];
+      curLen = 0;
+    }
+  }
+  if (cur.length) blocks.push(cur.join('\n'));
+  return blocks.length ? blocks : [text];
+}
+
+const MD_COMPONENTS = {
+  a: ({ children, ...props }: any) => (
+    <a {...props} style={{ cursor: 'pointer' }}>{children}</a>
+  ),
+};
+
+const renderBlock = (text: string) => (
+  <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>{text}</ReactMarkdown>
+);
+
+const MarkdownBlock: React.FC<{
+  blockId: string;
+  text: string;
+  scrollRoot: Element | null;
+  viewportHeight: number;
+  viewportWidth: number;
+}> = React.memo(({ blockId, text, scrollRoot, viewportHeight, viewportWidth }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  React.useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const bufferPx = Math.max(180, Math.round(viewportHeight || 240));
+    // Resolve visibility synchronously (on mount and on demand) so an on-screen
+    // block paints its markdown without waiting on the observer's async callback.
+    const rootEl: Element = (scrollRoot as Element) ?? document.scrollingElement ?? document.documentElement;
+    const evaluate = () => {
+      const rootRect = rootEl.getBoundingClientRect();
+      const nodeRect = node.getBoundingClientRect();
+      setInView(nodeRect.bottom >= rootRect.top - bufferPx && nodeRect.top <= rootRect.bottom + bufferPx);
+    };
+    evaluate();
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setInView(entry.isIntersecting);
+    }, {
+      root: scrollRoot ?? null,
+      rootMargin: `${bufferPx}px 0px ${bufferPx}px 0px`,
+      threshold: 0,
+    });
+    observer.observe(node);
+    // Re-evaluate when a programmatic jump settles (see RECHECK_VISIBILITY_EVENT).
+    scrollRoot?.addEventListener(RECHECK_VISIBILITY_EVENT, evaluate);
+    return () => {
+      observer.disconnect();
+      scrollRoot?.removeEventListener(RECHECK_VISIBILITY_EVENT, evaluate);
+    };
+  }, [scrollRoot, viewportHeight]);
+
+  // Remember the rendered height so the placeholder reserves exactly that space.
+  React.useLayoutEffect(() => {
+    if (!inView) return;
+    const node = ref.current;
+    if (!node) return;
+    const h = node.offsetHeight;
+    if (h > 0) blockHeights.set(blockId, h);
+  }, [inView, blockId, text]);
+
+  // chrome=8: block wrappers have minimal padding vs a full bubble.
+  const reserved = blockHeights.get(blockId) ?? estimateRenderedTextHeight(text, viewportWidth, 8);
+
+  return (
+    <Box ref={ref}>
+      {inView ? renderBlock(text) : <Box aria-hidden sx={{ height: reserved }} />}
+    </Box>
+  );
+});
+
+const WindowedMarkdown: React.FC<{
+  messageId: string;
+  text: string;
+  scrollRoot: Element | null;
+  viewportHeight: number;
+  viewportWidth: number;
+}> = ({ messageId, text, scrollRoot, viewportHeight, viewportWidth }) => {
+  const blocks = useMemo(() => splitMarkdownIntoBlocks(text, BLOCK_TARGET_CHARS), [text]);
+  if (blocks.length === 1) {
+    // Short enough that virtualizing would only add overhead.
+    return renderBlock(text);
+  }
+  return (
+    <>
+      {blocks.map((block, i) => (
+        <MarkdownBlock
+          key={i}
+          blockId={`${messageId}#${i}`}
+          text={block}
+          scrollRoot={scrollRoot}
+          viewportHeight={viewportHeight}
+          viewportWidth={viewportWidth}
+        />
+      ))}
+    </>
+  );
+};
+
+export default WindowedMarkdown;

--- a/frontend/src/app/pages/AgentChat/bubbles/markdownMeasure.ts
+++ b/frontend/src/app/pages/AgentChat/bubbles/markdownMeasure.ts
@@ -1,0 +1,55 @@
+// Shared text-measurement heuristics for chat bubbles. These are empirical pixel
+// values measured against the bubble styling in MessageBubble; they're used to
+// estimate how tall a chunk of text will render (for spacer / placeholder height
+// reservation) and how many characters make a message "oversized" enough to
+// virtualize. They're estimates only: actual heights are measured once an element
+// is on screen and override these everywhere.
+
+// Fired on the scroll container after a programmatic jump (scroll-to-bottom /
+// initial open pin) settles, so oversized messages and their blocks re-evaluate
+// visibility synchronously instead of waiting on the async IntersectionObserver,
+// which occasionally misses the final transition and leaves a stuck placeholder.
+export const RECHECK_VISIBILITY_EVENT = 'chat-recheck-visibility';
+
+export const BUBBLE_LINE_HEIGHT_PX = 22;      // line-height of bubble body text
+export const BUBBLE_AVG_CHAR_WIDTH_PX = 7.2;  // average glyph width at the bubble font
+export const BUBBLE_WIDTH_RATIO = 0.85;       // bubbles are maxWidth: 85% of the column
+export const MIN_CHARS_PER_VIEWPORT = 2_000;  // floor so tiny/zero viewports still allow real-sized messages
+export const OVERSIZED_VIEWPORT_MULTIPLE = 2;  // a message taller than ~2 screens gets virtualized
+
+// Tweak on the line-based estimate. Kept at 1.0 so estimates lean accurate/under
+// rather than over: the scroll-height lock tolerates under-estimates fine (the
+// total just grows monotonically as things measure), but OVER-estimates inflate
+// the lock's compensating pad into visible empty space below the chat. Prose in
+// particular over-estimated badly at higher values.
+const MARKDOWN_DENSITY_FACTOR = 1.0;
+
+// Characters that fit on one rendered line at this width.
+function charsPerLine(viewportWidth: number): number {
+  const readableWidth = Math.max(280, (viewportWidth || 0) * BUBBLE_WIDTH_RATIO);
+  return Math.max(36, Math.floor(readableWidth / BUBBLE_AVG_CHAR_WIDTH_PX));
+}
+
+// Rough pixel height `text` will occupy when rendered in a bubble at this width.
+// Counts by SOURCE line (each \n-delimited line takes at least one rendered line,
+// plus wraps for long lines) rather than total chars, so dense markdown with many
+// short lines isn't wildly under-counted. `chromePx` is the vertical padding/
+// margins around the text.
+export function estimateRenderedTextHeight(text: string, viewportWidth: number, chromePx = 40): number {
+  const cpl = charsPerLine(viewportWidth);
+  const sourceLines = text ? text.split('\n') : [''];
+  let lines = 0;
+  for (let i = 0; i < sourceLines.length; i++) {
+    lines += Math.max(1, Math.ceil(sourceLines[i].length / cpl));
+  }
+  return Math.ceil(Math.max(1, lines) * BUBBLE_LINE_HEIGHT_PX * MARKDOWN_DENSITY_FACTOR) + chromePx;
+}
+
+// Character count above which an assistant message is treated as "oversized" and
+// gets the placeholder + block-virtualization treatment: roughly two screens of
+// text, with a floor so it never trips on short messages.
+export function oversizedCharThreshold(viewportHeight: number, viewportWidth: number): number {
+  const visibleLines = Math.max(1, Math.ceil(Math.max(0, viewportHeight) / BUBBLE_LINE_HEIGHT_PX));
+  const charsPerViewport = Math.max(MIN_CHARS_PER_VIEWPORT, visibleLines * charsPerLine(viewportWidth));
+  return charsPerViewport * OVERSIZED_VIEWPORT_MULTIPLE;
+}

--- a/frontend/src/app/pages/AgentChat/shell/MessageActionBar.tsx
+++ b/frontend/src/app/pages/AgentChat/shell/MessageActionBar.tsx
@@ -21,6 +21,7 @@ import FeedbackDialog, { Sentiment } from './FeedbackDialog';
 interface BranchNavProps {
   currentIndex: number;
   totalBranches: number;
+  disabled?: boolean;
   onPrevious: () => void;
   onNext: () => void;
 }
@@ -108,7 +109,7 @@ const MessageActionBar: React.FC<Props> = ({
               <IconButton
                 size="small"
                 onClick={branchNav.onPrevious}
-                disabled={branchNav.currentIndex === 0}
+                disabled={branchNav.disabled || branchNav.currentIndex === 0}
                 sx={btnSx(c)}
               >
                 <ChevronLeftIcon sx={{ fontSize: 16 }} />
@@ -127,7 +128,7 @@ const MessageActionBar: React.FC<Props> = ({
               <IconButton
                 size="small"
                 onClick={branchNav.onNext}
-                disabled={branchNav.currentIndex === branchNav.totalBranches - 1}
+                disabled={branchNav.disabled || branchNav.currentIndex === branchNav.totalBranches - 1}
                 sx={btnSx(c)}
               >
                 <ChevronRightIcon sx={{ fontSize: 16 }} />
@@ -199,6 +200,7 @@ export default React.memo(MessageActionBar, (prev, next) => (
   && !!prev.onBranch === !!next.onBranch
   && prev.branchNav?.currentIndex === next.branchNav?.currentIndex
   && prev.branchNav?.totalBranches === next.branchNav?.totalBranches
+  && prev.branchNav?.disabled === next.branchNav?.disabled
   && prev.messageId === next.messageId
   && prev.sessionId === next.sessionId
 ));

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardCanvas.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardCanvas.tsx
@@ -16,6 +16,7 @@ import type {
 import type { Output } from '@/shared/state/outputsSlice';
 import type { CardType, useDashboardSelection } from '../hooks/state/useDashboardSelection';
 import type { useCanvasControls } from '../hooks/interaction/useCanvasControls';
+import { useWebviewSuspend } from '../hooks/interaction/useWebviewSuspend';
 import type { Tether } from '../geometry/dashboardTethers';
 
 type Selection = ReturnType<typeof useDashboardSelection>;
@@ -140,6 +141,8 @@ const DashboardCanvas: React.FC<DashboardCanvasProps> = ({
 }) => {
   const dotSize = Math.max(1, 1.5 * canvas.zoom);
   const dotSpacing = 24 * canvas.zoom;
+
+  useWebviewSuspend(browserCards, canvas.panX, canvas.panY, canvas.zoom, canvas.viewportRef);
 
   return (
     <>

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
@@ -2,69 +2,53 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import type { ClaudeTokens } from '@/shared/styles/claudeTokens';
+import { useDashboardActive } from '@/shared/hooks/useDashboardActive';
 import ChatBubbleTeardrop from '../ChatBubbleTeardrop';
 
-const SHIMMER_PERIOD_S = 6;
-
-/* Letters brighten as a wave passes: per-letter opacity keyframes are GPU-composited, unlike the old background-position gradient that repainted the text every frame. */
-const GlintText: React.FC<{ text: string; slotOffset: number; totalSlots: number }> = ({ text, slotOffset, totalSlots }) => (
-  <>
-    {Array.from(text).map((ch, i) => (
-      <Box
-        key={i}
-        component="span"
-        sx={{
-          opacity: 0.4,
-          animation: `empty-state-glint ${SHIMMER_PERIOD_S}s linear infinite`,
-          animationDelay: `${(((slotOffset + i) / totalSlots) * SHIMMER_PERIOD_S).toFixed(2)}s`,
-          whiteSpace: 'pre',
-          '@keyframes empty-state-glint': {
-            '0%, 8%, 100%': { opacity: 0.4 },
-            '4%': { opacity: 1 },
-          },
-          '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
-        }}
-      >
-        {ch}
-      </Box>
-    ))}
-  </>
-);
-
-const HINT_BEFORE = 'Click the ';
-const HINT_AFTER = ' below to launch your first agent';
-const HINT_SLOTS = HINT_BEFORE.length + 1 + HINT_AFTER.length;
-
-const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
-  <Box
-    sx={{
-      position: 'absolute',
-      inset: 0,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      pointerEvents: 'none',
-    }}
-  >
-    <Typography sx={{ color: c.text.tertiary, fontSize: '1.1rem', mb: 1 }}>
-      No agents running
-    </Typography>
-    <Typography
+const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => {
+  // The host hides Dashboard with visibility:hidden (not display:none), which keeps
+  // CSS animations ticking; gate on active so the shimmer only burns while watched.
+  const active = useDashboardActive();
+  return (
+    <Box
       sx={{
-        fontSize: '0.9rem',
-        display: 'inline-flex',
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        color: c.text.primary,
+        justifyContent: 'center',
+        pointerEvents: 'none',
       }}
     >
-      <GlintText text={HINT_BEFORE} slotOffset={0} totalSlots={HINT_SLOTS} />
-      <Box component="span" sx={{ display: 'inline-flex', color: c.text.tertiary, mx: 0.35 }}>
-        <ChatBubbleTeardrop sx={{ fontSize: 15 }} />
-      </Box>
-      <GlintText text={HINT_AFTER} slotOffset={HINT_BEFORE.length + 1} totalSlots={HINT_SLOTS} />
-    </Typography>
-  </Box>
-);
+      <style>{`@keyframes empty-state-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
+      <Typography sx={{ color: c.text.tertiary, fontSize: '1.1rem', mb: 1 }}>
+        No agents running
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: '0.9rem',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.7,
+          background: `linear-gradient(90deg, ${c.text.ghost} 0%, ${c.text.ghost} 40%, ${c.text.primary} 50%, ${c.text.ghost} 60%, ${c.text.ghost} 100%)`,
+          backgroundSize: '200% 100%',
+          WebkitBackgroundClip: 'text',
+          backgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          color: 'transparent',
+          animation: active ? 'empty-state-shimmer 6s linear infinite' : 'none',
+        }}
+      >
+        Click the
+        {/* Literal toolbar glyph; the shimmer's transparent color would hide it, so reset color here. */}
+        <Box component="span" sx={{ display: 'inline-flex', color: c.text.tertiary }}>
+          <ChatBubbleTeardrop sx={{ fontSize: 15 }} />
+        </Box>
+        below to launch your first agent
+      </Typography>
+    </Box>
+  );
+};
 
 export default DashboardEmptyState;

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
@@ -16,7 +16,6 @@ const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
       pointerEvents: 'none',
     }}
   >
-    <style>{`@keyframes empty-state-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }`}</style>
     <Typography sx={{ color: c.text.tertiary, fontSize: '1.1rem', mb: 1 }}>
       No agents running
     </Typography>
@@ -26,17 +25,10 @@ const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
         display: 'inline-flex',
         alignItems: 'center',
         gap: 0.7,
-        background: `linear-gradient(90deg, ${c.text.ghost} 0%, ${c.text.ghost} 40%, ${c.text.primary} 50%, ${c.text.ghost} 60%, ${c.text.ghost} 100%)`,
-        backgroundSize: '200% 100%',
-        WebkitBackgroundClip: 'text',
-        backgroundClip: 'text',
-        WebkitTextFillColor: 'transparent',
-        color: 'transparent',
-        animation: 'empty-state-shimmer 6s linear infinite',
+        color: c.text.primary,
       }}
     >
       Click the
-      {/* Literal toolbar glyph; the shimmer's transparent color would hide it, so reset color here. */}
       <Box component="span" sx={{ display: 'inline-flex', color: c.text.tertiary }}>
         <ChatBubbleTeardrop sx={{ fontSize: 15 }} />
       </Box>

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
@@ -26,6 +26,8 @@ const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
         alignItems: 'center',
         gap: 0.7,
         color: c.text.primary,
+        position: 'relative',
+        overflow: 'hidden',
       }}
     >
       Click the
@@ -33,6 +35,22 @@ const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
         <ChatBubbleTeardrop sx={{ fontSize: 15 }} />
       </Box>
       below to launch your first agent
+      {/* Sheen sweeps via transform only: the layer rasters once and the GPU slides it, unlike the old background-position shimmer that repainted every frame. */}
+      <Box
+        component="span"
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: 'linear-gradient(105deg, transparent 42%, rgba(255,255,255,0.14) 50%, transparent 58%)',
+          transform: 'translateX(-100%)',
+          animation: 'empty-state-sheen 6s linear infinite',
+          willChange: 'transform',
+          '@keyframes empty-state-sheen': { to: { transform: 'translateX(100%)' } },
+          '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+        }}
+      />
     </Typography>
   </Box>
 );

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardEmptyState.tsx
@@ -4,6 +4,37 @@ import Typography from '@mui/material/Typography';
 import type { ClaudeTokens } from '@/shared/styles/claudeTokens';
 import ChatBubbleTeardrop from '../ChatBubbleTeardrop';
 
+const SHIMMER_PERIOD_S = 6;
+
+/* Letters brighten as a wave passes: per-letter opacity keyframes are GPU-composited, unlike the old background-position gradient that repainted the text every frame. */
+const GlintText: React.FC<{ text: string; slotOffset: number; totalSlots: number }> = ({ text, slotOffset, totalSlots }) => (
+  <>
+    {Array.from(text).map((ch, i) => (
+      <Box
+        key={i}
+        component="span"
+        sx={{
+          opacity: 0.4,
+          animation: `empty-state-glint ${SHIMMER_PERIOD_S}s linear infinite`,
+          animationDelay: `${(((slotOffset + i) / totalSlots) * SHIMMER_PERIOD_S).toFixed(2)}s`,
+          whiteSpace: 'pre',
+          '@keyframes empty-state-glint': {
+            '0%, 8%, 100%': { opacity: 0.4 },
+            '4%': { opacity: 1 },
+          },
+          '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+        }}
+      >
+        {ch}
+      </Box>
+    ))}
+  </>
+);
+
+const HINT_BEFORE = 'Click the ';
+const HINT_AFTER = ' below to launch your first agent';
+const HINT_SLOTS = HINT_BEFORE.length + 1 + HINT_AFTER.length;
+
 const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
   <Box
     sx={{
@@ -24,33 +55,14 @@ const DashboardEmptyState: React.FC<{ c: ClaudeTokens }> = ({ c }) => (
         fontSize: '0.9rem',
         display: 'inline-flex',
         alignItems: 'center',
-        gap: 0.7,
         color: c.text.primary,
-        position: 'relative',
-        overflow: 'hidden',
       }}
     >
-      Click the
-      <Box component="span" sx={{ display: 'inline-flex', color: c.text.tertiary }}>
+      <GlintText text={HINT_BEFORE} slotOffset={0} totalSlots={HINT_SLOTS} />
+      <Box component="span" sx={{ display: 'inline-flex', color: c.text.tertiary, mx: 0.35 }}>
         <ChatBubbleTeardrop sx={{ fontSize: 15 }} />
       </Box>
-      below to launch your first agent
-      {/* Sheen sweeps via transform only: the layer rasters once and the GPU slides it, unlike the old background-position shimmer that repainted every frame. */}
-      <Box
-        component="span"
-        aria-hidden
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          pointerEvents: 'none',
-          background: 'linear-gradient(105deg, transparent 42%, rgba(255,255,255,0.14) 50%, transparent 58%)',
-          transform: 'translateX(-100%)',
-          animation: 'empty-state-sheen 6s linear infinite',
-          willChange: 'transform',
-          '@keyframes empty-state-sheen': { to: { transform: 'translateX(100%)' } },
-          '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
-        }}
-      />
+      <GlintText text={HINT_AFTER} slotOffset={HINT_BEFORE.length + 1} totalSlots={HINT_SLOTS} />
     </Typography>
   </Box>
 );

--- a/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
@@ -1077,21 +1077,40 @@ const BrowserCard: React.FC<Props> = ({
         )}
         {isElectron ? (
           suspendedSnap ? (
-            <Box
-              component="img"
-              src={suspendedSnap.dataUrl}
-              alt=""
-              onClick={() => dispatch(resumeBrowserCard(browserId))}
-              sx={{
-                position: 'absolute',
-                inset: 0,
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                objectPosition: 'top left',
-                cursor: 'pointer',
-              }}
-            />
+            suspendedSnap.dataUrl ? (
+              <Box
+                component="img"
+                src={suspendedSnap.dataUrl}
+                alt=""
+                onClick={() => dispatch(resumeBrowserCard(browserId))}
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                  objectPosition: 'top left',
+                  cursor: 'pointer',
+                }}
+              />
+            ) : (
+              <Box
+                onClick={() => dispatch(resumeBrowserCard(browserId))}
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  bgcolor: c.bg.surface,
+                }}
+              >
+                <Typography sx={{ color: c.text.ghost, fontSize: '0.9rem', px: 2, textAlign: 'center' }}>
+                  {activeTitle || activeUrl}
+                </Typography>
+              </Box>
+            )
           ) : (
           tabs.map((tab) => (
             <webview

--- a/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
@@ -25,6 +25,7 @@ import {
   setBrowserCardPosition,
   setBrowserCardSize,
   removeBrowserCard,
+  resumeBrowserCard,
   addBrowserTab,
   removeBrowserTab,
   setActiveBrowserTab,
@@ -219,6 +220,8 @@ const BrowserCard: React.FC<Props> = ({
   );
   const browserAgentSession = useAppSelector(selectBrowserAgentSession);
 
+  const suspendedSnap = useAppSelector((state) => state.dashboardLayout.suspendedBrowserCards[browserId]);
+
   const activity = useBrowserActivity(browserId);
   const agentRunning = browserAgentSession?.status === 'running';
   const agentActive = activity.active || agentRunning;
@@ -255,6 +258,11 @@ const BrowserCard: React.FC<Props> = ({
   useEffect(() => {
     setRegistryActiveTab(browserId, activeTabId);
   }, [browserId, activeTabId]);
+
+  // A resumed webview remounts at about:blank; dropping the init markers lets doLoad re-fire.
+  useEffect(() => {
+    if (suspendedSnap) initializedTabs.current.clear();
+  }, [suspendedSnap]);
 
   const tabIdKey = tabs.map((t) => t.id).join(',');
   useEffect(() => {
@@ -367,7 +375,7 @@ const BrowserCard: React.FC<Props> = ({
 
     return () => cleanups.forEach((fn) => fn());
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tabIdKey, browserId, dispatch, updateTabLocal]);
+  }, [tabIdKey, browserId, dispatch, updateTabLocal, suspendedSnap]);
 
   const navigate = useCallback((targetUrl: string) => {
     const finalUrl = resolveInput(targetUrl);
@@ -379,7 +387,8 @@ const BrowserCard: React.FC<Props> = ({
       });
     }
     dispatch(updateBrowserTabUrl({ browserId, tabId: activeTabId, url: finalUrl }));
-  }, [browserId, activeTabId, dispatch]);
+    if (suspendedSnap) dispatch(resumeBrowserCard(browserId));
+  }, [browserId, activeTabId, dispatch, suspendedSnap]);
 
   const handleUrlKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -1067,6 +1076,23 @@ const BrowserCard: React.FC<Props> = ({
           <Box sx={{ position: 'absolute', inset: 0, zIndex: 12, pointerEvents: 'none' }} />
         )}
         {isElectron ? (
+          suspendedSnap ? (
+            <Box
+              component="img"
+              src={suspendedSnap.dataUrl}
+              alt=""
+              onClick={() => dispatch(resumeBrowserCard(browserId))}
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                objectPosition: 'top left',
+                cursor: 'pointer',
+              }}
+            />
+          ) : (
           tabs.map((tab) => (
             <webview
               key={tab.id}
@@ -1092,6 +1118,7 @@ const BrowserCard: React.FC<Props> = ({
               }}
             />
           ))
+          )
         ) : null}
         <Dialog
           open={passkeyDialogOpen}

--- a/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
@@ -190,12 +190,6 @@ const BrowserCard: React.FC<Props> = ({
   isSelected = false, isHighlighted = false, multiDragDelta, onCardSelect, onDragStart, onDragMove, onDragEnd,
   cardZOrder = 0, onDoubleClick, onBringToFront,
 }) => {
-  // Arm the Windows webview crash-safety marker synchronously, before React commits
-  // the <webview> below. Cleared on dom-ready; a leftover marker next launch tells
-  // windowsWebviewEnabled() the mount crashed, so it falls back to the iframe.
-  // Idempotent, no-op on Mac and on the iframe path. See the gate block above.
-  if (isElectron && isWindows) armWindowsWebviewPending();
-
   const c = useClaudeTokens();
   const dispatch = useAppDispatch();
   const scrollOverlayRef = useOverlayScrollPassthrough(isSelected);
@@ -221,6 +215,13 @@ const BrowserCard: React.FC<Props> = ({
   const browserAgentSession = useAppSelector(selectBrowserAgentSession);
 
   const suspendedSnap = useAppSelector((state) => state.dashboardLayout.suspendedBrowserCards[browserId]);
+
+  // Arm the Windows webview crash-safety marker synchronously, before React commits
+  // the <webview> below. Cleared on dom-ready; a leftover marker next launch tells
+  // windowsWebviewEnabled() the mount crashed, so it falls back to the iframe.
+  // MUST skip parked cards: they render no webview, so dom-ready never fires and a
+  // stale marker reads as a phantom crash that locks Windows out of webviews.
+  if (isElectron && isWindows && !suspendedSnap) armWindowsWebviewPending();
 
   const activity = useBrowserActivity(browserId);
   const agentRunning = browserAgentSession?.status === 'running';

--- a/frontend/src/app/pages/Dashboard/cards/DashboardViewCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/DashboardViewCard.tsx
@@ -489,6 +489,7 @@ const DashboardOutputPreview: React.FC<{
   backendResult: any;
 }> = ({ previewRef, output, inputData, backendResult }) => {
   const tokens = useClaudeTokens();
+  const dispatch = useAppDispatch();
   const workspaceId = output.workspace_id ?? null;
   const { frontendUrl, isNewMode, isHydrating } = useRuntimePreviewUrl({
     workspaceId,
@@ -500,6 +501,58 @@ const DashboardOutputPreview: React.FC<{
     frontendUrl,
     isNewMode,
   });
+
+  // An orphaned record (files deleted on disk) used to render the raw 404 JSON
+  // inside the card, or spin on "Starting preview" forever; probe once instead.
+  const [filesMissing, setFilesMissing] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const tok = getAuthToken();
+    const headers: Record<string, string> = tok ? { Authorization: `Bearer ${tok}` } : {};
+    const probe = workspaceId
+      ? `${API_BASE}/outputs/workspace/${workspaceId}`
+      : `${SERVE_BASE}/${output.id}/serve/index.html`;
+    fetch(probe, { headers })
+      .then((r) => {
+        if (!cancelled && r.status === 404) setFilesMissing(true);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [workspaceId, output.id]);
+
+  if (filesMissing) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1.5,
+          px: 2,
+          textAlign: 'center',
+        }}
+      >
+        <Typography sx={{ color: tokens.text.secondary, fontSize: '0.9rem' }}>
+          This app's files are missing.
+        </Typography>
+        <Typography
+          onClick={() => dispatch(removeViewCard(output.id))}
+          sx={{
+            color: tokens.accent.primary,
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          Remove card
+        </Typography>
+      </Box>
+    );
+  }
 
   // Blank body during hydration so warm runtimes don't flash "Starting preview..."
   if (isHydrating && !frontendUrl) {

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
@@ -17,6 +17,9 @@ const SETTLE_MS = 800;
 const SUSPEND_MARGIN_PX = 320;
 const RESUME_MARGIN_PX = 96;
 const SNAPSHOT_MAX_W = 1024;
+// Below this on-screen width a live page is indistinguishable from its placeholder,
+// so booted-parked cards on a zoomed-out canvas stay parked until zoomed into.
+const RESUME_MIN_CARD_PX = 220;
 
 interface Viewport {
   panX: number;
@@ -96,7 +99,9 @@ export function useWebviewSuspend(
 
     for (const id of Object.keys(suspended)) {
       const card = browserCards[id];
-      if (card && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) {
+      if (!card) continue;
+      const bigEnough = card.width * zoom >= RESUME_MIN_CARD_PX;
+      if ((bigEnough && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) || agentNeedsLive(id, card)) {
         dispatch(resumeBrowserCard(id));
       }
     }

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
@@ -20,9 +20,6 @@ const SNAPSHOT_MAX_W = 1024;
 // Below this on-screen width a live page is indistinguishable from its placeholder,
 // so booted-parked cards on a zoomed-out canvas stay parked until zoomed into.
 const RESUME_MIN_CARD_PX = 220;
-// Hard ceiling on simultaneous live webviews; past it the farthest-from-center
-// non-agent card gets parked, so heavy pages degrade gracefully instead of OOMing.
-const MAX_LIVE_WEBVIEWS = 8;
 
 interface Viewport {
   panX: number;
@@ -100,77 +97,41 @@ export function useWebviewSuspend(
       vpH: el ? el.clientHeight : 800,
     };
 
-    const liveCount = Object.keys(browserCards).filter((id) => !suspended[id]).length;
-    let budget = MAX_LIVE_WEBVIEWS - liveCount;
-    const parked = Object.keys(suspended)
-      .map((id) => [id, browserCards[id]] as const)
-      .filter(([, card]) => !!card)
-      .sort((a, b) => distFromCenter(a[1], vpRef.current) - distFromCenter(b[1], vpRef.current));
-    for (const [id, card] of parked) {
-      if (agentNeedsLive(id, card)) {
-        dispatch(resumeBrowserCard(id));
-        budget--;
-        continue;
-      }
-      if (budget <= 0) continue;
+    for (const id of Object.keys(suspended)) {
+      const card = browserCards[id];
+      if (!card) continue;
       const bigEnough = card.width * zoom >= RESUME_MIN_CARD_PX;
-      if (bigEnough && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) {
+      if ((bigEnough && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) || agentNeedsLive(id, card)) {
         dispatch(resumeBrowserCard(id));
-        budget--;
       }
     }
 
     const timer = setTimeout(async () => {
-      const isSuspended = (id: string) => !!store.getState().dashboardLayout.suspendedBrowserCards[id];
       for (const [id, card] of Object.entries(browserCards)) {
-        if (isSuspended(id)) continue;
+        if (store.getState().dashboardLayout.suspendedBrowserCards[id]) continue;
         if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
         if (agentNeedsLive(id, card)) continue;
-        const dataUrl = await captureCard(id, card);
-        // The capture await yielded; conditions may have changed under us.
-        if (!dataUrl || cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX) || agentNeedsLive(id, card)) continue;
-        dispatch(suspendBrowserCard({ browserId: id, dataUrl }));
-      }
-
-      const countLive = () => Object.keys(browserCards).filter((id) => !isSuspended(id)).length;
-      if (countLive() > MAX_LIVE_WEBVIEWS) {
-        const candidates = Object.entries(browserCards)
-          .filter(([id, card]) => !isSuspended(id) && !agentNeedsLive(id, card))
-          .sort((a, b) => distFromCenter(b[1], vpRef.current) - distFromCenter(a[1], vpRef.current));
-        for (const [id, card] of candidates) {
-          if (countLive() <= MAX_LIVE_WEBVIEWS) break;
-          const dataUrl = await captureCard(id, card);
-          if (!dataUrl || agentNeedsLive(id, card)) continue;
+        const wv = getWebview(id, card.activeTabId);
+        if (!wv) continue;
+        try {
+          if (wv.isLoading()) continue;
+          const url = wv.getURL();
+          if (!url || url === 'about:blank') continue;
+          const image = await wv.capturePage();
+          if (image.isEmpty()) continue;
+          // The capture await yielded; conditions may have changed under us.
+          if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
+          if (agentNeedsLive(id, card)) continue;
+          const dataUrl = image.getSize().width > SNAPSHOT_MAX_W
+            ? image.resize({ width: SNAPSHOT_MAX_W, quality: 'good' }).toDataURL()
+            : image.toDataURL();
           dispatch(suspendBrowserCard({ browserId: id, dataUrl }));
+        } catch {
+          // capture failed mid-teardown or mid-navigation; card just stays live
         }
       }
     }, SETTLE_MS);
 
     return () => clearTimeout(timer);
   }, [browserCards, suspended, panX, panY, zoom, viewportRef, dispatch, resizeTick]);
-}
-
-function distFromCenter(card: BrowserCardPosition, vp: Viewport): number {
-  const cx = (-vp.panX + vp.vpW / 2) / vp.zoom;
-  const cy = (-vp.panY + vp.vpH / 2) / vp.zoom;
-  const dx = card.x + card.width / 2 - cx;
-  const dy = card.y + card.height / 2 - cy;
-  return dx * dx + dy * dy;
-}
-
-async function captureCard(id: string, card: BrowserCardPosition): Promise<string | null> {
-  const wv = getWebview(id, card.activeTabId);
-  if (!wv) return null;
-  try {
-    if (wv.isLoading()) return null;
-    const url = wv.getURL();
-    if (!url || url === 'about:blank') return null;
-    const image = await wv.capturePage();
-    if (image.isEmpty()) return null;
-    return image.getSize().width > SNAPSHOT_MAX_W
-      ? image.resize({ width: SNAPSHOT_MAX_W, quality: 'good' }).toDataURL()
-      : image.toDataURL();
-  } catch {
-    return null;
-  }
 }

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 import { store } from '@/shared/state/store';
 import {
@@ -68,6 +68,23 @@ export function useWebviewSuspend(
   const suspended = useAppSelector((s) => s.dashboardLayout.suspendedBrowserCards);
   const vpRef = useRef<Viewport>({ panX, panY, zoom, vpW: 1200, vpH: 800 });
 
+  // Window resize changes the viewport without touching pan/zoom/cards; tick so
+  // the evaluation below reruns, or a shrunken window never suspends anything.
+  const [resizeTick, setResizeTick] = useState(0);
+  useEffect(() => {
+    if (!isElectron) return;
+    let t: ReturnType<typeof setTimeout> | null = null;
+    const onResize = () => {
+      if (t) clearTimeout(t);
+      t = setTimeout(() => setResizeTick((n) => n + 1), 300);
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      if (t) clearTimeout(t);
+    };
+  }, []);
+
   useEffect(() => {
     if (!isElectron) return;
     const el = viewportRef.current;
@@ -111,5 +128,5 @@ export function useWebviewSuspend(
     }, SETTLE_MS);
 
     return () => clearTimeout(timer);
-  }, [browserCards, suspended, panX, panY, zoom, viewportRef, dispatch]);
+  }, [browserCards, suspended, panX, panY, zoom, viewportRef, dispatch, resizeTick]);
 }

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
@@ -20,6 +20,9 @@ const SNAPSHOT_MAX_W = 1024;
 // Below this on-screen width a live page is indistinguishable from its placeholder,
 // so booted-parked cards on a zoomed-out canvas stay parked until zoomed into.
 const RESUME_MIN_CARD_PX = 220;
+// Hard ceiling on simultaneous live webviews; past it the farthest-from-center
+// non-agent card gets parked, so heavy pages degrade gracefully instead of OOMing.
+const MAX_LIVE_WEBVIEWS = 8;
 
 interface Viewport {
   panX: number;
@@ -97,41 +100,77 @@ export function useWebviewSuspend(
       vpH: el ? el.clientHeight : 800,
     };
 
-    for (const id of Object.keys(suspended)) {
-      const card = browserCards[id];
-      if (!card) continue;
-      const bigEnough = card.width * zoom >= RESUME_MIN_CARD_PX;
-      if ((bigEnough && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) || agentNeedsLive(id, card)) {
+    const liveCount = Object.keys(browserCards).filter((id) => !suspended[id]).length;
+    let budget = MAX_LIVE_WEBVIEWS - liveCount;
+    const parked = Object.keys(suspended)
+      .map((id) => [id, browserCards[id]] as const)
+      .filter(([, card]) => !!card)
+      .sort((a, b) => distFromCenter(a[1], vpRef.current) - distFromCenter(b[1], vpRef.current));
+    for (const [id, card] of parked) {
+      if (agentNeedsLive(id, card)) {
         dispatch(resumeBrowserCard(id));
+        budget--;
+        continue;
+      }
+      if (budget <= 0) continue;
+      const bigEnough = card.width * zoom >= RESUME_MIN_CARD_PX;
+      if (bigEnough && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) {
+        dispatch(resumeBrowserCard(id));
+        budget--;
       }
     }
 
     const timer = setTimeout(async () => {
+      const isSuspended = (id: string) => !!store.getState().dashboardLayout.suspendedBrowserCards[id];
       for (const [id, card] of Object.entries(browserCards)) {
-        if (store.getState().dashboardLayout.suspendedBrowserCards[id]) continue;
+        if (isSuspended(id)) continue;
         if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
         if (agentNeedsLive(id, card)) continue;
-        const wv = getWebview(id, card.activeTabId);
-        if (!wv) continue;
-        try {
-          if (wv.isLoading()) continue;
-          const url = wv.getURL();
-          if (!url || url === 'about:blank') continue;
-          const image = await wv.capturePage();
-          if (image.isEmpty()) continue;
-          // The capture await yielded; conditions may have changed under us.
-          if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
-          if (agentNeedsLive(id, card)) continue;
-          const dataUrl = image.getSize().width > SNAPSHOT_MAX_W
-            ? image.resize({ width: SNAPSHOT_MAX_W, quality: 'good' }).toDataURL()
-            : image.toDataURL();
+        const dataUrl = await captureCard(id, card);
+        // The capture await yielded; conditions may have changed under us.
+        if (!dataUrl || cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX) || agentNeedsLive(id, card)) continue;
+        dispatch(suspendBrowserCard({ browserId: id, dataUrl }));
+      }
+
+      const countLive = () => Object.keys(browserCards).filter((id) => !isSuspended(id)).length;
+      if (countLive() > MAX_LIVE_WEBVIEWS) {
+        const candidates = Object.entries(browserCards)
+          .filter(([id, card]) => !isSuspended(id) && !agentNeedsLive(id, card))
+          .sort((a, b) => distFromCenter(b[1], vpRef.current) - distFromCenter(a[1], vpRef.current));
+        for (const [id, card] of candidates) {
+          if (countLive() <= MAX_LIVE_WEBVIEWS) break;
+          const dataUrl = await captureCard(id, card);
+          if (!dataUrl || agentNeedsLive(id, card)) continue;
           dispatch(suspendBrowserCard({ browserId: id, dataUrl }));
-        } catch {
-          // capture failed mid-teardown or mid-navigation; card just stays live
         }
       }
     }, SETTLE_MS);
 
     return () => clearTimeout(timer);
   }, [browserCards, suspended, panX, panY, zoom, viewportRef, dispatch, resizeTick]);
+}
+
+function distFromCenter(card: BrowserCardPosition, vp: Viewport): number {
+  const cx = (-vp.panX + vp.vpW / 2) / vp.zoom;
+  const cy = (-vp.panY + vp.vpH / 2) / vp.zoom;
+  const dx = card.x + card.width / 2 - cx;
+  const dy = card.y + card.height / 2 - cy;
+  return dx * dx + dy * dy;
+}
+
+async function captureCard(id: string, card: BrowserCardPosition): Promise<string | null> {
+  const wv = getWebview(id, card.activeTabId);
+  if (!wv) return null;
+  try {
+    if (wv.isLoading()) return null;
+    const url = wv.getURL();
+    if (!url || url === 'about:blank') return null;
+    const image = await wv.capturePage();
+    if (image.isEmpty()) return null;
+    return image.getSize().width > SNAPSHOT_MAX_W
+      ? image.resize({ width: SNAPSHOT_MAX_W, quality: 'good' }).toDataURL()
+      : image.toDataURL();
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useWebviewSuspend.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef } from 'react';
+import { useAppDispatch, useAppSelector } from '@/shared/hooks';
+import { store } from '@/shared/state/store';
+import {
+  suspendBrowserCard,
+  resumeBrowserCard,
+  type BrowserCardPosition,
+} from '@/shared/state/dashboardLayoutSlice';
+import { getWebview } from '@/shared/browserRegistry';
+import { getActivity } from '@/shared/browserCommandHandler';
+
+const isElectron = typeof navigator !== 'undefined' && navigator.userAgent.includes('Electron');
+
+const SETTLE_MS = 800;
+// Hysteresis: suspend only well past the edge, resume just past it, so a card
+// sitting on the boundary never flaps between webview and snapshot.
+const SUSPEND_MARGIN_PX = 320;
+const RESUME_MARGIN_PX = 96;
+const SNAPSHOT_MAX_W = 1024;
+
+interface Viewport {
+  panX: number;
+  panY: number;
+  zoom: number;
+  vpW: number;
+  vpH: number;
+}
+
+function cardIntersectsViewport(card: BrowserCardPosition, vp: Viewport, marginPx: number): boolean {
+  const m = marginPx / vp.zoom;
+  const vx = -vp.panX / vp.zoom - m;
+  const vy = -vp.panY / vp.zoom - m;
+  const vw = vp.vpW / vp.zoom + 2 * m;
+  const vh = vp.vpH / vp.zoom + 2 * m;
+  return card.x < vx + vw && card.x + card.width > vx && card.y < vy + vh && card.y + card.height > vy;
+}
+
+function agentNeedsLive(browserId: string, card: BrowserCardPosition): boolean {
+  if (getActivity(browserId)) return true;
+  const state = store.getState();
+  const glow = state.dashboardLayout.glowingBrowserCards[browserId];
+  if (glow && !glow.fading) return true;
+  const sessions = state.agents.sessions as Record<string, any>;
+  for (const s of Object.values(sessions)) {
+    if (s.browser_id === browserId && (s.status === 'running' || s.status === 'waiting_approval')) return true;
+  }
+  if (card.spawned_by) {
+    const parent = sessions[card.spawned_by];
+    if (parent && (parent.status === 'running' || parent.status === 'waiting_approval')) return true;
+  }
+  return false;
+}
+
+/**
+ * Swaps off-screen, agent-idle webviews for static snapshots (freeing their
+ * renderer processes) and wakes them when panned back into view. Agent-driven
+ * cards are never touched; commands to a suspended card wake it via
+ * browserCommandHandler's awaitWebview.
+ */
+export function useWebviewSuspend(
+  browserCards: Record<string, BrowserCardPosition>,
+  panX: number,
+  panY: number,
+  zoom: number,
+  viewportRef: React.RefObject<HTMLDivElement>,
+) {
+  const dispatch = useAppDispatch();
+  const suspended = useAppSelector((s) => s.dashboardLayout.suspendedBrowserCards);
+  const vpRef = useRef<Viewport>({ panX, panY, zoom, vpW: 1200, vpH: 800 });
+
+  useEffect(() => {
+    if (!isElectron) return;
+    const el = viewportRef.current;
+    vpRef.current = {
+      panX, panY, zoom,
+      vpW: el ? el.clientWidth : 1200,
+      vpH: el ? el.clientHeight : 800,
+    };
+
+    for (const id of Object.keys(suspended)) {
+      const card = browserCards[id];
+      if (card && cardIntersectsViewport(card, vpRef.current, RESUME_MARGIN_PX)) {
+        dispatch(resumeBrowserCard(id));
+      }
+    }
+
+    const timer = setTimeout(async () => {
+      for (const [id, card] of Object.entries(browserCards)) {
+        if (store.getState().dashboardLayout.suspendedBrowserCards[id]) continue;
+        if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
+        if (agentNeedsLive(id, card)) continue;
+        const wv = getWebview(id, card.activeTabId);
+        if (!wv) continue;
+        try {
+          if (wv.isLoading()) continue;
+          const url = wv.getURL();
+          if (!url || url === 'about:blank') continue;
+          const image = await wv.capturePage();
+          if (image.isEmpty()) continue;
+          // The capture await yielded; conditions may have changed under us.
+          if (cardIntersectsViewport(card, vpRef.current, SUSPEND_MARGIN_PX)) continue;
+          if (agentNeedsLive(id, card)) continue;
+          const dataUrl = image.getSize().width > SNAPSHOT_MAX_W
+            ? image.resize({ width: SNAPSHOT_MAX_W, quality: 'good' }).toDataURL()
+            : image.toDataURL();
+          dispatch(suspendBrowserCard({ browserId: id, dataUrl }));
+        } catch {
+          // capture failed mid-teardown or mid-navigation; card just stays live
+        }
+      }
+    }, SETTLE_MS);
+
+    return () => clearTimeout(timer);
+  }, [browserCards, suspended, panX, panY, zoom, viewportRef, dispatch]);
+}

--- a/frontend/src/app/pages/Dashboard/hooks/lifecycle/useDashboardLifecycle.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/lifecycle/useDashboardLifecycle.ts
@@ -81,13 +81,13 @@ export function useDashboardLifecycle({
     // CRITICAL path: these populate the cards the user expects to see
     // on first paint. Don't defer.
     dispatch(fetchSessions({ dashboardId }));
-    dispatch(fetchLayout(dashboardId));
+    dispatch(fetchLayout({ dashboardId }));
     const cleanupBrowserHandler = initBrowserCommandHandler();
     // Global broadcasts (spawned browser cards) skip the replay log, so a
     // socket gap loses them; a reconnect refetch is the only way they return.
     const unsubReconnect = dashboardWs.on('dashboard:reconnected', () => {
       dispatch(fetchSessions({ dashboardId }));
-      dispatch(fetchLayout(dashboardId));
+      dispatch(fetchLayout({ dashboardId, isReconnect: true }));
     });
     // DEFERRABLE: history list (for the search palette) and outputs
     // (for the apps panel) aren't on the first-paint path. Same for the

--- a/frontend/src/app/pages/Settings/sections/models/ApiKeyCard.tsx
+++ b/frontend/src/app/pages/Settings/sections/models/ApiKeyCard.tsx
@@ -22,10 +22,10 @@ export interface ApiKeyConfig {
 }
 
 export const API_KEY_CARDS: ApiKeyConfig[] = [
-  { field: 'anthropic_api_key', label: 'Anthropic', desc: 'Claude Sonnet, Opus, Haiku.', placeholder: 'sk-ant-...', href: 'https://console.anthropic.com/settings/keys' },
-  { field: 'openai_api_key', label: 'OpenAI', desc: 'GPT and o-series reasoning models.', placeholder: 'sk-...', href: 'https://platform.openai.com/api-keys' },
-  { field: 'google_api_key', label: 'Google', desc: 'Gemini Pro and Flash models.', placeholder: 'AIza...', href: 'https://aistudio.google.com/apikey' },
-  { field: 'openrouter_api_key', label: 'OpenRouter', desc: '300+ models from xAI, Meta, DeepSeek, Mistral, Qwen, and more.', placeholder: 'sk-or-...', href: 'https://openrouter.ai/keys' },
+  { field: 'anthropic_api_key', label: 'Anthropic', desc: 'The latest Claude models.', placeholder: 'sk-ant-...', href: 'https://console.anthropic.com/settings/keys' },
+  { field: 'openai_api_key', label: 'OpenAI', desc: 'The latest OpenAI models.', placeholder: 'sk-...', href: 'https://platform.openai.com/api-keys' },
+  { field: 'google_api_key', label: 'Google', desc: 'The latest Gemini models.', placeholder: 'AIza...', href: 'https://aistudio.google.com/apikey' },
+  { field: 'openrouter_api_key', label: 'OpenRouter', desc: 'Hundreds of models from every major provider.', placeholder: 'sk-or-...', href: 'https://openrouter.ai/keys' },
 ];
 
 const ApiKeyCard: React.FC<{

--- a/frontend/src/app/pages/Settings/sections/subscription/OpenSwarmProCard.tsx
+++ b/frontend/src/app/pages/Settings/sections/subscription/OpenSwarmProCard.tsx
@@ -105,7 +105,7 @@ const OpenSwarmProCard: React.FC = () => {
           desc: 'Your subscription ended. Pick a plan to get back in.',
           cta: 'Resubscribe',
           title: 'Resubscribe to OpenSwarm Pro',
-          subtitle: 'Keep using Claude Sonnet, Opus, and Haiku without a Claude account.',
+          subtitle: 'Keep using the latest Claude models without a Claude account.',
           currentPlan: lastPlan,
         };
       }
@@ -119,7 +119,7 @@ const OpenSwarmProCard: React.FC = () => {
         };
       }
       return {
-        desc: 'Claude Sonnet, Opus, and Haiku. No Claude account needed.',
+        desc: 'The latest Claude models. No Claude account needed.',
         cta: 'Subscribe',
         title: 'Choose your plan',
         subtitle: 'One subscription, we handle everything behind the scenes. Cancel anytime.',
@@ -129,22 +129,26 @@ const OpenSwarmProCard: React.FC = () => {
 
     return (
       <>
-        <Box sx={{ p: 1.5, borderRadius: `${c.radius.md}px`, border: `1px solid ${c.border.subtle}` }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box sx={{
+          p: 1.5, borderRadius: `${c.radius.md}px`, border: `1px solid ${c.border.subtle}`,
+          transition: c.transition,
+          '&:hover': { borderColor: c.border.medium, transform: 'translateY(-1px)', boxShadow: c.shadow.sm },
+        }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
               <Box sx={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0, bgcolor: c.border.medium }} />
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.8 }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.7 }}>
                   <Typography sx={{ fontSize: '0.78rem', fontWeight: 600, color: c.text.primary }}>
                     OpenSwarm Pro
                   </Typography>
-                  <Box sx={{ px: 0.7, py: 0.15, borderRadius: 999, bgcolor: `${c.accent.primary}15` }}>
-                    <Typography sx={{ fontSize: '0.6rem', color: c.accent.primary, fontWeight: 600 }}>
+                  <Box sx={{ px: 0.7, py: 0.15, borderRadius: 999, bgcolor: `${c.accent.primary}12` }}>
+                    <Typography sx={{ fontSize: '0.58rem', color: c.accent.primary, fontWeight: 600, letterSpacing: '0.03em' }}>
                       RECOMMENDED
                     </Typography>
                   </Box>
                 </Box>
-                <Typography sx={{ fontSize: '0.65rem', color: c.text.muted }}>
+                <Typography noWrap sx={{ fontSize: '0.65rem', color: c.text.muted }}>
                   {copy.desc}
                 </Typography>
               </Box>

--- a/frontend/src/app/pages/Settings/sections/subscription/SubscriptionCard.tsx
+++ b/frontend/src/app/pages/Settings/sections/subscription/SubscriptionCard.tsx
@@ -9,59 +9,71 @@ import type { SubscriptionProvider } from './subscriptionProviders';
 const SubscriptionCard: React.FC<{ provider: SubscriptionProvider; connected: boolean; onConnect: () => void; onDisconnect: () => void; connecting: boolean; userCode?: string; disconnecting?: boolean }> = ({ provider, connected, onConnect, onDisconnect, connecting, userCode, disconnecting }) => {
   const c = useClaudeTokens();
   const isPreview = (provider as any).preview;
+  const dotColor = connected ? c.status.success : connecting ? c.accent.primary : c.border.medium;
+
   return (
     <Box sx={{
       p: 1.5, borderRadius: `${c.radius.md}px`,
       border: `1px solid ${connected ? c.status.success + '30' : connecting ? c.accent.primary + '30' : c.border.subtle}`,
-      bgcolor: connected ? `${c.status.success}04` : connecting ? `${c.accent.primary}04` : 'transparent',
+      bgcolor: connected ? `${c.status.success}06` : connecting ? `${c.accent.primary}06` : 'transparent',
       opacity: isPreview ? 0.5 : 1,
-      transition: 'all 0.3s ease',
+      transition: c.transition,
+      '&:hover': isPreview ? {} : {
+        borderColor: connected ? c.status.success + '4d' : c.border.medium,
+        transform: 'translateY(-1px)',
+        boxShadow: c.shadow.sm,
+      },
+      // affirm "Connected" at rest, reveal "Disconnect" on hover so the undo never shouts
+      '&:hover .sub-rest': { opacity: 0 },
+      '&:hover .sub-undo': { opacity: 1, pointerEvents: 'auto' },
     }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
           <Box sx={{
-            width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
-            bgcolor: connected ? c.status.success : connecting ? c.accent.primary : c.border.medium,
+            width: 8, height: 8, borderRadius: '50%', flexShrink: 0, bgcolor: dotColor,
             transition: 'background-color 0.3s ease',
             ...(connecting ? {
-              animation: 'pulse-dot 1.5s ease-in-out infinite',
-              '@keyframes pulse-dot': {
-                '0%, 100%': { opacity: 1, transform: 'scale(1)' },
-                '50%': { opacity: 0.4, transform: 'scale(0.8)' },
-              },
+              animation: 'sub-pulse 1.4s ease-in-out infinite',
+              '@keyframes sub-pulse': { '0%, 100%': { opacity: 1 }, '50%': { opacity: 0.35 } },
             } : {}),
           }} />
-          <Box>
+          <Box sx={{ minWidth: 0 }}>
             <Typography sx={{ fontSize: '0.78rem', fontWeight: 600, color: c.text.primary }}>{provider.name}</Typography>
-            <Typography sx={{ fontSize: '0.65rem', color: connecting ? c.accent.primary : c.text.muted, transition: 'color 0.3s ease' }}>
+            <Typography noWrap sx={{ fontSize: '0.65rem', color: connecting ? c.accent.primary : c.text.muted, transition: 'color 0.2s ease' }}>
               {connecting ? 'Waiting for authorization...' : provider.desc}
             </Typography>
           </Box>
         </Box>
+
         {isPreview ? (
-          <Typography sx={{ fontSize: '0.65rem', color: c.text.ghost, fontStyle: 'italic' }}>
+          <Typography sx={{ fontSize: '0.65rem', color: c.text.ghost, fontStyle: 'italic', flexShrink: 0 }}>
             Coming soon
           </Typography>
         ) : connected ? (
           disconnecting ? (
             <CircularProgress size={14} sx={{ color: c.text.ghost }} />
           ) : (
-            <Typography onClick={onDisconnect} sx={{ fontSize: '0.68rem', color: c.text.tertiary, cursor: 'pointer', '&:hover': { color: c.status.error }, transition: 'color 0.2s ease' }}>
-              Disconnect
-            </Typography>
+            <Box sx={{ position: 'relative', flexShrink: 0, minWidth: 72, height: 16 }}>
+              <Typography className="sub-rest" sx={{ position: 'absolute', right: 0, top: 0, fontSize: '0.68rem', fontWeight: 500, color: c.status.success, transition: 'opacity 0.18s ease' }}>
+                Connected
+              </Typography>
+              <Typography className="sub-undo" onClick={onDisconnect} sx={{ position: 'absolute', right: 0, top: 0, fontSize: '0.68rem', color: c.text.tertiary, cursor: 'pointer', opacity: 0, pointerEvents: 'none', transition: 'opacity 0.18s ease', '&:hover': { color: c.status.error } }}>
+                Disconnect
+              </Typography>
+            </Box>
           )
         ) : connecting && userCode ? (
-          <Box sx={{ textAlign: 'right' }}>
+          <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
             <Typography sx={{ fontSize: '0.68rem', color: c.text.muted }}>Enter code:</Typography>
-            <Typography sx={{ fontSize: '0.85rem', fontWeight: 700, color: c.accent.primary, fontFamily: 'monospace', letterSpacing: '0.1em' }}>{userCode}</Typography>
+            <Typography sx={{ fontSize: '0.85rem', fontWeight: 700, color: c.accent.primary, fontFamily: c.font.mono, letterSpacing: '0.1em' }}>{userCode}</Typography>
           </Box>
         ) : connecting ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.8 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.8, flexShrink: 0 }}>
             <CircularProgress size={14} sx={{ color: c.accent.primary }} />
             <Typography sx={{ fontSize: '0.68rem', color: c.accent.primary }}>Connecting...</Typography>
           </Box>
         ) : (
-          <Button onClick={onConnect} variant="outlined" size="small" sx={{ textTransform: 'none', fontSize: '0.7rem', color: c.text.primary, borderColor: c.border.medium, minWidth: 70, '&:hover': { borderColor: c.accent.primary }, transition: 'all 0.2s ease' }}>
+          <Button onClick={onConnect} variant="outlined" size="small" sx={{ textTransform: 'none', fontSize: '0.7rem', fontWeight: 600, color: c.text.primary, borderColor: c.border.medium, borderRadius: `${c.radius.sm}px`, minWidth: 72, flexShrink: 0, '&:hover': { borderColor: c.accent.primary, bgcolor: `${c.accent.primary}0a` }, transition: 'all 0.2s ease' }}>
             Connect
           </Button>
         )}

--- a/frontend/src/app/pages/Settings/sections/subscription/subscriptionProviders.ts
+++ b/frontend/src/app/pages/Settings/sections/subscription/subscriptionProviders.ts
@@ -1,9 +1,9 @@
 // Descs stay version-free on purpose; model versions churn monthly and stale tags read as abandonware.
 export const SUBSCRIPTION_PROVIDERS = [
-  { id: 'claude', name: 'Claude Pro / Max', desc: 'The latest Sonnet, Opus, and Haiku models', color: '#E8927A', preview: false },
+  { id: 'claude', name: 'Claude Pro / Max', desc: 'The latest Claude models', color: '#E8927A', preview: false },
   // "Gemini" routes through Antigravity OAuth (same Google sign-in, higher quota than Gemini CLI's free tier).
-  { id: 'antigravity', name: 'Gemini Advanced', desc: 'The latest Gemini Pro and Flash models', color: '#4285F4', preview: false },
-  { id: 'codex', name: 'ChatGPT Plus / Pro', desc: 'The latest GPT and Codex models', color: '#74AA9C', preview: false },
+  { id: 'antigravity', name: 'Gemini Advanced', desc: 'The latest Gemini models', color: '#4285F4', preview: false },
+  { id: 'codex', name: 'ChatGPT Plus / Pro', desc: 'The latest ChatGPT models', color: '#74AA9C', preview: false },
 ];
 
 export type SubscriptionProvider = typeof SUBSCRIPTION_PROVIDERS[0];

--- a/frontend/src/app/pages/Views/ViewEditor.tsx
+++ b/frontend/src/app/pages/Views/ViewEditor.tsx
@@ -29,7 +29,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Collapse from '@mui/material/Collapse';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
-import { createDraftSession, removeDraftSession, fetchSession } from '@/shared/state/agentsSlice';
+import { createDraftSession, removeDraftSession } from '@/shared/state/agentsSlice';
 import { createOutput, updateOutput, fetchOutputs, Output, SERVE_BASE } from '@/shared/state/outputsSlice';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
 import AgentChat from '../AgentChat/AgentChat';
@@ -410,6 +410,13 @@ const ViewEditor: React.FC<Props> = ({ output }) => {
     (async () => {
       // Reattach: Output has an existing session + workspace; skip seeding/draft so we don't clobber agent state.
       if (output?.session_id && output?.workspace_id) {
+        // Mount the chat NOW so the cached conversation renders instantly
+        // (AgentChat's own hydrate + WS catch up on what we missed); holding it
+        // behind the verification round-trips blanked the chat for seconds on
+        // every reopen. The stale-id guard below still runs, just in the
+        // background, and swaps in a fresh draft on the rare 404.
+        setInitialDraftId(output.session_id);
+
         let resolvedWorkspacePath: string | null = null;
         try {
           const res = await fetch(`${WORKSPACE_API}/${output.workspace_id}`);
@@ -429,14 +436,9 @@ const ViewEditor: React.FC<Props> = ({ output }) => {
           sessionStillExists = sr.ok;
         } catch { /* network blip, treat as missing */ }
 
-        if (sessionStillExists) {
-          // Catch up on anything the agent did while we were on another tab.
-          dispatch(fetchSession(output.session_id));
-          setInitialDraftId(output.session_id);
-          return;
-        }
+        if (sessionStillExists) return;
 
-        // Stale link: clear it so future opens skip the 404 round-trip, then fall through.
+        // Stale link: clear it so future opens skip the 404 round-trip, then swap to a fresh draft.
         if (output.id) {
           try {
             await dispatch(updateOutput({ id: output.id, session_id: null })).unwrap();

--- a/frontend/src/app/pages/Views/ViewEditor.tsx
+++ b/frontend/src/app/pages/Views/ViewEditor.tsx
@@ -29,7 +29,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import Collapse from '@mui/material/Collapse';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
-import { createDraftSession, removeDraftSession } from '@/shared/state/agentsSlice';
+import { createDraftSession, removeDraftSession, fetchSession } from '@/shared/state/agentsSlice';
 import { createOutput, updateOutput, fetchOutputs, Output, SERVE_BASE } from '@/shared/state/outputsSlice';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
 import AgentChat from '../AgentChat/AgentChat';
@@ -410,11 +410,13 @@ const ViewEditor: React.FC<Props> = ({ output }) => {
     (async () => {
       // Reattach: Output has an existing session + workspace; skip seeding/draft so we don't clobber agent state.
       if (output?.session_id && output?.workspace_id) {
-        // Mount the chat NOW so the cached conversation renders instantly
-        // (AgentChat's own hydrate + WS catch up on what we missed); holding it
+        // Mount the chat NOW so a warm conversation renders instantly; holding it
         // behind the verification round-trips blanked the chat for seconds on
-        // every reopen. The stale-id guard below still runs, just in the
-        // background, and swaps in a fresh draft on the rare 404.
+        // every reopen. The fetch is load-bearing on cold opens: effectiveSessionId
+        // resolves only once the session is IN the store, and AgentChat (the other
+        // hydrator) can't mount until then. The stale-id guard below still runs in
+        // the background and swaps in a fresh draft on the rare 404.
+        dispatch(fetchSession(output.session_id));
         setInitialDraftId(output.session_id);
 
         let resolvedWorkspacePath: string | null = null;

--- a/frontend/src/app/pages/Views/ViewPreview.tsx
+++ b/frontend/src/app/pages/Views/ViewPreview.tsx
@@ -195,6 +195,13 @@ const ViewPreview = forwardRef<ViewPreviewHandle, Props>(({
       const wv = webviewRef.current;
       // Only the webview path is reliably snapshottable; iframe/dev or a hidden window (about:blank) returns null.
       if (!useWebview || !wv || windowHidden || typeof wv.capturePage !== 'function') return null;
+      // Never snapshot a guest that's detaching, crashed, or mid-navigation: capturePage on a
+      // WebContents being torn down can segfault the main process (the whole-app quit on fast app-switching).
+      try {
+        if (wv.isConnected === false) return null;
+        if (typeof wv.isCrashed === 'function' && wv.isCrashed()) return null;
+        if (typeof wv.isLoading === 'function' && wv.isLoading()) return null;
+      } catch { return null; }
       try {
         const img = await wv.capturePage();
         if (!img) return null;

--- a/frontend/src/shared/browserCommandHandler.ts
+++ b/frontend/src/shared/browserCommandHandler.ts
@@ -1,4 +1,6 @@
 import { getWebview, type BrowserWebview } from './browserRegistry';
+import { store } from './state/store';
+import { resumeBrowserCard } from './state/dashboardLayoutSlice';
 import { dashboardWs } from './ws/WebSocketManager';
 import { resolveInput } from './resolveUrl';
 import { rankAndCapInteractives, type RankItem } from './interactiveRanking';
@@ -1345,11 +1347,25 @@ async function handleEvaluate(wv: BrowserWebview, params: Record<string, any>): 
 // window for (re)registration before giving up, so the error stays a real
 // "card is gone" signal rather than a transient race.
 async function awaitWebview(browserId: string, tabId?: string): Promise<BrowserWebview | undefined> {
-  const deadline = Date.now() + 2000;
+  // A suspended (snapshot-swapped) card has no webview at all; wake it and
+  // wait out the remount + page reload before the command touches it.
+  const wasSuspended = !!store.getState().dashboardLayout.suspendedBrowserCards[browserId];
+  if (wasSuspended) store.dispatch(resumeBrowserCard(browserId));
+  const deadline = Date.now() + (wasSuspended ? 12000 : 2000);
   let wv = getWebview(browserId, tabId);
   while (!wv && Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, 100));
     wv = getWebview(browserId, tabId);
+  }
+  if (wasSuspended && wv) {
+    while (Date.now() < deadline) {
+      try {
+        if (!wv.isLoading() && wv.getURL() !== 'about:blank') break;
+      } catch {
+        // mid-mount hiccup; keep waiting
+      }
+      await new Promise((r) => setTimeout(r, 150));
+    }
   }
   return wv;
 }

--- a/frontend/src/shared/hooks/useDeepLink.ts
+++ b/frontend/src/shared/hooks/useDeepLink.ts
@@ -46,8 +46,9 @@ export function useDeepLink(): void {
             })
             .catch((err) => {
               console.error('[deep-link] Sign-in activation failed:', err);
+              // unwrap() rejects with a SerializedError object; String() of it is "[object Object]".
               report('signin', 'activation_failed', {
-                message: String(err).slice(0, 120),
+                message: String(err?.message ?? err).slice(0, 120),
               });
             });
           return;
@@ -73,7 +74,7 @@ export function useDeepLink(): void {
           .catch((err) => {
             console.error('[deep-link] Activation failed:', err);
             report('subscription', 'activation_failed', {
-              message: String(err).slice(0, 120),
+              message: String(err?.message ?? err).slice(0, 120),
             });
           });
       } catch (e) {

--- a/frontend/src/shared/serviceClient.ts
+++ b/frontend/src/shared/serviceClient.ts
@@ -41,11 +41,17 @@ function _flush(): void {
   const batch = _queue.splice(0);
   // Ship whole queue in one POST; /service/submit accepts a single object or array.
   const body = JSON.stringify(batch.length === 1 ? batch[0] : batch);
+  // keepalive lets the request outlive a closing window, so the last batch isn't eaten on quit.
   fetch(`${API_BASE}/service/submit`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body,
+    keepalive: true,
   }).catch(() => {});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', () => _flush());
 }
 
 export function sync(data: Record<string, unknown> = {}, opts: { immediate?: boolean } = {}): void {

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -680,6 +680,7 @@ const agentsSlice = createSlice({
           (m) => m.client_message_id === incoming.client_message_id && m.optimistic_status === 'pending',
         );
         if (optIdx >= 0) {
+          console.warn(`[ux-trace] ws-echo-merge sid=${action.payload.sessionId.slice(0, 8)} cmid=${incoming.client_message_id?.slice(-6)}`);
           session.messages[optIdx] = { ...incoming, optimistic_status: undefined };
           return;
         }
@@ -708,6 +709,7 @@ const agentsSlice = createSlice({
     ) {
       const { sessionId, clientMessageId, prompt, contextPaths, forcedTools, attachedSkills, images, hidden } = action.payload;
       const session = state.sessions[sessionId];
+      console.warn(`[ux-trace] optimistic-add sid=${sessionId.slice(0, 8)} cmid=${clientMessageId.slice(-6)} sessionInStore=${!!session} hidden=${!!hidden} status=${session?.status}`);
       if (!session) return;
       // Hidden messages (e.g. internal continuation prompts) skip the optimistic bubble.
       if (hidden) return;
@@ -1273,11 +1275,19 @@ const agentsSlice = createSlice({
             !incomingIds.has(m.id) &&
             !(m.client_message_id && incomingClientIds.has(m.client_message_id)),
         );
+        // Place survivors by timestamp, not blindly at the end: when the snapshot
+        // already carries the agent's reply, appending the just-sent user bubble
+        // rendered the OUTPUT above the INPUT. Insert before the first incoming
+        // message that is newer.
+        const mergedMessages = surviving.length ? [...incomingMsgs] : incomingMsgs;
+        for (const m of surviving) {
+          const at = mergedMessages.findIndex((x) => (x.timestamp || '') > (m.timestamp || ''));
+          if (at === -1) mergedMessages.push(m);
+          else mergedMessages.splice(at, 0, m);
+        }
         state.sessions[session.id] = {
           ...session,
-          messages: surviving.length
-            ? [...incomingMsgs, ...surviving]
-            : incomingMsgs,
+          messages: mergedMessages,
           pending_approvals: session.pending_approvals ?? existing?.pending_approvals ?? [],
           tool_group_meta: session.tool_group_meta ?? existing?.tool_group_meta ?? {},
           // mcp_suggestions live in client state only (the backend never

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -1252,7 +1252,12 @@ const agentsSlice = createSlice({
         // any local message the snapshot lacks; on a settled session the snapshot
         // is authoritative (so a server-side delete isn't resurrected).
         const incomingMsgs = session.messages ?? [];
-        const liveStatus = session.status === 'running' || session.status === 'waiting_approval';
+        // Live by EITHER side's account: a send on a completed chat flips local
+        // status to running while the racing snapshot still says completed and
+        // lacks the new turn; trusting only the snapshot wiped the user bubble
+        // until the run finished.
+        const isLive = (s?: string) => s === 'running' || s === 'waiting_approval';
+        const liveStatus = isLive(session.status) || isLive(existing?.status);
         const incomingClientIds = new Set(
           incomingMsgs.map((m) => m.client_message_id).filter(Boolean),
         );

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -1017,9 +1017,13 @@ const agentsSlice = createSlice({
         const fetchedIds = new Set(action.payload.map((s) => s.id));
         const activeStatuses = new Set(['running', 'waiting_approval']);
 
-        // Strip stale fetched sessions; keep other dashboards, drafts, tracked, and active sessions.
+        // Strip sessions the server no longer has, but a dashboard's list is only
+        // authoritative for ITS OWN sessions: hopping dashboards must not eat the
+        // finished chat you were just reading (it looked like wiped history).
+        const fetchedDashboardId = action.meta.arg?.dashboardId;
         for (const [id, existing] of Object.entries(state.sessions)) {
           if (fetchedIds.has(id)) continue;
+          if (fetchedDashboardId && existing.dashboard_id !== fetchedDashboardId) continue;
           if (existing.status === 'draft') continue;
           if (state.trackedNotificationIds.includes(id)) continue;
           if (activeStatuses.has(existing.status)) continue;

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -1262,13 +1262,17 @@ const agentsSlice = createSlice({
           incomingMsgs.map((m) => m.client_message_id).filter(Boolean),
         );
         const incomingIds = new Set(incomingMsgs.map((m) => m.id));
-        const surviving = liveStatus
-          ? (existing?.messages ?? []).filter(
-              (m) =>
-                !incomingIds.has(m.id) &&
-                !(m.client_message_id && incomingClientIds.has(m.client_message_id)),
-            )
-          : [];
+        // An optimistic message (no WS echo yet) is preserved even when both sides
+        // read settled: right after a send on a completed chat, NEITHER status has
+        // flipped to running, and the racing snapshot wiped the just-typed bubble
+        // for seconds. It can't be a deleted-message resurrection; the server has
+        // never confirmed it existed.
+        const surviving = (existing?.messages ?? []).filter(
+          (m) =>
+            (liveStatus || m.optimistic_status) &&
+            !incomingIds.has(m.id) &&
+            !(m.client_message_id && incomingClientIds.has(m.client_message_id)),
+        );
         state.sessions[session.id] = {
           ...session,
           messages: surviving.length

--- a/frontend/src/shared/state/agentsSlice.ts
+++ b/frontend/src/shared/state/agentsSlice.ts
@@ -680,7 +680,6 @@ const agentsSlice = createSlice({
           (m) => m.client_message_id === incoming.client_message_id && m.optimistic_status === 'pending',
         );
         if (optIdx >= 0) {
-          console.warn(`[ux-trace] ws-echo-merge sid=${action.payload.sessionId.slice(0, 8)} cmid=${incoming.client_message_id?.slice(-6)}`);
           session.messages[optIdx] = { ...incoming, optimistic_status: undefined };
           return;
         }
@@ -709,7 +708,6 @@ const agentsSlice = createSlice({
     ) {
       const { sessionId, clientMessageId, prompt, contextPaths, forcedTools, attachedSkills, images, hidden } = action.payload;
       const session = state.sessions[sessionId];
-      console.warn(`[ux-trace] optimistic-add sid=${sessionId.slice(0, 8)} cmid=${clientMessageId.slice(-6)} sessionInStore=${!!session} hidden=${!!hidden} status=${session?.status}`);
       if (!session) return;
       // Hidden messages (e.g. internal continuation prompts) skip the optimistic bubble.
       if (hidden) return;

--- a/frontend/src/shared/state/dashboardLayoutSlice.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.ts
@@ -980,6 +980,13 @@ const dashboardLayoutSlice = createSlice({
           state.viewCards = action.payload.viewCards;
           state.browserCards = action.payload.browserCards;
           state.notes = action.payload.notes || {};
+          // Cards boot parked (no guest process, title placeholder); the suspend
+          // hook wakes viewport-sized and agent-driven ones on its first pass.
+          // Beats mounting 100 webviews just to suspend 92 of them.
+          state.suspendedBrowserCards = {};
+          for (const id of Object.keys(action.payload.browserCards)) {
+            state.suspendedBrowserCards[id] = { dataUrl: '', capturedAt: 0 };
+          }
         } else {
           const occupied = collectOccupiedRects(state, action.payload.expandedSessionIds);
           addMissingCards(state.cards, action.payload.cards, occupied);

--- a/frontend/src/shared/state/dashboardLayoutSlice.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.ts
@@ -92,6 +92,8 @@ export interface DashboardLayoutState {
   /** Transient: new browser card id; Dashboard pans/zooms to it then clears via clearPendingFocusBrowserId. */
   pendingFocusBrowserId: string | null;
   pendingFocusNoteId: string | null;
+  /** Transient: snapshot stand-ins for off-screen webviews; never rides the layout PUT. */
+  suspendedBrowserCards: Record<string, { dataUrl: string; capturedAt: number }>;
 }
 
 const initialState: DashboardLayoutState = {
@@ -108,6 +110,7 @@ const initialState: DashboardLayoutState = {
   initialized: false,
   pendingFocusBrowserId: null,
   pendingFocusNoteId: null,
+  suspendedBrowserCards: {},
 };
 
 interface LayoutPayload {
@@ -629,6 +632,19 @@ const dashboardLayoutSlice = createSlice({
 
     removeBrowserCard(state, action: PayloadAction<string>) {
       delete state.browserCards[action.payload];
+      delete state.suspendedBrowserCards[action.payload];
+    },
+
+    suspendBrowserCard(state, action: PayloadAction<{ browserId: string; dataUrl: string }>) {
+      if (!state.browserCards[action.payload.browserId]) return;
+      state.suspendedBrowserCards[action.payload.browserId] = {
+        dataUrl: action.payload.dataUrl,
+        capturedAt: Date.now(),
+      };
+    },
+
+    resumeBrowserCard(state, action: PayloadAction<string>) {
+      delete state.suspendedBrowserCards[action.payload];
     },
 
     pasteBrowserCard(
@@ -707,6 +723,7 @@ const dashboardLayoutSlice = createSlice({
       card.tabs.splice(idx, 1);
       if (card.tabs.length === 0) {
         delete state.browserCards[action.payload.browserId];
+        delete state.suspendedBrowserCards[action.payload.browserId];
         return;
       }
       if (card.activeTabId === action.payload.tabId) {
@@ -939,6 +956,7 @@ const dashboardLayoutSlice = createSlice({
       state.nextZOrder = 1;
       state.initialized = false;
       state.pendingFocusNoteId = null;
+      state.suspendedBrowserCards = {};
     },
 
   },
@@ -1032,6 +1050,8 @@ export const {
   setBrowserCardPosition,
   setBrowserCardSize,
   removeBrowserCard,
+  suspendBrowserCard,
+  resumeBrowserCard,
   pasteBrowserCard,
   updateBrowserCardUrl,
   addBrowserTab,

--- a/frontend/src/shared/state/dashboardLayoutSlice.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.ts
@@ -124,7 +124,11 @@ function generateTabId(): string {
 
 export const fetchLayout = createAsyncThunk(
   'dashboardLayout/fetch',
-  async (dashboardId: string) => {
+  // isReconnect distinguishes a socket-reconnect recovery refetch (merge, keep
+  // live positions) from a fresh mount/switch load (replace, snapshot is the
+  // user's saved layout). Passed explicitly, not inferred from state, so a
+  // stale in-flight fetch from a previous dashboard can't be misread as a merge.
+  async ({ dashboardId }: { dashboardId: string; isReconnect?: boolean }) => {
     const res = await fetch(`${DASHBOARDS_API}/${dashboardId}`);
     const data = await res.json();
     const layout = data.layout ?? {};
@@ -294,6 +298,27 @@ export function findOpenSpotNear(
   // Pathological , full canvas occupied near anchor. Fall back to the
   // global first-empty scan so we never return an overlap.
   return findOpenGridCell(occupiedRects, newW, newH);
+}
+
+// Reconnect-refetch merge: ADD only the cards the snapshot carries that the
+// client is missing (e.g. a spawned browser whose broadcast was lost in a
+// socket gap), collision-resolving each against the live layout so a recovered
+// card can't land on a card already on canvas, and NEVER touch a card the
+// client already has (that's exactly what preserves its live, collision-placed
+// position). The shared `occupied` list carries placements forward so two
+// recovered cards in the same pass also avoid each other.
+function addMissingCards<T extends { x: number; y: number; width: number; height: number }>(
+  live: Record<string, T>,
+  incoming: Record<string, T>,
+  occupied: Rect[],
+): void {
+  for (const id of Object.keys(incoming)) {
+    if (live[id]) continue;
+    const card = incoming[id];
+    const pos = findOpenSpotNear(card.x, card.y, occupied, card.width, card.height);
+    live[id] = { ...card, x: pos.x, y: pos.y };
+    occupied.push({ x: pos.x, y: pos.y, w: card.width, h: card.height });
+  }
 }
 
 const dashboardLayoutSlice = createSlice({
@@ -924,11 +949,26 @@ const dashboardLayoutSlice = createSlice({
       })
       .addCase(fetchLayout.fulfilled, (state, action) => {
         state.loading = false;
+        // A fresh mount/switch load replaces (the snapshot is the user's saved
+        // layout, authoritative). A reconnect refetch (useDashboardLifecycle
+        // line ~90) recovers cards lost in a socket gap and must MERGE, blind-
+        // replacing there clobbered the live, collision-placed positions of
+        // cards already on canvas (the overlap / vanish under load while many
+        // browsers spawn). The caller says which; never inferred from state.
+        const isReconnectRefetch = action.meta.arg.isReconnect === true;
         state.initialized = true;
-        state.cards = action.payload.cards;
-        state.viewCards = action.payload.viewCards;
-        state.browserCards = action.payload.browserCards;
-        state.notes = action.payload.notes || {};
+        if (!isReconnectRefetch) {
+          state.cards = action.payload.cards;
+          state.viewCards = action.payload.viewCards;
+          state.browserCards = action.payload.browserCards;
+          state.notes = action.payload.notes || {};
+        } else {
+          const occupied = collectOccupiedRects(state, action.payload.expandedSessionIds);
+          addMissingCards(state.cards, action.payload.cards, occupied);
+          addMissingCards(state.viewCards, action.payload.viewCards, occupied);
+          addMissingCards(state.browserCards, action.payload.browserCards, occupied);
+          addMissingCards(state.notes, action.payload.notes || {}, occupied);
+        }
         state.persistedExpandedSessionIds = action.payload.expandedSessionIds;
 
         let maxZ = 0;

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -812,6 +812,7 @@ class WebSocketManager {
   }
 
   stopAgent(sessionId: string) {
+    console.warn(`[ux-trace] STOP-SENT sid=${sessionId.slice(0, 8)}\n${new Error().stack}`);
     this.send('agent:stop', { session_id: sessionId });
   }
 
@@ -854,6 +855,35 @@ const _sessionLastSeq: Map<string, number> = new Map();
 
 export function createSessionWs(sessionId: string): WebSocketManager {
   return new WebSocketManager(`${WS_BASE}/ws/agents/${sessionId}`, { sessionId });
+}
+
+// One backgrounded session socket, kept alive across a hop so an active agent's
+// stream doesn't pay a reconnect+resume handshake on reopen (the "Locking-in"
+// lag). Bounded to ONE: opening any other chat tears the previous one down, so
+// at most a single detached socket lingers, still pumping events into Redux.
+let _backgroundedSessionWs: { sessionId: string; ws: WebSocketManager } | null = null;
+
+export function acquireSessionWs(sessionId: string): WebSocketManager {
+  if (_backgroundedSessionWs?.sessionId === sessionId) {
+    const ws = _backgroundedSessionWs.ws;
+    _backgroundedSessionWs = null;
+    return ws;
+  }
+  return new WebSocketManager(`${WS_BASE}/ws/agents/${sessionId}`, { sessionId });
+}
+
+export function releaseSessionWs(sessionId: string, ws: WebSocketManager, keepAlive: boolean): void {
+  // Never keep more than one detached socket around.
+  if (_backgroundedSessionWs && _backgroundedSessionWs.sessionId !== sessionId) {
+    _backgroundedSessionWs.ws.disconnect();
+    _backgroundedSessionWs = null;
+  }
+  if (keepAlive) {
+    _backgroundedSessionWs = { sessionId, ws };
+  } else {
+    ws.disconnect();
+    if (_backgroundedSessionWs?.sessionId === sessionId) _backgroundedSessionWs = null;
+  }
 }
 
 export default WebSocketManager;

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -22,7 +22,7 @@ import {
   setTurnLabel,
   clearTurnLabel,
 } from '../state/agentsSlice';
-import { streamStart, streamDelta, streamEnd } from '../state/streamingSlice';
+import { streamStart, streamDelta, streamEnd, clearStreamingForSession } from '../state/streamingSlice';
 import { addBrowserCardFromBackend, removeBrowserCard, setBrowserCardPosition, setGlowingBrowserCards, GRID_GAP } from '../state/dashboardLayoutSlice';
 import { upsertOutput } from '../state/outputsSlice';
 import { getAuthToken } from '../config';
@@ -493,6 +493,7 @@ class WebSocketManager {
           // before its own aux call lands.
           if (session_id && (data.status === 'completed' || data.status === 'error' || data.status === 'stopped')) {
             store.dispatch(clearTurnLabel(session_id));
+            store.dispatch(clearStreamingForSession(session_id));
           }
         }
         // Clean spawned browser cards when the PARENT finishes, never per

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -237,6 +237,13 @@ class WebSocketManager {
     this.ws.onmessage = (event) => {
       try {
         const msg: WSEvent = JSON.parse(event.data);
+        // Pong bypasses the rAF coalescer: rAF stalls when the window gets no
+        // frames (minimized, display asleep) while ping timers keep firing, so
+        // a buffered pong read as silence and a healthy socket got killed.
+        if (msg.event === 'server:pong') {
+          this.clearPongTimeout();
+          return;
+        }
         // Buffer incoming messages and flush them per animation frame
         // in a single React batch. With N concurrent agents/browsers
         // streaming, each WS instance used to trigger its own React

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -812,7 +812,6 @@ class WebSocketManager {
   }
 
   stopAgent(sessionId: string) {
-    console.warn(`[ux-trace] STOP-SENT sid=${sessionId.slice(0, 8)}\n${new Error().stack}`);
     this.send('agent:stop', { session_id: sessionId });
   }
 


### PR DESCRIPTION
Virtualizes the chat transcript so long, tool-heavy chats and very large messages stay fast and memory-bounded (previously the entire transcript and every oversized message's full markdown mounted at once). It adds bidirectional windowing —  only a pixel-bounded buffer of items around the viewport stays mounted, with items beyond it unmounting behind measured-height spacers and hysteresis to prevent edge oscillation — plus oversized-message virtualization, where large messages render full in view and a height-reserved placeholder off-screen, splitting into fixed blocks   (WindowedMarkdown) so only blocks near the viewport ever parse/mount. It also fixes the surrounding scroll/layout: a bottom-anchored transcript (no whitespace below the last message), stable assistant-bubble width for virtualized messages, scrollbar-gutter: stable, a min-height scrollbar thumb, and synchronous visibility checks to avoid   placeholder→content flashes. Estimates are fallbacks only  (replaced by real measured heights once on screen), so there's no behavior change for normal-length chats; tsc and the production build are clean.