### PR TITLE
[aidan] ux/calendar-page: schedule calendar restyle + popover fixes

### DIFF
--- a/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
+++ b/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
@@ -30,7 +30,7 @@ import ChatInput from '@/app/pages/AgentChat/ChatInput';
 import type { ContextPath } from '@/app/components/editor/DirectoryBrowser';
 import SchedulePopover from '@/app/pages/Workflows/SchedulePopover';
 import { openWorkflowCard, fetchAllRuns, upsertRun } from '@/shared/state/workflowsSlice';
-import { addWorkflowCard, openWorkflowsHub } from '@/shared/state/dashboardLayoutSlice';
+import { addWorkflowCard, openWorkflowsHub, closeWorkflowsHub } from '@/shared/state/dashboardLayoutSlice';
 import { useElementSelection } from '@/app/components/editor/ElementSelectionContext';
 import { useClaudeTokens } from '@/shared/styles/ThemeContext';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
@@ -191,6 +191,7 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
     const allRuns = useAppSelector((s) => s.workflows.allRuns);
     const allRunsLoading = useAppSelector((s) => s.workflows.allRunsLoading);
     const workflowItems = useAppSelector((s) => s.workflows.items);
+    const workflowsHubOpen = useAppSelector((s) => Boolean(s.dashboardLayout.workflowsHub));
 
     const outputList = useMemo(() => Object.values(outputs), [outputs]);
     const filteredOutputs = useMemo(() => {
@@ -814,15 +815,16 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
               enterDelay={200}
               title={
                 <Box sx={{ textAlign: 'center' }}>
-                  <Box sx={{ fontWeight: 600 }}>History  ⌘O</Box>
+                  <Box sx={{ fontWeight: 600 }}>Workflows</Box>
+                  <Box sx={{ opacity: 0.6, fontSize: '0.7rem', mt: '1px' }}>Schedule and calendar</Box>
                 </Box>
               }
             >
               <Box
                 role="button"
-                aria-label="History"
+                aria-label="Workflows"
                 tabIndex={0}
-                onClick={handleOpenHistory}
+                onClick={() => dispatch(workflowsHubOpen ? closeWorkflowsHub() : openWorkflowsHub({ expandedSessionIds: [] }))}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
@@ -830,14 +832,15 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
                   width: BTN,
                   height: BTN,
                   borderRadius: `${c.radius.md}px`,
-                  color: c.text.tertiary,
+                  color: workflowsHubOpen ? c.accent.primary : c.text.tertiary,
+                  bgcolor: workflowsHubOpen ? c.bg.secondary : 'transparent',
                   cursor: 'pointer',
                   transition: 'opacity 0.15s, background-color 0.15s',
                   '&:hover': { opacity: 1, bgcolor: c.bg.secondary, color: c.accent.primary },
                   ...popIn(3),
                 }}
               >
-                <HistoryRoundedIcon sx={{ fontSize: 22 }} />
+                <CalendarMonthRounded sx={{ fontSize: 22 }} />
               </Box>
             </WarmTooltip>
 
@@ -873,6 +876,40 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
                 }}
               >
                 <StickyNote2OutlinedIcon sx={{ fontSize: 22 }} />
+              </Box>
+            </WarmTooltip>
+
+            <WarmTooltip
+              tokens={c}
+              placement="top"
+              arrow
+              enterDelay={200}
+              title={
+                <Box sx={{ textAlign: 'center' }}>
+                  <Box sx={{ fontWeight: 600 }}>History  ⌘O</Box>
+                </Box>
+              }
+            >
+              <Box
+                role="button"
+                aria-label="History"
+                tabIndex={0}
+                onClick={handleOpenHistory}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: BTN,
+                  height: BTN,
+                  borderRadius: `${c.radius.md}px`,
+                  color: c.text.tertiary,
+                  cursor: 'pointer',
+                  transition: 'opacity 0.15s, background-color 0.15s',
+                  '&:hover': { opacity: 1, bgcolor: c.bg.secondary, color: c.accent.primary },
+                  ...popIn(5),
+                }}
+              >
+                <HistoryRoundedIcon sx={{ fontSize: 22 }} />
               </Box>
             </WarmTooltip>
 

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useDashboardShortcuts.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useDashboardShortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect, type Dispatch, type SetStateAction } from 'react';
 import { report } from '@/shared/serviceClient';
 import { useAppDispatch } from '@/shared/hooks';
 import { closeSession, toggleExpandSession } from '@/shared/state/agentsSlice';
-import { removeViewCard, removeBrowserCard, removeNote, removeWorkflowCard } from '@/shared/state/dashboardLayoutSlice';
+import { removeViewCard, removeBrowserCard, removeNote, removeWorkflowCard, closeWorkflowsHub } from '@/shared/state/dashboardLayoutSlice';
 import { closeWorkflowCard } from '@/shared/state/workflowsSlice';
 import type { useDashboardSelection } from '../state/useDashboardSelection';
 
@@ -83,6 +83,8 @@ export function useDashboardShortcuts({
         } else if (type === 'workflow') {
           dispatch(removeWorkflowCard(id));
           dispatch(closeWorkflowCard(id));
+        } else if (type === 'workflows-hub') {
+          dispatch(closeWorkflowsHub());
         }
       }
       selection.deselectAll();

--- a/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
+++ b/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
@@ -185,7 +185,7 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', color: c.text.secondary }}>
         {/* Day headers: muted weekday caps; today's date gets the filled circle */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: '64px repeat(7, 1fr)', gap: 0, position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 2, pb: 0.5 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: '64px repeat(7, 1fr)', gap: 0, position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 4, borderBottom: `1px solid ${c.border.subtle}`, pt: 1.25, pb: 0.5 }}>
           <Box sx={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'flex-end', pr: 1, pb: 0.5 }}>
             {!compact && (
               <Typography sx={{ fontSize: '0.62rem', color: c.text.ghost, fontWeight: 500 }}>{TZ_LABEL}</Typography>
@@ -203,7 +203,7 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
             );
           })}
         </Box>
-        <Box sx={{ display: 'grid', gridTemplateColumns: '64px repeat(7, 1fr)', borderTop: `1px solid ${c.border.subtle}`, position: 'relative' }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: '64px repeat(7, 1fr)', position: 'relative' }}>
           {HOURS.map((hour, hourIdx) => (
             <React.Fragment key={hour}>
               {/* Hour label sits inside its row (top-aligned) rather than
@@ -282,7 +282,7 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
         {/* Sticky weekday header so it stays visible even when the
             calendar body scrolls. Slightly bigger + tinted bg so it
             reads cleanly in both light and dark themes. */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', flexShrink: 0, position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 2, borderBottom: `1px solid ${c.border.subtle}`, py: 0.6 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', flexShrink: 0, position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 2, borderBottom: `1px solid ${c.border.subtle}`, pt: 1.25, pb: 0.6 }}>
           {WEEKDAY_LABEL_SHORT.map((l, i) => (
             <Typography key={`${l}-${i}`} sx={{ textAlign: 'center', fontSize: '0.74rem', color: c.text.muted, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' }}>{l}</Typography>
           ))}

--- a/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
+++ b/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
@@ -192,13 +192,13 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
             )}
           </Box>
           {days.map((d) => {
-            const isToday = sameDay(d, today);
+            const isToday = sameDay(d, now);
             return (
               <Box key={d.toISOString()} sx={{ textAlign: 'center', pb: 0.5 }}>
                 <Typography sx={{ fontSize: DAY_LABEL, color: c.text.muted, fontWeight: 600, letterSpacing: '0.08em', lineHeight: 1.3, textTransform: 'uppercase' }}>
                   {WEEKDAY_LABEL_SHORT[d.getDay()]}
                 </Typography>
-                <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: compact ? 30 : 38, height: compact ? 30 : 38, borderRadius: '50%', bgcolor: isToday ? c.accent.primary : 'transparent', color: isToday ? '#fff' : c.text.primary, fontWeight: isToday ? 700 : 500, fontSize: DAY_NUM, mt: 0.25 }}>{d.getDate()}</Box>
+                <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, boxSizing: 'border-box', width: compact ? 26 : 32, height: compact ? 26 : 32, borderRadius: '50%', bgcolor: isToday ? c.accent.primary : 'transparent', color: isToday ? '#fff' : c.text.primary, fontWeight: isToday ? 600 : 500, fontSize: DAY_NUM, lineHeight: 1, mt: 0.25, boxShadow: isToday ? `0 0 0 1.5px ${c.bg.surface}, 0 0 0 3px ${c.accent.primary}` : 'none' }}>{d.getDate()}</Box>
               </Box>
             );
           })}
@@ -278,29 +278,29 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
     const cells = Array.from({ length: 35 }, (_, i) => addDays(start, i));
     const accent = c.accent.primary;
     return (
-      <Box sx={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100%' }}>
         {/* Sticky weekday header so it stays visible even when the
             calendar body scrolls. Slightly bigger + tinted bg so it
             reads cleanly in both light and dark themes. */}
-        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 2, borderBottom: `1px solid ${c.border.subtle}`, py: 0.6 }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', flexShrink: 0, position: 'sticky', top: 0, bgcolor: c.bg.surface, zIndex: 2, borderBottom: `1px solid ${c.border.subtle}`, py: 0.6 }}>
           {WEEKDAY_LABEL_SHORT.map((l, i) => (
             <Typography key={`${l}-${i}`} sx={{ textAlign: 'center', fontSize: '0.74rem', color: c.text.muted, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase' }}>{l}</Typography>
           ))}
         </Box>
-        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 0, borderLeft: `1px solid ${c.border.subtle}` }}>
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gridTemplateRows: `repeat(5, minmax(${compact ? 70 : 96}px, 1fr))`, flex: 1, minHeight: 0, gap: 0, borderLeft: `1px solid ${c.border.subtle}` }}>
           {cells.map((d) => {
             const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
             const evs = eventsByDay.map.get(key) || [];
-            const isToday = sameDay(d, today);
+            const isToday = sameDay(d, now);
             const inMonth = d.getMonth() === today.getMonth();
             return (
-              <Box key={d.toISOString()} sx={{ minHeight: compact ? 70 : 96, borderRight: `1px solid ${c.border.subtle}`, borderBottom: `1px solid ${c.border.subtle}`, p: 0.5, position: 'relative', overflow: 'hidden', bgcolor: inMonth ? 'transparent' : c.bg.elevated }}>
+              <Box key={d.toISOString()} sx={{ borderRight: `1px solid ${c.border.subtle}`, borderBottom: `1px solid ${c.border.subtle}`, p: 0.5, position: 'relative', overflow: 'hidden', bgcolor: inMonth ? 'transparent' : c.bg.elevated }}>
                 <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
                   {/* Out-of-month dates still need to be legible (Apple
                       Calendar shows them in a muted shade, not invisible).
                       Color tweak instead of opacity so dark themes stay
                       readable. */}
-                  <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 22, height: 22, borderRadius: '50%', bgcolor: isToday ? accent : 'transparent', color: isToday ? '#fff' : inMonth ? c.text.primary : c.text.ghost, fontWeight: isToday ? 700 : 500, fontSize: '0.82rem', px: 0.5 }}>{d.getDate()}</Box>
+                  <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, boxSizing: 'border-box', width: 22, height: 22, borderRadius: '50%', bgcolor: isToday ? accent : 'transparent', color: isToday ? '#fff' : inMonth ? c.text.primary : c.text.ghost, fontWeight: isToday ? 600 : 500, fontSize: '0.82rem', lineHeight: 1, boxShadow: isToday ? `0 0 0 1.5px ${c.bg.surface}, 0 0 0 3px ${accent}` : 'none' }}>{d.getDate()}</Box>
                 </Box>
                 {evs.slice(0, compact ? 3 : 4).map((e, idx) => (
                   <Box
@@ -334,7 +334,7 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
     const day = addDays(today, i);
     const key = `${day.getFullYear()}-${day.getMonth()}-${day.getDate()}`;
     const arr = eventsByDay.map.get(key) || [];
-    const isToday = sameDay(day, today);
+    const isToday = sameDay(day, now);
     if (arr.length || isToday) upcoming.push({ date: day, events: arr, isToday });
   }
   const accent = c.accent.primary;

--- a/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
+++ b/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
@@ -319,7 +319,14 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
                   );
                 })}
                 {evs.length > (compact ? 3 : 4) && (
-                  <Typography sx={{ fontSize: EVENT_FS, color: c.text.muted, mt: 0.3, pl: 1.4 }}>+{evs.length - (compact ? 3 : 4)} more</Typography>
+                  <MonthDayOverflow
+                    date={d}
+                    count={evs.length - (compact ? 3 : 4)}
+                    events={evs}
+                    now={now}
+                    fontSize={EVENT_FS}
+                    onSelectWorkflow={onSelectWorkflow}
+                  />
                 )}
               </Box>
             );
@@ -488,6 +495,57 @@ function EventStack({ events, paused, onSelectWorkflow, eventFontSize, onContext
               <Typography sx={{ fontSize: '0.74rem', color: c.text.muted }}>{formatTime(e.date.getHours(), e.date.getMinutes())}</Typography>
             </Box>
           ))}
+        </Box>
+      </Popover>
+    </>
+  );
+}
+
+// "+N more" on a packed month cell opens a scrollable popover listing every
+// run that day, so a heavy day isn't a dead end. Past fires keep the hollow
+// ring the cell rows use, for a consistent at-a-glance "already ran" read.
+function MonthDayOverflow({ date, count, events, now, fontSize, onSelectWorkflow }: {
+  date: Date;
+  count: number;
+  events: { workflow: Workflow; date: Date }[];
+  now: Date;
+  fontSize: string;
+  onSelectWorkflow?: (id: string) => void;
+}) {
+  const c = useClaudeTokens();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const accent = c.accent.primary;
+  return (
+    <>
+      <Typography
+        onClick={(e) => { e.stopPropagation(); setAnchor(e.currentTarget); }}
+        role="button"
+        sx={{ fontSize, color: c.text.muted, mt: 0.3, pl: 1.4, cursor: 'pointer', '&:hover': { color: accent } }}>
+        +{count} more
+      </Typography>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}>
+        <Box sx={{ minWidth: 240, maxHeight: 360, overflowY: 'auto', p: 1 }}>
+          <Typography sx={{ fontSize: '0.7rem', fontWeight: 700, color: c.text.muted, letterSpacing: '0.06em', mb: 0.5 }}>
+            {`${events.length} scheduled · ${date.toLocaleString('en', { weekday: 'short', month: 'short', day: 'numeric' })}`}
+          </Typography>
+          {events.map((e, idx) => {
+            const passed = e.date.getTime() < now.getTime();
+            return (
+              <Box
+                key={`${e.workflow.id}-${idx}`}
+                onClick={() => { setAnchor(null); onSelectWorkflow?.(e.workflow.id); }}
+                sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 0.5, py: 0.5, borderRadius: `${c.radius.md}px`, cursor: 'pointer', '&:hover': { bgcolor: c.bg.elevated } }}>
+                <Box sx={{ width: 6, height: 6, borderRadius: '50%', boxSizing: 'border-box', bgcolor: passed ? 'transparent' : accent, border: passed ? `1.5px solid ${accent}` : 'none', flexShrink: 0 }} />
+                <Typography sx={{ flex: 1, fontSize: '0.82rem', color: c.text.primary, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.workflow.title}</Typography>
+                <Typography sx={{ fontSize: '0.74rem', color: c.text.muted, flexShrink: 0 }}>{formatTime(e.date.getHours(), e.date.getMinutes())}</Typography>
+              </Box>
+            );
+          })}
         </Box>
       </Popover>
     </>

--- a/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
+++ b/frontend/src/app/pages/Workflows/ScheduleCalendar.tsx
@@ -302,17 +302,22 @@ export default function ScheduleCalendar({ view, density, onSelectWorkflow, refD
                       readable. */}
                   <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, boxSizing: 'border-box', width: 22, height: 22, borderRadius: '50%', bgcolor: isToday ? accent : 'transparent', color: isToday ? '#fff' : inMonth ? c.text.primary : c.text.ghost, fontWeight: isToday ? 600 : 500, fontSize: '0.82rem', lineHeight: 1, boxShadow: isToday ? `0 0 0 1.5px ${c.bg.surface}, 0 0 0 3px ${accent}` : 'none' }}>{d.getDate()}</Box>
                 </Box>
-                {evs.slice(0, compact ? 3 : 4).map((e, idx) => (
+                {evs.slice(0, compact ? 3 : 4).map((e, idx) => {
+                  // Past fires read as a hollow ring, upcoming ones stay filled,
+                  // so a glance down a day tells you what already ran.
+                  const passed = e.date.getTime() < now.getTime();
+                  return (
                   <Box
                     key={`${e.workflow.id}-${idx}`}
                     onClick={() => onSelectWorkflow?.(e.workflow.id)}
                     onContextMenu={(ev) => { ev.preventDefault(); setCtxMenu({ x: ev.clientX, y: ev.clientY, workflow: e.workflow }); }}
                     sx={{ mt: 0.3, display: 'flex', alignItems: 'center', gap: 0.5, fontSize: EVENT_FS, color: c.text.primary, cursor: 'pointer', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', '&:hover': { color: accent } }}>
-                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: accent, flexShrink: 0 }} />
+                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', boxSizing: 'border-box', bgcolor: passed ? 'transparent' : accent, border: passed ? `1.5px solid ${accent}` : 'none', flexShrink: 0 }} />
                     <span style={{ color: c.text.muted, flexShrink: 0 }}>{formatTime(e.date.getHours(), e.date.getMinutes())}</span>
                     <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, fontWeight: 500 }}>{e.workflow.title}</span>
                   </Box>
-                ))}
+                  );
+                })}
                 {evs.length > (compact ? 3 : 4) && (
                   <Typography sx={{ fontSize: EVENT_FS, color: c.text.muted, mt: 0.3, pl: 1.4 }}>+{evs.length - (compact ? 3 : 4)} more</Typography>
                 )}

--- a/frontend/src/app/pages/Workflows/SchedulePopover.tsx
+++ b/frontend/src/app/pages/Workflows/SchedulePopover.tsx
@@ -226,8 +226,8 @@ export default function SchedulePopover({
               <IconButton size="small" onClick={onNext} sx={{ p: 0.3, color: c.text.muted, '&:hover': { color: c.text.primary } }}><ChevronRightIcon sx={{ fontSize: 17 }} /></IconButton>
               <Typography sx={{ fontSize: '0.84rem', fontWeight: 600, color: c.text.primary, ml: 0.25 }}>{periodLabel}</Typography>
             </Box>
-            <Box sx={{ flex: 1, overflowY: 'auto', px: 1.5, py: 1, borderTop: `1px solid ${c.border.subtle}`, minHeight: 0 }}>
-              <ScheduleCalendar view={calendarView} density="roomy" onSelectWorkflow={onWorkflowSelect} refDate={refDate} />
+            <Box sx={{ flex: 1, overflowY: 'auto', px: 1.5, pt: 0, pb: 1, borderTop: `1px solid ${c.border.subtle}`, minHeight: 0 }}>
+              <ScheduleCalendar view={calendarView} density="compact" onSelectWorkflow={onWorkflowSelect} refDate={refDate} />
             </Box>
           </Box>
         )}

--- a/frontend/src/app/pages/Workflows/WorkflowsHubCard.tsx
+++ b/frontend/src/app/pages/Workflows/WorkflowsHubCard.tsx
@@ -533,7 +533,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
         )}
 
         {/* Main calendar area */}
-        <Box sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 1.25, bgcolor: c.bg.surface }}>
+        <Box sx={{ flex: 1, minWidth: 0, overflow: 'auto', px: 1.25, pt: 0, pb: 1.25, bgcolor: c.bg.surface }}>
           <ScheduleCalendar view={view} density="roomy" onSelectWorkflow={onSelectWorkflow} refDate={refDate} />
         </Box>
       </Box>

--- a/frontend/src/app/pages/Workflows/WorkflowsHubCard.tsx
+++ b/frontend/src/app/pages/Workflows/WorkflowsHubCard.tsx
@@ -382,6 +382,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
         border,
         borderRadius: `${c.radius.lg}px`,
         boxShadow: shadow,
+        overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
         zIndex: (isDragging || isResizing) ? 999999 : cardZOrder,
@@ -396,7 +397,8 @@ const WorkflowsHubCard: React.FC<Props> = ({
         onPointerUp={onHeaderPointerUp}
         sx={{
           display: 'flex', alignItems: 'center', gap: 0.6,
-          px: 1.5, py: 0.6,
+          px: 1.5, py: 0.5,
+          bgcolor: c.bg.elevated,
           borderBottom: `1px solid ${c.border.subtle}`,
           cursor: isDragging ? 'grabbing' : 'grab',
           touchAction: 'none', userSelect: 'none',
@@ -421,7 +423,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
       </Box>
 
       {/* ===== Toolbar row (matches Figma image #8 header) ===== */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.65, px: 1.5, py: 0.7, borderBottom: `1px solid ${c.border.subtle}`, flexShrink: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.65, px: 1.5, py: 0.55, bgcolor: c.bg.elevated, borderBottom: `1px solid ${c.border.subtle}`, flexShrink: 0 }}>
         <Tooltip title={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}>
           <IconButton size="small" data-no-drag onClick={() => setSidebarOpen((v) => !v)} sx={{ p: 0.5, color: sidebarOpen ? c.text.secondary : c.text.muted, '&:hover': { color: c.text.primary } }}>
             <MenuIcon sx={{ fontSize: 18 }} />
@@ -434,7 +436,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
           sx={{
             display: 'inline-flex', alignItems: 'center', gap: 0.4,
             fontSize: '0.85rem', fontWeight: 600, color: c.text.primary,
-            bgcolor: c.bg.elevated, border: `1px solid ${c.border.subtle}`,
+            bgcolor: c.bg.surface, border: `1px solid ${c.border.subtle}`,
             px: 1, py: 0.4, borderRadius: `${c.radius.md}px`, cursor: 'pointer',
             '&:hover': { borderColor: c.accent.primary, color: c.accent.primary },
           }}
@@ -477,9 +479,6 @@ const WorkflowsHubCard: React.FC<Props> = ({
           <TimeSavedBadge />
         </Box>
 
-        <IconButton size="small" data-no-drag sx={{ p: 0.5, color: c.text.muted }}>
-          <SearchIcon sx={{ fontSize: 18 }} />
-        </IconButton>
         <Box sx={{ position: 'relative' }}>
           <Box
             onClick={() => setViewOpen((v) => !v)}
@@ -515,8 +514,8 @@ const WorkflowsHubCard: React.FC<Props> = ({
       <Box sx={{ flex: 1, display: 'flex', minHeight: 0 }}>
         {/* Sidebar */}
         {sidebarOpen && (
-        <Box sx={{ width: 240, flexShrink: 0, borderRight: `1px solid ${c.border.subtle}`, display: 'flex', flexDirection: 'column' }}>
-          <Box sx={{ px: 1.5, pt: 1.25, pb: 0.75 }}>
+        <Box sx={{ width: 210, flexShrink: 0, bgcolor: c.bg.elevated, borderRight: `1px solid ${c.border.subtle}`, display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ px: 1.25, pt: 1, pb: 0.6 }}>
             <InputBase
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -526,7 +525,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
             />
           </Box>
           <MiniMonth refDate={refDate} onPick={setRefDate} />
-          <Box sx={{ flex: 1, overflowY: 'auto', px: 1.5, pb: 1.5 }}>
+          <Box sx={{ flex: 1, overflowY: 'auto', px: 1.25, pb: 1.25 }}>
             <SidebarSection title="Scheduled" items={scheduled.filter((w) => match(w.title, search))} onPick={onSelectWorkflow} scheduled onContext={(wf, e) => setSidebarCtxMenu({ x: e.clientX, y: e.clientY, workflow: wf })} />
             <SidebarSection title="Unscheduled" items={unscheduled.filter((w) => match(w.title, search))} onPick={onSelectWorkflow} scheduled={false} onContext={(wf, e) => setSidebarCtxMenu({ x: e.clientX, y: e.clientY, workflow: wf })} onSchedule={(wf, el) => setSchedulePopover({ anchorEl: el, workflow: wf })} />
           </Box>
@@ -534,7 +533,7 @@ const WorkflowsHubCard: React.FC<Props> = ({
         )}
 
         {/* Main calendar area */}
-        <Box sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 1.5 }}>
+        <Box sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 1.25, bgcolor: c.bg.surface }}>
           <ScheduleCalendar view={view} density="roomy" onSelectWorkflow={onSelectWorkflow} refDate={refDate} />
         </Box>
       </Box>
@@ -612,7 +611,7 @@ function MiniMonth({ refDate, onPick }: { refDate: Date; onPick: (d: Date) => vo
   const today = new Date();
   const label = refDate.toLocaleString('en', { month: 'long', year: 'numeric' });
   return (
-    <Box sx={{ px: 1.5, pb: 1, borderBottom: `1px solid ${c.border.subtle}` }}>
+    <Box sx={{ px: 1.25, pb: 0.75, borderBottom: `1px solid ${c.border.subtle}` }}>
       <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5 }}>
         <Typography sx={{ flex: 1, fontSize: '0.82rem', fontWeight: 700, color: c.text.primary }}>{label}</Typography>
         <IconButton size="small" data-no-drag onClick={() => onPick(addMonths(refDate, -1))} sx={{ p: 0.15 }}><ChevronLeftIcon sx={{ fontSize: 14 }} /></IconButton>


### PR DESCRIPTION
284ceb5c: Removes the workflows calendar panel when the Delete/Backspace shortcut fires on the dashboard, so the delete key no longer leaves the schedule calendar card orphaned on the canvas.

1591581e: Restyles the Workflows hub: tinted header/sidebar against the white calendar, more compact calendar and sidebar spacing, rounded-corner clipping so the card border matches the browser views, removes the non-functional top-right search icon, and adds a toggling calendar button to the main dashboard toolbar (history last, notes second-to-last, calendar before that). Also fixes the today highlight comparing against the navigated week instead of the live clock, so paging to a different week no longer highlights the wrong weekday, and makes the Month grid grow vertically when the card is stretched.

10586eaf: Polishes the Schedule popover calendar. Switches it back to its by-design compact density (smaller hour rows and labels) so more of the day is visible at once. Fixes "12 AM" bleeding above the sticky day-of-week header: the scroll container's top padding sat above the top:0 sticky header and let scrolled hours show through, so the scrollport top padding is zeroed and the header pins flush (same parity fix on the hub's main calendar area). The Week header gets a bottom border and a raised z-index above the red "now" line so it reads as a clean band, the now-redundant body-grid top border is dropped, and top spacing is added inside the Week/Month headers for breathing room between the nav row and the day labels without reintroducing the bleed.

0afc98a1: Past fires in the Month view now render as a hollow orange ring instead of a filled dot, so a glance down a day shows what already ran versus what is still upcoming. The state is driven by the live clock, so a dot flips the minute its time passes.

632da1a7: Makes the "+N more" on a packed Month cell clickable: it opens a scrollable popover listing every run scheduled that day (count + date header), so a heavy day (+25, +93 more) is no longer a dead end. Rows deep-link to their workflow and reuse the same hollow-ring/filled-dot convention; it mirrors the existing per-hour overflow popover.