### PR TITLE
[pierre] feat: plain scroll zooms canvas, cmd/ctrl+scroll pans vertically

### DIFF
--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
@@ -175,7 +175,7 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
 
   animateToRef.current = animateTo;
 
-  // Plain wheel zooms at the viewport center; cmd/ctrl+wheel and trackpad pinch zoom at the cursor.
+  // Plain wheel zooms at the viewport center; cmd/ctrl+wheel pans vertically; trackpad pinch zooms at the cursor.
   useEffect(() => {
     const el = viewportRef.current;
     if (!el || !enabled) return;  // Skip wheel listener when canvas is hidden
@@ -233,8 +233,8 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
     const scrollableCache: WeakMap<HTMLElement, 'scrollable' | 'not'> = new WeakMap();
 
     const onWheel = (e: WheelEvent) => {
-      // Pinch-to-zoom on trackpads sets ctrlKey; plain scroll does not
-      const isPinchZoom = e.ctrlKey || e.metaKey;
+      // ctrl/cmd wheel is a modifier gesture: a real held key (cmd/ctrl + scroll → vertical pan) or a trackpad pinch, which also sets ctrlKey (→ zoom at cursor). Either way it bypasses scrollable children and acts on the canvas.
+      const isModifierWheel = e.ctrlKey || e.metaKey;
 
       // Let scrollable children handle the event when appropriate, but fall through to canvas pan if the child is at its scroll boundary.
       const dy = e.deltaMode === 1 ? e.deltaY * 40 : e.deltaY;
@@ -259,7 +259,7 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
           scrollableCache.set(target, cls);
         }
 
-        if (cls === 'scrollable' && !isPinchZoom) {
+        if (cls === 'scrollable' && !isModifierWheel) {
           // Re-read scrollHeight/clientHeight; cached decision is structural, scroll position is dynamic.
           const canScrollY = target.scrollHeight > target.clientHeight;
           const canScrollX = target.scrollWidth > target.clientWidth;
@@ -292,8 +292,12 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
         inertiaFrameRef.current = null;
       }
 
-      if (isPinchZoom) {
-        // Pinch / cmd+wheel → accumulate zoom deltas + last cursor position. factor = 2^(-Σdy·s) which equals the product of per-event factors, so accumulating dy is mathematically identical to applying each event one at a time.
+      if (isModifierWheel && cmdRef.current) {
+        // Real cmd/ctrl physically held + scroll → vertical pan. cmdRef is set from a keydown; a trackpad pinch sets ctrlKey with no keydown, so it falls through to the zoom branch below and pinch-to-zoom survives.
+        pendingPanDy += dy;
+        scheduleWheelFlush();
+      } else if (isModifierWheel) {
+        // Trackpad pinch → accumulate zoom deltas + last cursor position. factor = 2^(-Σdy·s) which equals the product of per-event factors, so accumulating dy is mathematically identical to applying each event one at a time.
         const rect = el.getBoundingClientRect();
         pendingZoomDy += dy;
         pendingZoomCenter = { cx: e.clientX - rect.left, cy: e.clientY - rect.top };

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
@@ -173,7 +173,7 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
 
   animateToRef.current = animateTo;
 
-  // Wheel zoom centered on cursor
+  // Plain wheel zooms at the viewport center; cmd/ctrl+wheel and trackpad pinch zoom at the cursor.
   useEffect(() => {
     const el = viewportRef.current;
     if (!el || !enabled) return;  // Skip wheel listener when canvas is hidden
@@ -199,9 +199,10 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
           const factor = Math.pow(2, -zDy * sensitivityToMultiplier(sensitivityRef.current));
           const newZoom = clamp(prev.zoom * factor, MIN_ZOOM, MAX_ZOOM);
           const ratio = newZoom / prev.zoom;
+          // Apply any pan accumulated in the same frame too: a zoom and a pan can now land together (vertical zoom + horizontal pan across a RAF boundary, or a forwarded pan), and dropping it would swallow the gesture.
           return {
-            panX: zCenter.cx - (zCenter.cx - prev.panX) * ratio,
-            panY: zCenter.cy - (zCenter.cy - prev.panY) * ratio,
+            panX: zCenter.cx - (zCenter.cx - prev.panX) * ratio - dx,
+            panY: zCenter.cy - (zCenter.cy - prev.panY) * ratio - dy,
             zoom: newZoom,
           };
         });
@@ -290,15 +291,20 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
       }
 
       if (isPinchZoom) {
-        // Pinch gesture → accumulate zoom deltas + last cursor position. factor = 2^(-Σdy·s) which equals the product of per-event factors, so accumulating dy is mathematically identical to applying each event one at a time.
+        // Pinch / cmd+wheel → accumulate zoom deltas + last cursor position. factor = 2^(-Σdy·s) which equals the product of per-event factors, so accumulating dy is mathematically identical to applying each event one at a time.
         const rect = el.getBoundingClientRect();
         pendingZoomDy += dy;
         pendingZoomCenter = { cx: e.clientX - rect.left, cy: e.clientY - rect.top };
         scheduleWheelFlush();
-      } else {
-        // Two-finger scroll → accumulate pan deltas.
+      } else if (Math.abs(dx) > Math.abs(dy)) {
+        // Horizontal-dominant scroll → pan X; it's the only horizontal-pan gesture. Dominant-axis, so the vertical jitter in a sideways swipe doesn't also zoom.
         pendingPanDx += dx;
-        pendingPanDy += dy;
+        scheduleWheelFlush();
+      } else {
+        // Plain vertical scroll → zoom, anchored at the viewport center (same anchor as zoomIn/zoomOut), not the cursor.
+        const rect = el.getBoundingClientRect();
+        pendingZoomDy += dy;
+        pendingZoomCenter = { cx: rect.width / 2, cy: rect.height / 2 };
         scheduleWheelFlush();
       }
     };

--- a/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts
@@ -9,6 +9,8 @@ const MAX_ZOOM = 3.0;
 const ZOOM_IN_FACTOR = 1.1;
 const ZOOM_OUT_FACTOR = 1 / ZOOM_IN_FACTOR;
 const FIT_PADDING = 200;
+// A mouse notch lands as deltaY 100 where a trackpad sends ~1-10, so cap the per-event zoom delta: uncapped, one notch is a ~24% jump and macOS wheel acceleration stacks them. No-op for trackpads.
+const WHEEL_ZOOM_DELTA_CAP = 24;
 
 // Maps the 1 to 100 user setting to an internal multiplier (50 default = 0.004).
 function sensitivityToMultiplier(setting: number): number {
@@ -301,9 +303,9 @@ export function useCanvasControls(zoomSensitivity: number = 50, contentBounds?: 
         pendingPanDx += dx;
         scheduleWheelFlush();
       } else {
-        // Plain vertical scroll → zoom, anchored at the viewport center (same anchor as zoomIn/zoomOut), not the cursor.
+        // Plain vertical scroll → zoom, anchored at the viewport center (same anchor as zoomIn/zoomOut), not the cursor. Clamp the per-event delta so a discrete mouse notch is a small step, not a lurch.
         const rect = el.getBoundingClientRect();
-        pendingZoomDy += dy;
+        pendingZoomDy += clamp(dy, -WHEEL_ZOOM_DELTA_CAP, WHEEL_ZOOM_DELTA_CAP);
         pendingZoomCenter = { cx: rect.width / 2, cy: rect.height / 2 };
         scheduleWheelFlush();
       }


### PR DESCRIPTION
## What

Reworks the dashboard canvas wheel gestures so scrolling zooms by default.

- **Plain vertical wheel / two-finger scroll → zoom**, anchored at the **viewport center** (reusing the `zoomIn`/`zoomOut` anchor math), not the cursor. Replaces the old vertical-pan-on-scroll.
- **Horizontal-dominant scroll → pan X** (unchanged in spirit; this is shift+wheel and sideways two-finger swipes). Gated on the dominant axis so a diagonal swipe's vertical jitter doesn't also zoom.
- **cmd / ctrl + scroll → vertical pan** (up/down).
- **Trackpad pinch → zoom at the cursor** (unchanged).

Respects the existing `zoomSensitivity` setting and the `MIN_ZOOM`/`MAX_ZOOM` clamps. No new setting.

## Three commits, in dependency order

1. `pierre/scroll-to-zoom` — plain vertical wheel zooms at the viewport center; horizontal stays pan X. Includes a `flushWheel` fix to fold a same-frame pan into the zoom branch (a vertical zoom and a horizontal pan can now accumulate in one RAF tick).
2. `pierre/clamp-mouse-wheel-zoom` — clamp the per-event zoom delta to ±24. A mouse notch arrives as `deltaY: 100` vs a trackpad's ~1–10; uncapped that's a ~24% jump per notch and macOS wheel acceleration stacks them. No-op for trackpads, so the smooth pinch/scroll curve is unchanged.
3. `pierre/cmd-scroll-vertical-pan` — cmd/ctrl+scroll pans vertically. A trackpad pinch reports as a wheel with `ctrlKey` set, indistinguishable at the event level from a real Ctrl+wheel; gated on the physically-held key (`cmdRef`, tracked via keydown) so a real modifier pans while a pinch still zooms.

## Decisions

- **Horizontal scroll keeps panning X.** It's the only horizontal-pan gesture; removing it would strand users. Only vertical scroll becomes zoom.
- **Scrollable children still scroll.** The ancestor walk is preserved: scroll over a chat transcript / list scrolls the child, and only falls through to the canvas (as zoom) at the child's scroll boundary.
- **Webview-forwarded cmd/ctrl+wheel (`canvas-wheel-zoom`) stays cursor-zoom.** That channel is a synthetic event with no held-key signal, so it can't tell a pinch from a real modifier; keeping it zoom preserves pinch-to-zoom while hovering a browser card. Panning it too would be a follow-up touching `webview-preload.js` and the re-dispatchers.

## Testing

Drove the running app (webpack dev build against the live backend) via Playwright and asserted on the canvas transform, rather than only typechecking:

- Plain wheel zooms in/out with the **viewport-center** world point held fixed (provably center-anchored, not cursor-anchored); trackpad pinch does the inverse (cursor world point fixed).
- A mouse notch (`deltaY: 100`) produces the clamped 0.9356 zoom ratio, not the raw 0.7579.
- Horizontal scroll pans X with zoom untouched.
- cmd+wheel and ctrl+wheel pan vertically only (no zoom); a synthesized `ctrlKey` pinch with no keydown still zooms at the cursor.
- A scrollable card body scrolls the card, then falls through to canvas zoom at its boundary; space+drag / cmd+drag still pan.

## Note for reviewers

The spec described "left-drag pans the canvas" — in this codebase plain left-drag is **marquee select** (`useDashboardInteractions.ts`); panning is space+drag, cmd+drag, or middle/right-drag. Those all still work; only the scroll gesture changed. `AgentChat`'s existing wheel guard (which swallows plain vertical scroll at the transcript boundary) is left untouched, so an on-canvas chat card does not fall through to zoom — consistent with prior behavior.

Scope is one file: `frontend/src/app/pages/Dashboard/hooks/interaction/useCanvasControls.ts`.