### PR TITLE
browser-card: fix top edge / corner resize, stop unintended drag + webview focus

### DIFF
--- a/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
@@ -1374,7 +1374,7 @@ const BrowserCard: React.FC<Props> = ({
             position: 'absolute',
             cursor: CURSOR_MAP[dir],
             opacity: 0,
-            zIndex: 10,
+            zIndex: 20,
             ...sx,
           }}
         />


### PR DESCRIPTION
## Summary
- The browser card on the dashboard could not be resized from the top edge, top-left corner, or top-right corner. Worse, dragging there moved the whole card and auto-focused the underlying `<webview>`.
- Root cause: resize handles render with `zIndex: 10`, but the card's tab bar sits above the top edge at `zIndex: 16` and owns its own `onPointerDown` (the card drag handler). The handles' outside 3px is also clipped by the card's `overflow: hidden`, so the only hittable 3px of the n/nw/ne handles sat under the tab bar and lost the z-index race.
- Fix: bump resize-handle `zIndex` from `10` -> `20` in `frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx`. The handles' existing `e.stopPropagation()` keeps the tab bar's drag handler from firing once the handle is the real hit target. All 8 handles are already defined correctly and the resize math already handles the n/nw/ne directions (it adjusts both `y` and `height`).

## Test plan
- [ ] `bash run.sh`, open a BrowserCard on the dashboard, point its webview at a page with an input (e.g. `https://example.com`).
- [ ] Hover the top edge -> cursor is `ns-resize`. Drag down -> card shrinks from the top; bottom stays put; webview does NOT focus.
- [ ] Hover top-left corner -> `nwse-resize`. Drag -> diagonal resize from the top-left.
- [ ] Hover top-right corner -> `nesw-resize`. Drag -> diagonal resize from the top-right.
- [ ] Regression: bottom edge, bottom-left, bottom-right, left, right all still resize.
- [ ] Regression: dragging the middle of the tab bar still moves the whole card.
- [ ] Regression: clicking a tab and a tab's close icon still works (close icons sit well below the 3px resize strip).
- [ ] Regression: webview only focuses when you click into its body, not when grabbing top edges/corners.