### PR TITLE
renderer: a read that asks for fresh data, or any read after a mutation, no longer answers from the 1s GET dedupe cache

### DIFF
--- a/frontend/src/shared/config.ts
+++ b/frontend/src/shared/config.ts
@@ -1,4 +1,5 @@
 import { noteBackendFailure, noteBackendSuccess, noteRequestStalled, setBackendProber } from '@/shared/backendConnection';
+import { bypassesGetCache, mutationClearsGetCache } from '@/shared/getCachePolicy';
 
 const _w = window as any;
 // Prefer the preload-injected port; if it's missing (preload raced the backend port being picked), re-query the live value before falling back to 8324. The bare 8324 guess is wrong on any machine where the backend landed on a fallback port (e.g. 8324 was held by a leftover backend); see the self-heal below.
@@ -141,6 +142,11 @@ function _installAuthFetchInterceptor() {
         try {
           const resp = await withStallWatch(() => originalFetch(input, finalInit));
           noteBackendSuccess();
+          // A refresh right after a save must see the save: a list GET cached moments before the
+          // mutation (a panel's mount fetch, a poll) would otherwise answer the refresh with the
+          // pre-save list, and the UI sits stale until something else refetches (Settings > Memory
+          // showed "Nothing saved yet" for a fact the store already held).
+          if (mutationClearsGetCache(method)) _cachedFetches.clear();
           return resp;
         } catch (err) {
           noteBackendFailure();
@@ -151,15 +157,20 @@ function _installAuthFetchInterceptor() {
 
       const cacheKey = `GET ${url}`;
 
+      // A caller that asked for no-store/reload gets the network; the dedupe cache is for bursts of
+      // identical default reads (twenty cards mounting), not for a read that wants fresh truth.
+      const wantsFresh = bypassesGetCache(finalInit?.cache ?? (input instanceof Request ? input.cache : undefined));
       const cached = _cachedFetches.get(cacheKey);
-      if (cached && cached.expiresAt > Date.now()) {
+      if (cached && cached.expiresAt > Date.now() && !wantsFresh) {
         return cached.resp.clone();
-      } else if (cached) {
+      } else if (cached && (wantsFresh || cached.expiresAt <= Date.now())) {
         _cachedFetches.delete(cacheKey);
       }
 
+      // Same for an identical GET already in flight: joining one that started before a mutation
+      // would hand a fresh-wanting caller the pre-mutation answer.
       const inflight = _inflightFetches.get(cacheKey);
-      if (inflight) {
+      if (inflight && !wantsFresh) {
         const resp = await inflight;
         return resp.clone();
       }

--- a/frontend/src/shared/getCachePolicy.test.ts
+++ b/frontend/src/shared/getCachePolicy.test.ts
@@ -1,0 +1,17 @@
+// Run: node --test frontend/src/shared/getCachePolicy.test.ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bypassesGetCache, mutationClearsGetCache } from './getCachePolicy.ts';
+
+test('no-store and reload bypass the dedupe cache; the defaults do not', () => {
+  assert.equal(bypassesGetCache('no-store'), true);
+  assert.equal(bypassesGetCache('reload'), true);
+  assert.equal(bypassesGetCache('default'), false);
+  assert.equal(bypassesGetCache('force-cache'), false);
+  assert.equal(bypassesGetCache(undefined), false);
+});
+
+test('every mutation clears the GET cache; reads never do', () => {
+  for (const m of ['POST', 'post', 'PATCH', 'PUT', 'DELETE']) assert.equal(mutationClearsGetCache(m), true, m);
+  for (const m of ['GET', 'get', 'HEAD', 'OPTIONS']) assert.equal(mutationClearsGetCache(m), false, m);
+});

--- a/frontend/src/shared/getCachePolicy.ts
+++ b/frontend/src/shared/getCachePolicy.ts
@@ -1,0 +1,15 @@
+// The renderer dedupes identical GETs to our API through a 1s response cache (config.ts). Two
+// things must never be served from it: a request that asked for fresh data, and any GET after a
+// mutation that could have changed what it reads. Pure so it can be tested without a window.
+
+/** A caller that says no-store / reload wants the network, not the 1s dedupe cache. */
+export function bypassesGetCache(cache: RequestCache | undefined): boolean {
+  return cache === 'no-store' || cache === 'reload';
+}
+
+/** After a successful mutation the whole GET cache is stale-by-assumption; it is a burst dedupe,
+ *  not a store, so dropping it costs at most one extra round trip per URL. */
+export function mutationClearsGetCache(method: string): boolean {
+  const m = method.toUpperCase();
+  return m !== 'GET' && m !== 'HEAD' && m !== 'OPTIONS';
+}


### PR DESCRIPTION
## What

The renderer's fetch interceptor (`frontend/src/shared/config.ts`) dedupes identical GETs to the local API through a 1 s response cache. Two cases must never be answered from it, and neither was:

- a caller that asked for fresh data (`cache: 'no-store'` / `'reload'`) — it now bypasses the cache **and** an identical in-flight request;
- any GET after a successful mutation that may have changed what it reads — every mutation now clears the GET cache (it is a burst dedupe, not a store; the cost is at most one extra round trip per URL).

The policy lives in a small pure module (`getCachePolicy.ts`) with a `node --test` file, so it is testable without a window.

## Why (user-visible)

Settings › Memory: add a fact within about a second of opening the tab and the list stays on "Nothing saved yet" even though the store already holds the fact — the panel's post-save `refresh()` GET was served from the panel's own mount GET, cached moments earlier. Reopening the tab showed it. Any panel that mounts, mutates, and refetches the same URL inside a second has the same hole.

## How it was verified

- `node --test frontend/src/shared/getCachePolicy.test.ts` (2 tests) and `tsc --noEmit` clean.
- On a packaged 1.7.7 build (macOS): opening Settings › Memory and adding a fact immediately shows the fact 3/3 runs with this change; the same steps failed 3/3 without it (the list stayed empty until the tab was reopened).

No behaviour change for default reads: bursts of identical GETs (twenty cards mounting) still dedupe exactly as before.
