### PR TITLE
fix: stop dashboard select-mode from leaking onto other pages

### DIFF
--- a/frontend/src/app/components/editor/useDomElementSelector.ts
+++ b/frontend/src/app/components/editor/useDomElementSelector.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { SelectedElement, useElementSelection } from './ElementSelectionContext';
+import { useDashboardActive } from '@/shared/hooks/useDashboardActive';
 
 const SELECT_ATTR = 'data-select-type';
 const SELECT_ID_ATTR = 'data-select-id';
@@ -110,6 +111,9 @@ export interface DomSelectorState {
 
 export function useDomElementSelector(): DomSelectorState {
   const ctx = useElementSelection();
+  // Dashboard stays mounted (visibility-hidden) on other routes; gate listeners
+  // so its select mode can't fire over the App Builder or other pages.
+  const active = useDashboardActive();
   const [overlay, setOverlay] = useState<OverlayState>(EMPTY_OVERLAY);
   const [dragRect, setDragRect] = useState<DragRect>(EMPTY_DRAG);
   const [dragPreview, setDragPreview] = useState<DragPreviewElement[]>([]);
@@ -330,7 +334,7 @@ export function useDomElementSelector(): DomSelectorState {
   }, [ctx]);
 
   useEffect(() => {
-    if (!ctx?.selectMode) {
+    if (!ctx?.selectMode || !active) {
       setOverlay(EMPTY_OVERLAY);
       setDragRect(EMPTY_DRAG);
       setDragPreview([]);
@@ -369,7 +373,7 @@ export function useDomElementSelector(): DomSelectorState {
       // Defensive: if select mode flips off mid-drag, drop the class so webviews regain interactivity.
       document.body.classList.remove('dashboard-marquee-active');
     };
-  }, [ctx?.selectMode, handleMouseMove, handleMouseDown, handleMouseUp, handleClick]);
+  }, [ctx?.selectMode, active, handleMouseMove, handleMouseDown, handleMouseUp, handleClick]);
 
   return { overlay, dragRect, dragPreview };
 }

--- a/frontend/src/app/components/editor/useDomElementSelector.ts
+++ b/frontend/src/app/components/editor/useDomElementSelector.ts
@@ -111,8 +111,6 @@ export interface DomSelectorState {
 
 export function useDomElementSelector(): DomSelectorState {
   const ctx = useElementSelection();
-  // Dashboard stays mounted (visibility-hidden) on other routes; gate listeners
-  // so its select mode can't fire over the App Builder or other pages.
   const active = useDashboardActive();
   const [overlay, setOverlay] = useState<OverlayState>(EMPTY_OVERLAY);
   const [dragRect, setDragRect] = useState<DragRect>(EMPTY_DRAG);

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -9,8 +9,6 @@ import DashboardCanvas from './canvas/DashboardCanvas';
 const DashboardSelectionOverlay: React.FC = () => {
   const active = useDashboardActive();
   const { overlay, dragRect, dragPreview } = useDomElementSelector();
-  // Selection state stays in context so it restores on return; we just stop
-  // portaling highlights over whatever route is currently on top.
   if (!active) return null;
   return <SelectionOverlay overlay={overlay} dragRect={dragRect} dragPreview={dragPreview} />;
 };

--- a/frontend/src/app/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/app/pages/Dashboard/Dashboard.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import SelectionOverlay from '@/app/components/editor/SelectionOverlay';
 import { ElementSelectionProvider } from '@/app/components/editor/ElementSelectionContext';
 import { useDomElementSelector } from '@/app/components/editor/useDomElementSelector';
+import { useDashboardActive } from '@/shared/hooks/useDashboardActive';
 import { useDashboardController } from './hooks/state/useDashboardController';
 import DashboardCanvas from './canvas/DashboardCanvas';
 
 const DashboardSelectionOverlay: React.FC = () => {
+  const active = useDashboardActive();
   const { overlay, dragRect, dragPreview } = useDomElementSelector();
+  // Selection state stays in context so it restores on return; we just stop
+  // portaling highlights over whatever route is currently on top.
+  if (!active) return null;
   return <SelectionOverlay overlay={overlay} dragRect={dragRect} dragPreview={dragPreview} />;
 };
 


### PR DESCRIPTION
## Summary
- Dashboard is mounted once and kept behind every other route via DashboardHost (visibility-hidden), but its portal-rendered SelectionOverlay and global mouse listeners kept firing on top of the App Builder.
- Gate DashboardSelectionOverlay's render and useDomElementSelector's listener effect on useDashboardActive, so highlights and click handling pause when Dashboard is hidden.
- ElementSelectionContext is untouched, so selectMode and selected elements survive navigation and restore on return.

## Test plan
- [x] Toggle select mode in an agent chat, select a card, navigate to /apps — no highlights, hover borders, or drag rectangles appear over the Apps page.
- [x] Navigate back to the dashboard — prior selections and select-mode toggle are restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)