### PR TITLE
build(mac): an unsigned local build launches — dev entitlements without the keychain group, no profile; native build scripts survive a path with a space

### DIFF
--- a/electron/build/entitlements.mac.dev.plist
+++ b/electron/build/entitlements.mac.dev.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Entitlements for the UNSIGNED local build (scripts/build-app.sh without a signing identity):
+     entitlements.mac.plist minus keychain-access-groups. That group is a restricted entitlement
+     tied to the team's provisioning profile; on an ad-hoc signature macOS refuses it and kills the
+     app at exec. Passkey sign-in via the shared keychain group is therefore off in a dev build; every
+     other capability (JIT, unsigned executable memory, library validation off for native addons,
+     network, microphone, user-selected files) is unchanged. -->
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/electron/scripts/build-haptics.sh
+++ b/electron/scripts/build-haptics.sh
@@ -11,13 +11,15 @@ HERE="$(cd "$(dirname "$0")/.." && pwd)"   # electron/
 ELECTRON_TARGET="$(node -p "require('$HERE/node_modules/electron/package.json').version.split('+')[0]" 2>/dev/null || echo '42.3.3')"
 SRC="$HERE/native/haptics"
 OUT="$HERE/build-staging/haptics/$ARCH"
-NODE_GYP="$HERE/node_modules/.bin/node-gyp"
-[[ -x "$NODE_GYP" ]] || NODE_GYP="npx --yes node-gyp"  # transitive dep usually, npx if not
+# An array, not a string: the local binary path can contain spaces (a checkout under "Projects Claude/"
+# split it into two words), while the npx fallback is legitimately several words.
+NODE_GYP=("$HERE/node_modules/.bin/node-gyp")
+[[ -x "${NODE_GYP[0]}" ]] || NODE_GYP=(npx --yes node-gyp)  # transitive dep usually, npx if not
 
 echo "[haptics] building for arch=$ARCH (electron $ELECTRON_TARGET)"
 cd "$SRC"
 rm -rf build
-$NODE_GYP rebuild \
+"${NODE_GYP[@]}" rebuild \
   --target="$ELECTRON_TARGET" \
   --arch="$ARCH" \
   --dist-url=https://electronjs.org/headers

--- a/electron/scripts/build-mouseclamp.sh
+++ b/electron/scripts/build-mouseclamp.sh
@@ -11,13 +11,15 @@ HERE="$(cd "$(dirname "$0")/.." && pwd)"   # electron/
 ELECTRON_TARGET="$(node -p "require('$HERE/node_modules/electron/package.json').version.split('+')[0]" 2>/dev/null || echo '42.3.3')"
 SRC="$HERE/native/mouseclamp"
 OUT="$HERE/build-staging/mouseclamp/$ARCH"
-NODE_GYP="$HERE/node_modules/.bin/node-gyp"
-[[ -x "$NODE_GYP" ]] || NODE_GYP="npx --yes node-gyp"  # transitive dep usually, npx if not
+# An array, not a string: the local binary path can contain spaces (a checkout under "Projects Claude/"
+# split it into two words), while the npx fallback is legitimately several words.
+NODE_GYP=("$HERE/node_modules/.bin/node-gyp")
+[[ -x "${NODE_GYP[0]}" ]] || NODE_GYP=(npx --yes node-gyp)  # transitive dep usually, npx if not
 
 echo "[mouseclamp] building for arch=$ARCH (electron $ELECTRON_TARGET)"
 cd "$SRC"
 rm -rf build
-$NODE_GYP rebuild \
+"${NODE_GYP[@]}" rebuild \
   --target="$ELECTRON_TARGET" \
   --arch="$ARCH" \
   --dist-url=https://electronjs.org/headers

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -550,8 +550,23 @@ if $PUBLISH_MODE; then
 elif $SIGN_MODE; then
     npx electron-builder --mac "${EB_ARCH_FLAGS[@]}" --publish never
 else
+    # Unsigned local build. electron-builder falls back to an ad-hoc signature but still applies the
+    # release entitlements + provisioning profile; the restricted keychain-access-groups entitlement
+    # is not honoured for an ad-hoc identity, so macOS SIGKILLs the app at exec (silently: no
+    # window, nothing on stderr). Pack first, then re-sign the outer bundle with the same
+    # entitlements minus that group and no profile (passkeys stay off in a dev build anyway), then
+    # build the dmg/zip from the app that actually launches.
     export CSC_IDENTITY_AUTO_DISCOVERY=false
-    npx electron-builder --mac "${EB_ARCH_FLAGS[@]}" --publish never
+    npx electron-builder --mac "${EB_ARCH_FLAGS[@]}" --dir --publish never
+    for A in "${BUILD_ARCHS[@]}"; do
+        APP_DIR="dist/mac-$A"
+        [[ "$A" == "x64" && ! -d "$APP_DIR" ]] && APP_DIR="dist/mac"
+        APP="$APP_DIR/OpenSwarm.app"
+        [[ -d "$APP" ]] || { echo "ERROR: packed app not found at $APP" >&2; exit 1; }
+        rm -f "$APP/Contents/embedded.provisionprofile"
+        codesign --force --sign - --options runtime --entitlements build/entitlements.mac.dev.plist "$APP"
+        npx electron-builder --mac "--$A" --prepackaged "$APP" --publish never
+    done
 fi
 
 rm -rf "$PROJECT_ROOT/electron/build-staging"


### PR DESCRIPTION
## What

Two things stopped `bash scripts/build-app.sh` — the documented unsigned local build — from producing an app that opens:

1. **Unsigned builds were SIGKILLed at exec.** electron-builder falls back to an ad-hoc signature but still applied the release entitlements + provisioning profile. `keychain-access-groups` is a restricted entitlement macOS will not honour on an ad-hoc identity, so the app died at launch with nothing on stderr and no window. Bisected on a local build: the same signature minus that one key launches fine, hardened runtime and all.
   The unsigned path now packs with `--dir`, re-signs the outer bundle with `build/entitlements.mac.dev.plist` (production minus that group) and no profile, then builds the dmg/zip from that app with `--prepackaged`, so what lands in `dist/` is what launches. Signed and publish builds are untouched. Passkey sign-in via the shared keychain group is off in a dev build — it could not have worked on an ad-hoc signature anyway.
2. **`build-mouseclamp.sh` / `build-haptics.sh` invoked `$NODE_GYP` unquoted**; a checkout under a directory with a space split the binary path into two words and the build died before packaging. The command is an array now (the npx fallback is legitimately several words).

## Verified

- Local unsigned build on macOS (arm64): the packed app launches with no manual re-signing; the app inside the produced zip carries the dev signature and no embedded profile.
- `build-mouseclamp.sh arm64` on a path containing a space builds and stages `mouseclamp.node` (`Mach-O 64-bit bundle arm64`).
- `plutil -lint` on the new plist; it differs from `entitlements.mac.plist` by exactly `keychain-access-groups`.
