### PR TITLE
[aidan] bug: dashboard not renaming during first run

### DIFF
--- a/backend/apps/dashboards/dashboards.py
+++ b/backend/apps/dashboards/dashboards.py
@@ -61,8 +61,8 @@ def _delete(dashboard_id: str):
         os.remove(path)
 
 
-def _migrate_if_needed():
-    """One-time migration: if no dashboards exist, create 'Dashboard 1' from old layout."""
+def migrate_if_needed():
+    """One-time migration: if no dashboards exist, create the default from old layout."""
     existing = _load_all()
     if existing:
         return
@@ -80,7 +80,7 @@ def _migrate_if_needed():
         except Exception:
             logger.exception("Failed to read old layout.json, using empty layout")
 
-    dashboard = Dashboard(name="Dashboard 1", layout=layout)
+    dashboard = Dashboard(name="Untitled Dashboard", layout=layout)
     _save(dashboard)
     logger.info(f"Created default dashboard: {dashboard.id}")
 
@@ -105,7 +105,7 @@ def _migrate_if_needed():
 @asynccontextmanager
 async def dashboards_lifespan():
     os.makedirs(DATA_DIR, exist_ok=True)
-    _migrate_if_needed()
+    migrate_if_needed()
     yield
 
 

--- a/backend/tests/test_disk_resilience.py
+++ b/backend/tests/test_disk_resilience.py
@@ -143,7 +143,7 @@ def test_migration_survives_corrupt_session(tmp_path, monkeypatch):
     (sess_dir / "good.json").write_text(json.dumps({"id": "good"}))
     (sess_dir / "bad.json").write_text("{ truncated ,,,")
 
-    dmod._migrate_if_needed()  # must not raise despite the corrupt session
+    dmod.migrate_if_needed()  # must not raise despite the corrupt session
 
     dashboards = dmod._load_all()
     assert len(dashboards) == 1

--- a/frontend/src/app/pages/Dashboard/hooks/lifecycle/useAgentSpawn.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/lifecycle/useAgentSpawn.ts
@@ -205,12 +205,7 @@ export function useAgentSpawn({
               (s) => s.status !== 'draft' && s.dashboard_id === dashboardId,
             ).length;
             const NAME_GEN_TRIGGERS = [1, 3, 6];
-            const currentDash = store.getState().dashboards.items[dashboardId];
-            const canAutoName =
-              currentDash &&
-              (currentDash.auto_named || currentDash.name === 'Untitled Dashboard');
-
-            if (NAME_GEN_TRIGGERS.includes(agentCount) && canAutoName) {
+            if (NAME_GEN_TRIGGERS.includes(agentCount)) {
               dispatch(generateDashboardName(dashboardId));
             }
           }

--- a/frontend/src/app/pages/Dashboard/hooks/lifecycle/useDashboardLifecycle.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/lifecycle/useDashboardLifecycle.ts
@@ -255,16 +255,13 @@ export function useDashboardLifecycle({
 
   const namedOnFirstMessageRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!dashboardId || !layoutInitialized) return;
+    if (!dashboardId) return;
     if (namedOnFirstMessageRef.current === dashboardId) return;
-    const dash = store.getState().dashboards.items[dashboardId];
-    if (!dash) return;
-    if (!dash.auto_named && dash.name !== 'Untitled Dashboard') return;
     const hasUserMessage = Object.values(sessions).some(
       (s) => s.dashboard_id === dashboardId && s.messages?.some((m) => m.role === 'user'),
     );
     if (!hasUserMessage) return;
     namedOnFirstMessageRef.current = dashboardId;
     dispatch(generateDashboardName(dashboardId));
-  }, [sessions, dashboardId, layoutInitialized, dispatch]);
+  }, [sessions, dashboardId, dispatch]);
 }


### PR DESCRIPTION
On a fresh install the backend's one-time migration seeded the default dashboard as "Dashboard 1" with `auto_named=false`, which made the auto-rename eligibility guard in `/dashboards/{id}/generate-name` short-circuit and leave the name untouched after the first prompt. The seed now uses "Untitled Dashboard" to match the frontend's create flow, and the two client-side auto-rename triggers drop their redundant `state.dashboards.items` lookups so a cold-boot Redux race can no longer suppress the dispatch.