### PR TITLE
[aidan] fix: stop browser cards from leaking across dashboards

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openswarm",
-  "version": "1.1.70",
+  "version": "1.2.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openswarm",
-      "version": "1.1.70",
+      "version": "1.2.77",
       "hasInstallScript": true,
       "dependencies": {
         "electron-updater": "6.8.3",
@@ -567,6 +567,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1434,6 +1435,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -1582,6 +1584,7 @@
       "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -2885,6 +2888,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,6 +83,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1963,6 +1964,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2006,6 +2008,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2241,6 +2244,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz",
       "integrity": "sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.10",
@@ -3373,6 +3377,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3769,6 +3774,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3808,6 +3814,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4136,6 +4143,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8174,6 +8182,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8230,6 +8239,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8448,6 +8458,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8460,6 +8471,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8506,6 +8518,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8644,7 +8657,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8956,6 +8970,7 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -10059,6 +10074,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10107,6 +10123,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/frontend/src/app/pages/Dashboard/hooks/state/useDashboardSelectors.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/state/useDashboardSelectors.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useAppSelector } from '@/shared/hooks';
 
 // All of the dashboard's Redux reads in one place. Keeps Dashboard.tsx a
@@ -10,7 +11,19 @@ export function useDashboardSelectors(dashboardId: string) {
   const expandedSessionIds = useAppSelector((state) => state.agents.expandedSessionIds);
   const cards = useAppSelector((state) => state.dashboardLayout.cards);
   const viewCards = useAppSelector((state) => state.dashboardLayout.viewCards);
-  const browserCards = useAppSelector((state) => state.dashboardLayout.browserCards);
+  const allBrowserCards = useAppSelector((state) => state.dashboardLayout.browserCards);
+  // Browser cards live in a single global dict (no per-dashboard nesting) so
+  // a card spawned on dashboard A used to leak into dashboard B if the user
+  // switched mid-spawn. Filter here so every downstream consumer (render,
+  // bounds, layout save, keyboard nav) sees only this dashboard's cards.
+  // Legacy cards without dashboard_id fall through , next save tags them.
+  const browserCards = useMemo(() => {
+    const out: typeof allBrowserCards = {};
+    for (const [id, bc] of Object.entries(allBrowserCards)) {
+      if (!bc.dashboard_id || bc.dashboard_id === dashboardId) out[id] = bc;
+    }
+    return out;
+  }, [allBrowserCards, dashboardId]);
   const notes = useAppSelector((state) => state.dashboardLayout.notes);
   const pendingFocusNoteId = useAppSelector((state) => state.dashboardLayout.pendingFocusNoteId);
   const layoutInitialized = useAppSelector((state) => state.dashboardLayout.initialized);

--- a/frontend/src/shared/state/dashboardLayoutSlice.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.ts
@@ -59,6 +59,8 @@ export interface BrowserCardPosition {
   zOrder: number;
   /** Agent session that spawned this browser; auto-removed when its owner reaches terminal state. */
   spawned_by?: string | null;
+  /** Dashboard this card belongs to; cards render and persist only on their owning dashboard. */
+  dashboard_id?: string;
 }
 
 export type NoteColor = 'yellow' | 'pink' | 'blue' | 'green' | 'purple' | 'gray';
@@ -975,10 +977,14 @@ const dashboardLayoutSlice = createSlice({
         // browsers spawn). The caller says which; never inferred from state.
         const isReconnectRefetch = action.meta.arg.isReconnect === true;
         state.initialized = true;
+        const ownerDashboardId = action.meta.arg.dashboardId;
         if (!isReconnectRefetch) {
           state.cards = action.payload.cards;
           state.viewCards = action.payload.viewCards;
           state.browserCards = action.payload.browserCards;
+          for (const card of Object.values(state.browserCards)) {
+            card.dashboard_id = ownerDashboardId;
+          }
           state.notes = action.payload.notes || {};
           // Cards boot parked (no guest process, title placeholder); the suspend
           // hook wakes viewport-sized and agent-driven ones on its first pass.
@@ -992,6 +998,9 @@ const dashboardLayoutSlice = createSlice({
           addMissingCards(state.cards, action.payload.cards, occupied);
           addMissingCards(state.viewCards, action.payload.viewCards, occupied);
           addMissingCards(state.browserCards, action.payload.browserCards, occupied);
+          for (const card of Object.values(state.browserCards)) {
+            if (!card.dashboard_id) card.dashboard_id = ownerDashboardId;
+          }
           addMissingCards(state.notes, action.payload.notes || {}, occupied);
         }
         state.persistedExpandedSessionIds = action.payload.expandedSessionIds;

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -736,7 +736,14 @@ class WebSocketManager {
 
       case 'dashboard:browser_card_added':
         if (data.browser_card) {
-          store.dispatch(addBrowserCardFromBackend(data.browser_card));
+          // Tag with origin dashboard so the card renders only on the dashboard
+          // that spawned it , without this, a browser spawned by an agent on
+          // dashboard A leaks into whatever dashboard the user is currently
+          // viewing (the global browserCards dict + unfiltered render).
+          store.dispatch(addBrowserCardFromBackend({
+            ...data.browser_card,
+            dashboard_id: data.dashboard_id,
+          }));
           const parentId = data.parent_session_id;
           if (parentId) {
             const layoutState = store.getState().dashboardLayout;


### PR DESCRIPTION
## Summary

When an agent on dashboard A was spawning browser cards and the user switched to dashboard B mid-flight, the new browsers appeared on B instead of A. The backend already broadcasts the originating `dashboard_id` with every `dashboard:browser_card_added` event, but the frontend was throwing it away — browser cards live in one global Redux dict and the canvas rendered all of them with no filter.

Fix: tag every `BrowserCardPosition` with its `dashboard_id` (stamped at WS arrival in `WebSocketManager.ts` and at `fetchLayout` hydration in `dashboardLayoutSlice.ts`), then filter by it inside `useDashboardSelectors` so render, bounds, layout save, and keyboard nav all see only the local dashboard's cards. Backend untouched — it already persists each spawned card to its owning dashboard's layout, so nothing is lost when a leaked card gets filtered out.

Also pulls in unrelated `peer: true` annotations and a version bump in `electron/` + `frontend/` package-lock files from a recent `npm install`.

## Test plan

- [ ] On dashboard A, prompt an agent to open three sites in sequence with brief pauses
- [ ] While it's still spawning, switch to dashboard B — B stays empty of those browsers
- [ ] Switch back to A — all three browsers are present
- [ ] Fresh agent on B still spawns its own browsers on B
- [ ] Reload the app — both dashboards hydrate their correct sets from disk