### PR TITLE
[pierre] fix: soften the camera glide when a card is framed

### DIFF
--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
@@ -9,6 +9,10 @@ const MAX_ZOOM = 3.0;
 const ZOOM_IN_FACTOR = 1.1;
 const ZOOM_OUT_FACTOR = 1 / ZOOM_IN_FACTOR;
 const FIT_PADDING = 200;
+// Framing a card (spawn, click-to-focus, arrow-nav) glides longer than a zoom button press so the camera reads as gliding rather than snapping.
+const FIT_DURATION = 560;
+// Must outlast FIT_DURATION, else the settle snap lands mid-glide and stutters.
+const FIT_SETTLE_DELAY = FIT_DURATION + 60;
 
 // Maps the 1 to 100 user setting to an internal multiplier (50 default = 0.004).
 function sensitivityToMultiplier(setting: number): number {
@@ -156,7 +160,8 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
 
     const step = (now: number) => {
       const t = Math.min((now - startTime) / duration, 1);
-      const ease = 1 - Math.pow(1 - t, 3); // cubic ease-out
+      // Cubic ease-in-out: ease-out alone starts at full speed, which reads as a jerk on long camera moves.
+      const ease = t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
       setState({
         panX: start.panX + (target.panX - start.panX) * ease,
         panY: start.panY + (target.panY - start.panY) * ease,
@@ -651,7 +656,7 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
         const dPan = Math.abs(cur.panX - target.panX) + Math.abs(cur.panY - target.panY);
         const dZoom = Math.abs(cur.zoom - target.zoom);
         if (dPan < 5 && dZoom < 0.01) return;
-        animateTo(target);
+        animateTo(target, FIT_DURATION);
         // Settle pass: cancelAnimation() must be able to cancel it, else back-to-back fitToCards races and the first settle overwrites the second target.
         settleTimerRef.current = window.setTimeout(() => {
           settleTimerRef.current = null;
@@ -663,7 +668,7 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
             Math.abs(cur2.panY - fresh.panY) +
             Math.abs(cur2.zoom - fresh.zoom) * 1000;
           if (drift > 8) setState(fresh);
-        }, 370);
+        }, FIT_SETTLE_DELAY);
       } else {
         setState(target);
       }


### PR DESCRIPTION
## Problem

Spawning a chat, browser, app, or note snapped the camera onto the new card. Every spawn path funnels through `fitToCards()` in `useCanvasControls.ts`, which animated for **320ms on a pure cubic ease-out** — so the move started at full velocity and read as a lurch rather than a glide.

## Fix

Three changes, all in `frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts`:

- **Card-framing gets its own `FIT_DURATION` (560ms)** instead of riding `animateTo`'s 320ms default. Keeping it separate means the zoom-in/zoom-out buttons (150ms) and the pan spring-back (250ms) stay as snappy as they were.
- **Easing is now cubic ease-in-out.** This is the bigger half of "softer": ease-out alone starts at full speed, so the first frame jumped. Ease-in-out ramps up as well as down, so there's no hard edge at either end of the move.
- **The settle pass moves from 370ms to `FIT_DURATION + 60`.** That timer re-snaps the camera if the viewport rect drifted mid-animation (sidebar collapse, route switch); left at 370ms it would now fire *during* the glide and visibly stutter, so it has to stay behind the animation.

## Scope note

`fitToCards` is shared, so click-to-focus, arrow-key nav, and minimap jumps get the same gentler glide. That reads as consistent to me rather than as a regression, but it's worth a look — if only spawns should slow down, the duration can be threaded through as a parameter instead.

## Testing

`tsc --noEmit` clean. **Not yet exercised in the running app** — 560ms is a taste call and wants an eyeball on a real spawn before merge; easy to nudge either way.