### PR TITLE
[pierre] fix: persist element selection on new-agent composer across collapse

### DIFF
--- a/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
+++ b/frontend/src/app/pages/Dashboard/DashboardToolbar.tsx
@@ -290,14 +290,17 @@ const DashboardToolbar = React.forwardRef<HTMLDivElement, Props>(
     const autoSelectOnNew = useAppSelector((s) => s.settings.data.auto_select_mode_on_new_agent);
     const prevInputOpenRef = useRef(inputOpen);
     useEffect(() => {
+      // Collapsing the composer drops the selecting cursor but KEEPS the selected
+      // elements, so they persist across collapse/reopen like the draft text does.
+      // The selection is cleared on send via ChatInput's clearOwnerElements(ownerId).
       if (prevInputOpenRef.current && !inputOpen && elementSelection) {
-        elementSelection.clearOwnerElements(TOOLBAR_OWNER_ID);
         if (elementSelection.selectMode && elementSelection.activeOwnerId === TOOLBAR_OWNER_ID) {
           elementSelection.setSelectMode(false);
         }
       }
+      // Re-arm select mode on reopen without wiping any in-progress selection
+      // (mirrors the selector button, which only clears when switching owners).
       if (!prevInputOpenRef.current && inputOpen && autoSelectOnNew && elementSelection) {
-        elementSelection.clearOwnerElements(TOOLBAR_OWNER_ID);
         elementSelection.setActiveOwnerId(TOOLBAR_OWNER_ID);
         elementSelection.setExcludeSelectId(null);
         elementSelection.setSelectMode(true);


### PR DESCRIPTION
When you create a new chat, use the selector, then click out to the canvas (collapsing the composer) and reopen it, the selection was wiped, but an existing chat keeps its selection across the same collapse. The toolbar composer was explicitly clearing its selections (`clearOwnerElements(TOOLBAR_OWNER_ID)`) on collapse and reopen, whereas existing AgentCard chats key by a persistent `session.id` and never do. This drops those wipes so toolbar selections persist across collapse/reopen; they are still cleared on send via the existing `ChatInput` path.

Verified manually (no JS test runner in repo): new chat select then collapse then reopen keeps the chips; new chat select then send opens the next chat clean; existing chat behavior unchanged.