### PR TITLE
[pierre] fix: surface app terminal + console errors to the App Builder

### DIFF
--- a/backend/apps/agents/manager/prompt/compose_turn_system_prompt.py
+++ b/backend/apps/agents/manager/prompt/compose_turn_system_prompt.py
@@ -12,6 +12,7 @@ from typeguard import typechecked
 from backend.apps.agents.core.models import AgentSession
 from backend.apps.agents.manager.prompt.tool_catalog import get_all_tool_names
 from backend.apps.agents.manager.prompt.prompt_context import (
+    build_app_runtime_contract,
     build_browser_context,
     build_installed_skills_catalog,
     build_mcp_registry_summary,
@@ -73,6 +74,9 @@ def compose_turn_system_prompt(
         from backend.apps.outputs.view_builder_templates import load_app_builder_skill
         skill_block = f"<app_builder_reference>\n{load_app_builder_skill()}\n</app_builder_reference>"
         composed_prompt = f"{composed_prompt}\n\n{skill_block}" if composed_prompt else skill_block
+        # Appended AFTER the reference, and never sourced from it: the skill is a user-editable file seeded once per install, so a stale or edited copy silently drops whatever it omits. Platform mechanics have to reach the agent regardless of what that file says.
+        contract_block = build_app_runtime_contract(session.cwd)
+        composed_prompt = f"{composed_prompt}\n\n{contract_block}"
     else:
         # Every other mode gets one line of discovery instead of the whole reference: CreateApp's result carries the reference when actually used, so the base prompt stays cheap.
         apps_note = (

--- a/backend/apps/agents/manager/prompt/prompt_context.py
+++ b/backend/apps/agents/manager/prompt/prompt_context.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable, Dict, List, Optional, Tuple
 
 from typeguard import typechecked
@@ -193,6 +194,37 @@ def build_selected_app_context(selected_app_output_ids: Optional[List[str]]) -> 
         "dedicated agent drives the live app through its own actions, no editing.\n\n"
         + "\n\n".join(entries)
         + "\n</selected_app_context>"
+    )
+
+
+@typechecked
+def build_app_runtime_contract(workspace_path: Optional[str]) -> str:
+    """The non-negotiable runtime mechanics for an App Builder turn: where the app's
+    terminal lives, how to restart it, and the requirement to read it before claiming
+    a change works. Deliberately NOT sourced from the App Builder skill file, which is
+    seeded once per install and never overwritten, so an install that predates a skill
+    update (or a user who edits the guidance out) would otherwise never see any of this."""
+    root = workspace_path or "."
+    log = os.path.join(root, ".openswarm", "terminal.log")
+    return (
+        "<app_runtime_contract>\n"
+        "Your app is already running. Its terminal — backend stdout/stderr, runtime events, and the\n"
+        "browser console — is tee'd to a file you can read directly. This is the ONLY way you can see\n"
+        "what the app actually does; editing files tells you nothing about whether it runs.\n\n"
+        "Read it with exactly this, every time:\n\n"
+        f'    tail -50 {log} 2>/dev/null || echo "Terminal log not yet available"\n\n'
+        "Lines are prefixed [BACKEND], [BACKEND:stderr], [RUNTIME], [FRONTEND], [FRONTEND:warn],\n"
+        "[FRONTEND:error]. Grep it for `error` when it is long. If this app is open in more than one\n"
+        "dashboard card, the extra cards log to terminal-2.log, terminal-3.log, and so on.\n\n"
+        "Rules, not suggestions:\n"
+        "- Read the terminal after every batch of writes. Fix what it reports before moving on.\n"
+        f"- Read it again before you tell the user anything is done. `bash {os.path.join(root, 'restart.sh')}` restarts the\n"
+        "  runtime; do that after installing packages or changing backend startup, then read the log to\n"
+        "  confirm a clean boot. The file resets on every start.\n"
+        "- \"Terminal log not yet available\" means the runtime never started. That is a problem to fix,\n"
+        "  not a reason to skip the check.\n"
+        "- Never claim the app works when you have not read the terminal. If you did not check, say so.\n"
+        "</app_runtime_contract>"
     )
 
 

--- a/backend/apps/agents/manager/streaming/post_tool_hook.py
+++ b/backend/apps/agents/manager/streaming/post_tool_hook.py
@@ -111,22 +111,27 @@ async def post_tool_hook(ctx: HookContext, input_data: dict, tool_use_id, contex
                 })
             except Exception:
                 pass
-    elif wrote_files:
-        if file_path:
-            try:
-                await asyncio.sleep(0.4)
-                from backend.apps.outputs.runtime import (
-                    manager as outputs_runtime_manager,
-                )
-                errs = outputs_runtime_manager.drain_errors_for_path(file_path)
-            except Exception:
-                errs = []
-            if errs:
-                joined = "\n".join(errs[-20:])
-                content = (
-                    f"{content}\n\n"
-                    + wrap_platform_note(f"Build server reported (after this write):\n{joined}")
-                )
+    # Every write drains, App Builder included. This was an `elif` on the branch above, so a view-builder frontend write took that branch and skipped the drain: the one agent whose whole job is the app never saw its own vite/babel/tsc errors.
+    if wrote_files and file_path:
+        errs: list[str] = []
+        console_errs: list[str] = []
+        try:
+            # Give vite/uvicorn a beat to actually emit whatever this write broke.
+            await asyncio.sleep(0.4)
+            from backend.apps.outputs.runtime import (
+                manager as outputs_runtime_manager,
+            )
+            errs = outputs_runtime_manager.drain_errors_for_path(file_path)
+            console_errs = outputs_runtime_manager.drain_frontend_errors_for_path(file_path)
+        except Exception:
+            pass
+        notes = []
+        if errs:
+            notes.append("Build server reported (after this write):\n" + "\n".join(errs[-20:]))
+        if console_errs:
+            notes.append("The app's console logged (after this write):\n" + "\n".join(console_errs[-10:]))
+        if notes:
+            content = f"{content}\n\n" + wrap_platform_note("\n\n".join(notes))
 
     result_payload = {"text": content}
     hook_tool_name = input_data.get("tool_name", "")

--- a/backend/apps/outputs/runtime.py
+++ b/backend/apps/outputs/runtime.py
@@ -118,6 +118,8 @@ class AppRuntime:
         self.p_subscribers: set[LogSubscriber] = set()
         # Recent build/runtime errors scraped from stderr; drained by the agent's post-tool hook after Write/Edit so the agent sees vite/babel/uvicorn errors in its next turn and can self-fix instead of leaving the user with a red iframe overlay.
         self.recent_errors: deque[str] = deque(maxlen=RECENT_ERRORS_MAX)
+        # Webview console.error lines, drained alongside recent_errors: a clean build still leaves runtime TypeErrors that only the browser sees.
+        self.p_frontend_errors: deque[str] = deque(maxlen=RECENT_ERRORS_MAX)
         self.render_state: Optional[str] = None
         self.render_error_text: str = ""
         self.p_stdout_task: Optional[asyncio.Task] = None
@@ -132,6 +134,12 @@ class AppRuntime:
         into the agent's context immediately after a file write."""
         out = list(self.recent_errors)
         self.recent_errors.clear()
+        return out
+
+    def drain_frontend_errors(self) -> list[str]:
+        """Pop the app's console.error lines, for the same post-write note as drain_errors()."""
+        out = list(self.p_frontend_errors)
+        self.p_frontend_errors.clear()
         return out
 
     def set_render_ok(self) -> None:
@@ -486,6 +494,9 @@ class AppRuntime:
     def record_frontend_log(self, level: str, text: str) -> None:
         """Fold a webview console line into the terminal stream (ring buffer, WS subscribers, terminal.log). Called by the console-log beacon endpoint."""
         stream = {"warn": "frontend-warn", "error": "frontend-error"}.get(level, "frontend")
+        # The app-ready/app-error beacons ride this same console channel but already drive render_state via the report-* endpoints; re-capturing them would duplicate render_error_text into the agent's note.
+        if stream == "frontend-error" and "[openswarm:app-" not in text:
+            self.p_frontend_errors.append(text.rstrip())
         self.p_broadcast(LogLine(stream, text))
 
     def p_reset_terminal_log(self) -> None:
@@ -690,13 +701,8 @@ class AppRuntimeManager:
             return rt
         return self.idle_lru.get(key)
 
-    def drain_errors_for_path(self, file_path: str) -> list[str]:
-        """If `file_path` falls under one of the live workspace
-        runtimes' workspace_path, drain that workspace's recent
-        build/runtime errors. Returns [] if no workspace owns the path
-        or no errors are queued; caller can treat empty as 'all clear'.
-        Used by agent_manager's post-tool hook so the agent sees vite /
-        babel / uvicorn errors right after a Write/Edit completes."""
+    def p_runtimes_owning(self, file_path: str) -> list[AppRuntime]:
+        """Every runtime whose workspace contains `file_path`, or [] if none does."""
         if not file_path:
             return []
         try:
@@ -704,14 +710,33 @@ class AppRuntimeManager:
         except Exception:
             return []
         # Walk both active and idle runtimes; the user might have navigated away from the workspace mid-build, but the agent could still be editing files; the LRU keeps the runtime alive for ~3 idle slots. Aggregate across instances: with two cards of the same app open, either instance's build errors matter to the agent.
-        drained: list[str] = []
+        owning: list[AppRuntime] = []
         for rt in (*self.runtimes.values(), *self.idle_lru.values()):
             try:
                 ws_root = os.path.abspath(rt.workspace_path)
             except Exception:
                 continue
             if abs_path == ws_root or abs_path.startswith(ws_root + os.sep):
-                drained.extend(rt.drain_errors())
+                owning.append(rt)
+        return owning
+
+    def drain_errors_for_path(self, file_path: str) -> list[str]:
+        """If `file_path` falls under one of the live workspace
+        runtimes' workspace_path, drain that workspace's recent
+        build/runtime errors. Returns [] if no workspace owns the path
+        or no errors are queued; caller can treat empty as 'all clear'.
+        Used by agent_manager's post-tool hook so the agent sees vite /
+        babel / uvicorn errors right after a Write/Edit completes."""
+        drained: list[str] = []
+        for rt in self.p_runtimes_owning(file_path):
+            drained.extend(rt.drain_errors())
+        return drained
+
+    def drain_frontend_errors_for_path(self, file_path: str) -> list[str]:
+        """The app's console.error lines, for the same post-write note as drain_errors_for_path."""
+        drained: list[str] = []
+        for rt in self.p_runtimes_owning(file_path):
+            drained.extend(rt.drain_frontend_errors())
         return drained
 
     def get_render_state_for_workspace(self, workspace_id: str) -> tuple[Optional[str], str]:

--- a/backend/apps/skills/skills.py
+++ b/backend/apps/skills/skills.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 import json
 import logging
 import re
@@ -106,34 +107,63 @@ def p_built_in_skill_registry() -> list[dict]:
     ]
 
 
-def p_seed_built_in_skills() -> None:
-    """Copy each built-in skill into SKILLS_DIR if not already present, and
-    ensure the index has the `built_in: true` flag so the UI and DELETE
-    endpoint know to treat it specially. Idempotent; safe to call on
-    every boot. Doesn't overwrite the file once it exists (so user edits
-    are preserved across restarts and upgrades)."""
+def p_content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def seed_built_in_skills() -> None:
+    """Copy each built-in skill into SKILLS_DIR and keep an *unedited* copy in sync
+    with the bundled source across upgrades. Idempotent; safe on every boot.
+
+    `seeded_hash` in the index records the bytes we last wrote. A file still hashing
+    to it was never edited, so a newer bundle replaces it; a file that diverges is a
+    user edit and is left alone. Installs predating `seeded_hash` can't be told apart
+    from an edit, so we only claim provenance when the bytes already match the bundle
+    -- otherwise they stay untracked and frozen, since silently clobbering a real edit
+    is the worse failure. Before this, seeding was create-if-absent, so every install
+    was pinned forever to whatever shipped the day it first booted."""
     index = load_index()
     dirty = False
     for entry in p_built_in_skill_registry():
         skill_id = entry["id"]
         fpath = os.path.join(SKILLS_DIR, f"{skill_id}.md")
-        if not os.path.exists(fpath):
+        try:
+            with open(entry["source_path"], encoding="utf-8") as src:
+                bundled = src.read()
+        except OSError:
+            logger.warning("built-in skill source missing: %s", entry["source_path"])
+            continue
+        current = None
+        if os.path.exists(fpath):
             try:
-                with open(entry["source_path"], encoding="utf-8") as src:
-                    content = src.read()
-                with open(fpath, "w", encoding="utf-8") as dst:
-                    dst.write(content)
-            except FileNotFoundError:
-                logger.warning("built-in skill source missing: %s", entry["source_path"])
+                with open(fpath, encoding="utf-8") as f:
+                    current = f.read()
+            except OSError:
+                logger.warning("built-in skill unreadable, leaving as-is: %s", fpath, exc_info=True)
                 continue
-        # Refresh index metadata. Existing user-changed name/description in the index stays, but built_in always gets re-asserted in case the index was created before this mechanism existed.
         meta = dict(index.get(skill_id, {}))
+        seeded_hash = meta.get("seeded_hash")
+        if current is None or (seeded_hash and p_content_hash(current) == seeded_hash):
+            # Absent, or byte-identical to what we last seeded: no user edit to lose.
+            if current != bundled:
+                try:
+                    os.makedirs(SKILLS_DIR, exist_ok=True)
+                    with open(fpath, "w", encoding="utf-8") as dst:
+                        dst.write(bundled)
+                except OSError:
+                    logger.warning("built-in skill write failed: %s", fpath, exc_info=True)
+                    continue
+            meta["seeded_hash"] = p_content_hash(bundled)
+        elif not seeded_hash and current == bundled:
+            # Untracked but already in sync; safe to adopt so the NEXT upgrade can move it.
+            meta["seeded_hash"] = p_content_hash(bundled)
+        # Anything else is a user edit, or an untracked install indistinguishable from one: leave both the file and its (absent) provenance alone so we never overwrite it.
+        # Refresh index metadata. Existing user-changed name/description in the index stays, but built_in always gets re-asserted in case the index was created before this mechanism existed.
         meta.setdefault("name", entry["name"])
         meta.setdefault("description", entry["description"])
         meta.setdefault("command", entry["command"])
         if not meta.get("built_in"):
             meta["built_in"] = True
-            dirty = True
         if index.get(skill_id) != meta:
             index[skill_id] = meta
             dirty = True
@@ -156,7 +186,7 @@ async def skills_lifespan():
     os.makedirs(SKILLS_DIR, exist_ok=True)
     os.makedirs(SKILLS_WORKSPACE_DIR, exist_ok=True)
     try:
-        p_seed_built_in_skills()
+        seed_built_in_skills()
         p_prune_orphan_index()
     except Exception:
         # Don't block app startup on a skill-seed failure; the worst case is the user has to manually paste the skill in once.

--- a/backend/tests/test_builtin_skill_upgrade.py
+++ b/backend/tests/test_builtin_skill_upgrade.py
@@ -1,0 +1,90 @@
+"""Built-in skills must follow the bundled source across upgrades unless the user edited them.
+
+Seeding used to be create-if-absent, which pinned every install to whatever shipped the day it
+first booted: the App Builder agent's prompt kept a months-old skill and so never learned that
+`.openswarm/terminal.log` existed. `seeded_hash` records the bytes we last wrote so an untouched
+file can be safely replaced, while a real edit (or an untracked pre-existing install) is left alone.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import backend.apps.skills.skills as skills_mod
+
+
+@pytest.fixture
+def seeded(tmp_path, monkeypatch):
+    """A stubbed SKILLS_DIR plus a one-entry built-in registry pointing at a bundle we control."""
+    d = tmp_path / "skills"
+    d.mkdir()
+    monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(d))
+    monkeypatch.setattr(skills_mod, "INDEX_PATH", str(d / ".skills_index.json"))
+    source = tmp_path / "bundled.md"
+    source.write_text("v1 bundled", encoding="utf-8")
+
+    def p_registry():
+        return [{
+            "id": "app_builder_skill",
+            "name": "App Builder",
+            "description": "d",
+            "command": "app-builder-skill",
+            "source_path": str(source),
+        }]
+
+    # String-literal setattr: p_built_in_skill_registry stays file-private under the p-private rule.
+    monkeypatch.setattr(skills_mod, "p_built_in_skill_registry", p_registry)
+    return d, source
+
+
+def p_skill(d):
+    return os.path.join(str(d), "app_builder_skill.md")
+
+
+def p_read(d):
+    return open(p_skill(d), encoding="utf-8").read()
+
+
+def test_unedited_copy_upgrades_when_the_bundle_changes(seeded):
+    d, source = seeded
+    skills_mod.seed_built_in_skills()
+    source.write_text("v2 bundled with terminal.log", encoding="utf-8")
+    skills_mod.seed_built_in_skills()
+    assert p_read(d) == "v2 bundled with terminal.log"
+
+
+def test_user_edit_is_preserved_across_a_bundle_bump(seeded):
+    d, source = seeded
+    skills_mod.seed_built_in_skills()
+    with open(p_skill(d), "w", encoding="utf-8") as f:
+        f.write("my own house rules")
+    source.write_text("v2 bundled", encoding="utf-8")
+    skills_mod.seed_built_in_skills()
+    assert p_read(d) == "my own house rules"
+
+
+def test_second_boot_does_not_clobber_a_preserved_edit(seeded):
+    # Regression: adopting the *current* bytes as provenance would make the next boot treat a real edit as unedited.
+    d, source = seeded
+    skills_mod.seed_built_in_skills()
+    with open(p_skill(d), "w", encoding="utf-8") as f:
+        f.write("my own house rules")
+    source.write_text("v2 bundled", encoding="utf-8")
+    skills_mod.seed_built_in_skills()
+    skills_mod.seed_built_in_skills()
+    assert p_read(d) == "my own house rules"
+
+
+def test_untracked_stale_install_is_never_clobbered(seeded):
+    # The real-world bug: a file seeded before seeded_hash existed. Indistinguishable from an edit, so leave it.
+    d, source = seeded
+    with open(p_skill(d), "w", encoding="utf-8") as f:
+        f.write("stale bundle from an old install")
+    source.write_text("v2 bundled", encoding="utf-8")
+    skills_mod.seed_built_in_skills()
+    assert p_read(d) == "stale bundle from an old install"
+    with open(d / ".skills_index.json", encoding="utf-8") as f:
+        assert "seeded_hash" not in json.load(f)["app_builder_skill"]

--- a/backend/tests/test_runtime_frontend_errors.py
+++ b/backend/tests/test_runtime_frontend_errors.py
@@ -1,0 +1,56 @@
+"""The app's webview console.error lines, captured so the agent's post-tool hook can show them
+alongside vite/uvicorn build errors. A clean build still leaves runtime TypeErrors that only the
+browser ever sees; before this the agent was blind to them."""
+
+import pytest
+
+from backend.apps.outputs.runtime import AppRuntime, AppRuntimeManager
+
+P_TYPE_ERROR = "TypeError: cards.map is not a function"
+
+
+def p_runtime(workspace_path: str) -> AppRuntime:
+    return AppRuntime(workspace_id="ws1", workspace_path=workspace_path, instance=1)
+
+
+def test_console_error_is_captured_and_drained_once(tmp_path):
+    rt = p_runtime(str(tmp_path))
+    rt.record_frontend_log("error", P_TYPE_ERROR)
+    assert rt.drain_frontend_errors() == [P_TYPE_ERROR]
+    assert rt.drain_frontend_errors() == []
+
+
+def test_console_log_and_warn_are_not_captured(tmp_path):
+    rt = p_runtime(str(tmp_path))
+    rt.record_frontend_log("log", "mounted")
+    rt.record_frontend_log("warn", "deprecated prop")
+    assert rt.drain_frontend_errors() == []
+
+
+def test_render_beacons_are_not_captured_as_console_errors(tmp_path):
+    """app-error rides the same console.error channel but already drives render_state via the
+    report-* endpoints; capturing it would duplicate render_error_text into the agent's note."""
+    rt = p_runtime(str(tmp_path))
+    rt.record_frontend_log("error", "[openswarm:app-error] Boom at App.tsx:12")
+    assert rt.drain_frontend_errors() == []
+
+
+def test_console_errors_do_not_leak_into_the_build_error_queue(tmp_path):
+    """Separate queues: drain_errors() is the process stderr scrape, and its ERROR_PATTERNS
+    filter never sees console lines."""
+    rt = p_runtime(str(tmp_path))
+    rt.record_frontend_log("error", P_TYPE_ERROR)
+    assert rt.drain_errors() == []
+
+
+@pytest.mark.asyncio
+async def test_drain_frontend_errors_for_path_finds_the_owning_workspace(tmp_path, monkeypatch):
+    async def p_fake_start(self):
+        return True
+    monkeypatch.setattr(AppRuntime, "start", p_fake_start)
+    mgr = AppRuntimeManager()
+    rt = await mgr.attach("ws1", str(tmp_path), 1)
+    rt.record_frontend_log("error", P_TYPE_ERROR)
+    written = str(tmp_path / "frontend" / "src" / "App.tsx")
+    assert mgr.drain_frontend_errors_for_path(written) == [P_TYPE_ERROR]
+    assert mgr.drain_frontend_errors_for_path("/somewhere/else/main.py") == []

--- a/backend/tests/test_tool_result_hook.py
+++ b/backend/tests/test_tool_result_hook.py
@@ -4,11 +4,12 @@ behavior directly: a tool result becomes a tool_result message, and an Agent too
 sub-session into the manager's LIVE registry (the InstanceOf[dict] sharing, the subtle bit)."""
 
 import pytest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 from backend.apps.agents.core.models import AgentSession
 from backend.apps.agents.manager.streaming.HookContext import HookContext
 from backend.apps.agents.manager.streaming import post_tool_hook as tool_result_hook
+from backend.apps.agents.manager import view_builder_state
 
 
 def p_ctx(registry: dict) -> HookContext:
@@ -97,3 +98,58 @@ async def test_view_builder_plain_write_does_not_flag_deps_changed():
         )
     events = [c.args[1] for c in send.await_args_list]
     assert "agent:app_deps_changed" not in events
+
+
+def p_app_manager(build_errors=(), console_errors=()) -> MagicMock:
+    fake = MagicMock()
+    fake.drain_errors_for_path.return_value = list(build_errors)
+    fake.drain_frontend_errors_for_path.return_value = list(console_errors)
+    return fake
+
+
+async def p_write(ctx, fake_manager, file_path="/ws/frontend/src/App.tsx") -> str:
+    with patch.object(tool_result_hook.ws_manager, "send_to_session", new=AsyncMock()), \
+         patch("backend.apps.outputs.runtime.manager", fake_manager):
+        await tool_result_hook.post_tool_hook(
+            ctx, {"tool_name": "Write", "tool_response": "ok",
+                  "tool_input": {"file_path": file_path, "content": "x"}}, "tu1", None
+        )
+    view_builder_state.view_builder_dirty_sessions.discard(ctx.session_id)
+    return str(ctx.session.messages[-1].content)
+
+
+@pytest.mark.asyncio
+async def test_view_builder_write_surfaces_build_errors_into_the_tool_result():
+    """Regression: this drain sat behind an `elif` on the view-builder reload branch, so a
+    frontend write took that branch instead -- the App Builder was the one agent that never
+    saw its own vite/babel/tsc errors after a write."""
+    ctx = p_ctx({})
+    ctx.session.mode = "view-builder"
+    body = await p_write(ctx, p_app_manager(build_errors=["[plugin:vite] SyntaxError: Unexpected token"]))
+    assert "Build server reported" in body
+    assert "SyntaxError" in body
+
+
+@pytest.mark.asyncio
+async def test_write_surfaces_app_console_errors_as_a_separate_note():
+    ctx = p_ctx({})
+    ctx.session.mode = "view-builder"
+    body = await p_write(ctx, p_app_manager(console_errors=["TypeError: x is not a function"]))
+    assert "The app's console logged" in body
+    assert "TypeError: x is not a function" in body
+
+
+@pytest.mark.asyncio
+async def test_createapp_write_from_another_mode_still_surfaces_errors():
+    """An agent in normal chat mode editing an app it made with CreateApp gets the same feedback."""
+    ctx = p_ctx({})  # default mode, not view-builder
+    body = await p_write(ctx, p_app_manager(build_errors=["Traceback (most recent call last)"]))
+    assert "Traceback" in body
+
+
+@pytest.mark.asyncio
+async def test_write_outside_any_app_workspace_adds_no_note():
+    ctx = p_ctx({})
+    body = await p_write(ctx, p_app_manager(), file_path="/some/other/repo/main.py")
+    assert "Build server reported" not in body
+    assert "The app's console logged" not in body


### PR DESCRIPTION
The post-write error drain sat behind an `elif` on the view-builder reload branch, so a frontend write took that branch and skipped the drain entirely — the App Builder, the one agent whose whole job is the app, never saw its own vite/babel/tsc errors after a write. Split it into its own `if` so every write drains.

Also captures the webview's `console.error` lines into their own queue and appends them as a second note, so runtime `TypeError`s that a clean build can't catch reach the agent too. The `app-ready`/`app-error` beacons are filtered out — they already drive `render_error_text` via the `report-*` endpoints, and would otherwise show up twice.

Verified with the full backend suite (1722 passed, 5 skipped) plus 4 new hook tests and a new `test_runtime_frontend_errors.py` covering the drain, the beacon filter, queue separation, and path ownership. `no-underscore-names` and `p-private` are clean.

---

**Follow-up (`b40cb79`): make sure existing installs actually get this**

The drain above only helps if the App Builder's prompt knows the terminal log exists — but built-in skills were seeded create-if-absent, pinning every install to whatever shipped the day it first booted. An install predating the `terminal.log` guidance would never learn it. Two prongs:

- `seed_built_in_skills` now records a `seeded_hash` of the bytes it last wrote. A file still matching that hash was never touched, so a newer bundle replaces it; a diverged file is a real user edit and is left alone. Installs predating `seeded_hash` are adopted only when already byte-identical to the bundle, since an untracked stale file is indistinguishable from an edit and clobbering a real edit is the worse failure.
- `build_app_runtime_contract` injects the non-negotiable mechanics — where the terminal log lives, how to restart, read-before-claiming-done — into every App Builder turn, appended after the skill reference and deliberately not sourced from it, so platform mechanics reach the agent even when the skill file is stale or edited out.

New `test_builtin_skill_upgrade.py` covers the upgrade, edit-preservation, the second-boot re-clobber regression, and the untracked-stale-install case.
