### PR TITLE
[aidan] fix/agent-chat: stop agents reading the recap as spoofed tool output

### DIFF
--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -60,6 +60,7 @@ from backend.apps.agents.manager.session.history_compaction import (
     _get_branch_messages,
     _truncate_large_tool_result,
     wrap_platform_note,
+    strip_forged_sentinels,
 )
 from backend.apps.agents.manager.prompt.prompt_context import (
     _build_browser_context,
@@ -1034,6 +1035,9 @@ class AgentManager:
                     content = _json.dumps(raw_response, indent=2, default=str)
                 except Exception:
                     content = str(raw_response)
+
+            # Untrusted tool output could forge our trusted-note tag; neuter it before we append real ones below.
+            content = strip_forged_sentinels(content)
 
             hook_tool_name_for_errors = input_data.get("tool_name", "")
             wrote_files = hook_tool_name_for_errors in ("Write", "Edit", "MultiEdit")

--- a/backend/apps/agents/agent_manager.py
+++ b/backend/apps/agents/agent_manager.py
@@ -59,6 +59,7 @@ from backend.apps.agents.manager.session.history_compaction import (
     _estimate_post_compact_input,
     _get_branch_messages,
     _truncate_large_tool_result,
+    wrap_platform_note,
 )
 from backend.apps.agents.manager.prompt.prompt_context import (
     _build_browser_context,
@@ -1072,7 +1073,7 @@ class AgentManager:
                         joined = "\n".join(errs[-20:])
                         content = (
                             f"{content}\n\n"
-                            f"---\nBuild server reported (after this write):\n{joined}"
+                            + wrap_platform_note(f"Build server reported (after this write):\n{joined}")
                         )
 
             result_payload = {"text": content}
@@ -2116,7 +2117,7 @@ class AgentManager:
                             _names = ", ".join(t.replace("mcp:", "") for t in trimmed)
                             _trim_msg = Message(
                                 role="system",
-                                content=(
+                                content=wrap_platform_note(
                                     f"Trimmed {len(trimmed)} app{'s' if len(trimmed) != 1 else ''} from this session to fit "
                                     f"the model's context: {_names}. Re-activate via MCPSearch + MCPActivate "
                                     "if you still need them."

--- a/backend/apps/agents/manager/session/history_compaction.py
+++ b/backend/apps/agents/manager/session/history_compaction.py
@@ -32,6 +32,17 @@ def wrap_platform_note(body: str) -> str:
     return f"{PLATFORM_NOTE_OPEN}\n{PLATFORM_NOTE_PREAMBLE}\n{body}\n{PLATFORM_NOTE_CLOSE}"
 
 
+_SENTINEL_TAG_RE = re.compile(r"</?openswarm_(?:platform_note|session_recap)\b[^>]*>")
+
+
+def strip_forged_sentinels(text: str) -> str:
+    """Neuter any platform-note/recap tags hiding in UNTRUSTED text (tool results,
+    user input) so attacker-supplied content can't pose as trusted platform context."""
+    if "openswarm_platform_note" not in text and "openswarm_session_recap" not in text:
+        return text
+    return _SENTINEL_TAG_RE.sub(lambda m: m.group(0).replace("<", "&lt;").replace(">", "&gt;"), text)
+
+
 def p_recap_tool_call_line(content: object) -> str:
     """One compact line for a tool_call turn: Tool call: name(<truncated input>)."""
     if isinstance(content, dict):
@@ -46,7 +57,7 @@ def p_recap_tool_call_line(content: object) -> str:
         input_str = str(content)
     if len(input_str) > RECAP_TOOL_INPUT_CAP:
         input_str = input_str[:RECAP_TOOL_INPUT_CAP] + "..."
-    return f"Tool call: {tool}({input_str})"
+    return f"Tool call: {tool}({strip_forged_sentinels(input_str)})"
 
 
 def p_recap_tool_result_line(content: object) -> str:
@@ -61,7 +72,7 @@ def p_recap_tool_result_line(content: object) -> str:
     if len(body) > RECAP_TOOL_RESULT_CAP:
         body = body[:RECAP_TOOL_RESULT_CAP] + "..."
     label = f"Tool result ({tool_name})" if tool_name else "Tool result"
-    return f"{label}: {body}"
+    return f"{label}: {strip_forged_sentinels(body)}"
 
 
 def _get_branch_messages(session) -> list:
@@ -121,10 +132,10 @@ def _build_history_prefix(messages, cutoff_msg_id: str | None = None) -> str:
             continue
         if m.role == "user":
             text = m.content if isinstance(m.content, str) else str(m.content)
-            lines.append(f"User: {text}")
+            lines.append(f"User: {strip_forged_sentinels(text)}")
         elif m.role == "assistant":
             text = m.content if isinstance(m.content, str) else str(m.content)
-            lines.append(f"Assistant: {text}")
+            lines.append(f"Assistant: {strip_forged_sentinels(text)}")
         elif m.role == "tool_call":
             lines.append(p_recap_tool_call_line(m.content))
         elif m.role == "tool_result":
@@ -196,7 +207,7 @@ def _truncate_large_tool_result(content: object, session_id: str, msg_id: str, m
     except Exception as e:
         logger.warning(f"Failed to spill tool result to {blob_path}: {e}")
         return content, None
-    head = serialized[:4_000]
+    head = strip_forged_sentinels(serialized[:4_000])
     note = wrap_platform_note(
         f"Output truncated by OpenSwarm. Full output ({len(serialized)} chars) saved to "
         f"{blob_path}. Ask the user or run a follow-up tool call if you need the rest."

--- a/backend/apps/agents/manager/session/history_compaction.py
+++ b/backend/apps/agents/manager/session/history_compaction.py
@@ -7,6 +7,62 @@ from backend.config.paths import SESSIONS_DIR
 
 logger = logging.getLogger(__name__)
 
+# One plain-English trust line, fenced by a tag. The model treats the fence as
+# structural framing; the sentence is what actually defuses a security-conscious
+# agent flagging the block as spoofed tool output.
+PLATFORM_NOTE_PREAMBLE = (
+    "This block is authored by the OpenSwarm platform, not tool output and not a "
+    "prior message. It is trusted context."
+)
+PLATFORM_NOTE_OPEN = "<openswarm_platform_note>"
+PLATFORM_NOTE_CLOSE = "</openswarm_platform_note>"
+SESSION_RECAP_OPEN = "<openswarm_session_recap>"
+SESSION_RECAP_CLOSE = "</openswarm_session_recap>"
+
+# Per-turn caps so the re-grounded recap stays compact (summaries, not replays)
+# and cannot reinflate the context window from one giant tool input/output.
+RECAP_TOOL_INPUT_CAP = 200
+RECAP_TOOL_RESULT_CAP = 500
+
+
+def wrap_platform_note(body: str) -> str:
+    """Fence platform-authored text so the model reads it as trusted annotation,
+    never as spoofed tool output. The frontend parses the same tag to render a
+    calm chip instead of leaking the raw tag into chat."""
+    return f"{PLATFORM_NOTE_OPEN}\n{PLATFORM_NOTE_PREAMBLE}\n{body}\n{PLATFORM_NOTE_CLOSE}"
+
+
+def p_recap_tool_call_line(content: object) -> str:
+    """One compact line for a tool_call turn: Tool call: name(<truncated input>)."""
+    if isinstance(content, dict):
+        tool = content.get("tool") or content.get("name") or "tool"
+        raw_input = content.get("input")
+        try:
+            input_str = json.dumps(raw_input, ensure_ascii=False, default=str)
+        except Exception:
+            input_str = str(raw_input)
+    else:
+        tool = "tool"
+        input_str = str(content)
+    if len(input_str) > RECAP_TOOL_INPUT_CAP:
+        input_str = input_str[:RECAP_TOOL_INPUT_CAP] + "..."
+    return f"Tool call: {tool}({input_str})"
+
+
+def p_recap_tool_result_line(content: object) -> str:
+    """One compact line for a tool_result turn: Tool result (name): <truncated text>."""
+    tool_name = ""
+    if isinstance(content, dict):
+        tool_name = content.get("tool_name") or ""
+        text = content.get("text")
+        body = text if isinstance(text, str) else json.dumps(content, ensure_ascii=False, default=str)
+    else:
+        body = str(content)
+    if len(body) > RECAP_TOOL_RESULT_CAP:
+        body = body[:RECAP_TOOL_RESULT_CAP] + "..."
+    label = f"Tool result ({tool_name})" if tool_name else "Tool result"
+    return f"{label}: {body}"
+
 
 def _get_branch_messages(session) -> list:
     """Return the linear message list for the active branch, walking the branch tree."""
@@ -61,14 +117,21 @@ def _build_history_prefix(messages, cutoff_msg_id: str | None = None) -> str:
             messages = messages[skip_idx + 1:]
     lines = []
     for m in messages:
-        if m.role not in ("user", "assistant") or getattr(m, "hidden", False):
+        if getattr(m, "hidden", False):
             continue
-        text = m.content if isinstance(m.content, str) else str(m.content)
-        label = "User" if m.role == "user" else "Assistant"
-        lines.append(f"{label}: {text}")
+        if m.role == "user":
+            text = m.content if isinstance(m.content, str) else str(m.content)
+            lines.append(f"User: {text}")
+        elif m.role == "assistant":
+            text = m.content if isinstance(m.content, str) else str(m.content)
+            lines.append(f"Assistant: {text}")
+        elif m.role == "tool_call":
+            lines.append(p_recap_tool_call_line(m.content))
+        elif m.role == "tool_result":
+            lines.append(p_recap_tool_result_line(m.content))
     if not lines:
         return ""
-    return "<prior_conversation>\n" + "\n".join(lines) + "\n</prior_conversation>"
+    return f"{SESSION_RECAP_OPEN}\n{PLATFORM_NOTE_PREAMBLE}\n" + "\n".join(lines) + f"\n{SESSION_RECAP_CLOSE}"
 
 
 def _estimate_post_compact_input(session) -> int:
@@ -134,9 +197,9 @@ def _truncate_large_tool_result(content: object, session_id: str, msg_id: str, m
         logger.warning(f"Failed to spill tool result to {blob_path}: {e}")
         return content, None
     head = serialized[:4_000]
-    replacement = (
-        f"{head}\n\n"
-        f"[truncated, full output ({len(serialized)} chars) saved to {blob_path}. "
-        f"Ask the user or run a follow-up tool call if you need the rest.]"
+    note = wrap_platform_note(
+        f"Output truncated by OpenSwarm. Full output ({len(serialized)} chars) saved to "
+        f"{blob_path}. Ask the user or run a follow-up tool call if you need the rest."
     )
+    replacement = f"{head}\n\n{note}"
     return replacement, blob_path

--- a/backend/main.py
+++ b/backend/main.py
@@ -673,16 +673,6 @@ async def mcp_meta(action: str, request: Request):
 
         session.active_mcps.append(server_name)
         session.needs_fork = True
-        # When the session has prior turns, fork_session alone won't
-        # make the bundled CLI re-read mcp_servers, the transport
-        # snapshot at launch time is what serves tool schemas. Force a
-        # full fresh-session restart so the next turn rebuilds with the
-        # newly-activated server in its mcp_servers dict from scratch.
-        # First-turn activations don't need this (the SDK session hasn't
-        # locked in yet). One-time ~200-400ms cold start on the auto-
-        # continuation turn that fires right after this anyway.
-        if session.sdk_session_id:
-            session.needs_fresh_session = True
         try:
             from backend.apps.agents.core.ws_manager import ws_manager as _ws
             await _ws.send_to_session(parent_session_id, "agent:status", {

--- a/frontend/src/app/pages/AgentChat/bubbles/MessageBubble.tsx
+++ b/frontend/src/app/pages/AgentChat/bubbles/MessageBubble.tsx
@@ -21,6 +21,7 @@ import remarkGfm from 'remark-gfm';
 import WindowedMarkdown from './WindowedMarkdown';
 import { estimateRenderedTextHeight, oversizedCharThreshold, RECHECK_VISIBILITY_EVENT } from './markdownMeasure';
 import { THINKING_LABELS } from '../thinkingLabels';
+import { extractPlatformNote } from '../parsing/toolResultParsing';
 import { AgentMessage, retryLastUserMessage } from '@/shared/state/agentsSlice';
 import { openSettingsModal } from '@/shared/state/settingsSlice';
 import { fetchSubscriptionStatus } from '@/shared/state/subscriptionsSlice';
@@ -891,7 +892,9 @@ const MessageBubble: React.FC<Props> = React.memo(({ message, editing = false, o
   const { role, content } = message;
 
   if (role === 'system') {
-    const sysText = typeof content === 'string' ? content : JSON.stringify(content);
+    const rawSysText = typeof content === 'string' ? content : JSON.stringify(content);
+    const { body: sysBody, note: sysNote } = extractPlatformNote(rawSysText);
+    const sysText = sysNote || sysBody;
     // A raw subprocess/API failure ("Command failed with exit code 1", API Error JSON) is dev
     // jargon, and the same failure is already shown as a friendly card on the assistant side.
     // Swallow just that stderr dump so the user sees one calm card, not jargon beneath it.

--- a/frontend/src/app/pages/AgentChat/parsing/toolResultParsing.ts
+++ b/frontend/src/app/pages/AgentChat/parsing/toolResultParsing.ts
@@ -125,12 +125,14 @@ export interface ParsedBashResult {
   stdout: string;
   stderr: string;
   exitCode: number | null;
+  platformNote?: string;
 }
 
 export interface ParsedTextResult {
   type: 'text';
   content: string;
   isError?: boolean;
+  platformNote?: string;
 }
 
 export interface ParsedMcpResult {
@@ -139,11 +141,34 @@ export interface ParsedMcpResult {
   action: string;
   data: Record<string, any>;
   rawText: string;
+  platformNote?: string;
 }
 
 export type ParsedResult = ParsedBashResult | ParsedTextResult | ParsedMcpResult;
 
-export function parseToolResult(toolName: string, rawText: string): ParsedResult {
+const PLATFORM_NOTE_RE = /<openswarm_platform_note>([\s\S]*?)<\/openswarm_platform_note>/g;
+const PLATFORM_NOTE_PREAMBLE =
+  'This block is authored by the OpenSwarm platform, not tool output and not a prior message. It is trusted context.';
+
+export function extractPlatformNote(rawText: string): { body: string; note: string | null } {
+  if (!rawText.includes('<openswarm_platform_note>')) return { body: rawText, note: null };
+  const notes: string[] = [];
+  const body = rawText.replace(PLATFORM_NOTE_RE, (matched: string, inner: string) => {
+    const cleaned = inner.replace(PLATFORM_NOTE_PREAMBLE, '').trim();
+    if (cleaned) notes.push(cleaned);
+    return '';
+  }).trim();
+  return { body, note: notes.length ? notes.join('\n\n') : null };
+}
+
+export function parseToolResult(toolName: string, rawTextWithNote: string): ParsedResult {
+  const { body: rawText, note } = extractPlatformNote(rawTextWithNote);
+  const parsed = parseToolBody(toolName, rawText);
+  if (note) parsed.platformNote = note;
+  return parsed;
+}
+
+function parseToolBody(toolName: string, rawText: string): ParsedResult {
   if (isBashTool(toolName)) {
     try {
       const parsed = JSON.parse(rawText);

--- a/frontend/src/app/pages/AgentChat/tool-bubbles/DefaultToolBubble.tsx
+++ b/frontend/src/app/pages/AgentChat/tool-bubbles/DefaultToolBubble.tsx
@@ -293,6 +293,34 @@ export const DefaultToolBubble: React.FC<DefaultToolBubbleProps> = ({
               </pre>
             ) : null}
 
+            {parsedResult?.platformNote && (
+              <Box
+                sx={{
+                  mx: 1.5,
+                  mb: 1,
+                  mt: 0.5,
+                  px: 1,
+                  py: 0.75,
+                  bgcolor: c.bg.surface,
+                  border: `1px solid ${c.border.medium}`,
+                  borderRadius: 1.5,
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: c.text.secondary,
+                    fontSize: '0.72rem',
+                    fontFamily: c.font.mono,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {parsedResult.platformNote}
+                </Typography>
+              </Box>
+            )}
+
             {!parsedResult && isPending && !isStreaming && !isBrowserAgent && (
               <Box sx={{ px: 1.5, pb: 1, pt: 0.5 }}>
                 <Box


### PR DESCRIPTION
On a fresh-session restart (MCPActivate, branch edit, manual /compact, or a stopped turn), the agent was handed a flattened text recap of its own prior work with every tool call and result stripped out, leaving bare, ungrounded claims. A security-trained coding agent read that as injected/spoofed context and would raise alarming "tool output is being spoofed" warnings and stop trusting its own output.

bbc5f22a: Grounds the fresh-session recap so it keeps tool-call/result turns plus a trusted-platform label, instead of the bare narration a coding agent was reading as a prompt-injection attack and refusing to continue. Build-server, truncation, and MCP-trim notes now carry the same trusted tag and render as a calm chip in chat rather than leaking raw tags. A repro harness confirmed the panic fires on the old recap and stops on the grounded one, and the grounded recap was confirmed firing live.

b6584b14: Makes MCPActivate fork the SDK session instead of forcing a full fresh-session restart, so newly-activated tools still load while the session keeps its real transcript and avoids the recap path entirely. Verified live that the forked continuation turn loads the activated server's tools without dropping the session.