### PR TITLE
[aidan] fix/browser: keep webview UA product token so Google sign-in works

### DIFF
--- a/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
+++ b/frontend/src/app/pages/Dashboard/cards/BrowserCard.tsx
@@ -122,9 +122,9 @@ function markWindowsWebviewSurvived(): void {
 const isWindows = navigator.userAgent.includes('Windows');
 const isElectron = navigator.userAgent.includes('Electron') && (!isWindows || windowsWebviewEnabled());
 
+// Keep the openswarm/<ver> product token: Google's sign-in flags a BARE Chrome UA as not-genuine-Chrome and blocks it ("browser may not be secure"), but tolerates a UA carrying a product token. Only the Electron token must go (that one Google hard-blocks).
 const chromeUserAgent = navigator.userAgent
-  .replace(/\s*Electron\/\S+/i, '')
-  .replace(/\s*openswarm\/\S+/i, '');
+  .replace(/\s*Electron\/\S+/i, '');
 
 // Persistent partition so browser-card logins/cookies/localStorage outlive a reload or quit. MUST match BROWSER_PARTITION in electron/main.js, which configures permissions + iframe header-strip on this exact partition.
 const BROWSER_PARTITION = 'persist:openswarm-browser';


### PR DESCRIPTION
e7800a8a: Strips only the Electron token from the in-app browser webview's User-Agent and keeps the openswarm/<version> product token. A bare Chrome UA was being flagged by Google's sign-in as not-genuine-Chrome and rejected with "browser or app may not be secure"