### PR TITLE
state: split dashboardLayoutSlice into reducer/model modules; saves carry their fetch baseline

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,11 +48,17 @@ jobs:
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
             | tail -1 | tee collected.txt
+      # --timeout: a test that blocks forever (a bare ws.receive_json() waiting for an event that never
+      # comes, say) otherwise stalls the run at 99% until timeout-minutes with no summary and no junit.
+      # With the cap it fails by name, the rest of the suite runs, and the assertion below still holds.
       - name: Run the backend suite
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --timeout=300 \
             --junitxml "${RUNNER_TEMP}/pytest.xml"
       - name: Every collected test ran
+        # Runs after a red suite too, so a failure report also says whether the run was complete.
+        if: ${{ !cancelled() }}
         run: |
           python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
           import re, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,65 @@
+name: backend-tests
+
+# The backend pytest suite, run on every pull request and on pushes to the mainline branches. Until
+# now nothing ran it in CI, so a regression only surfaced when someone ran it by hand.
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  workflow_dispatch:
+
+# Runs checked-out project code on pull_request: the token stays read-only.
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.lock
+            backend/requirements-dev.txt
+      - name: Install backend deps (locked runtime + dev)
+        run: |
+          python -m pip install --require-hashes --only-binary=:all: -r backend/requirements.lock
+          python -m pip install -r backend/requirements-dev.txt
+      # Two numbers that must agree. A test process that dies mid-run can exit 0 with no summary
+      # (a hard-exit shutdown path did exactly that once and silently skipped ~42% of the suite), so
+      # the job also asserts that every collected test was actually run: junit testcase count ==
+      # collect-only count. Green then means green, not "green as far as it got".
+      - name: Count the suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
+            | tail -1 | tee collected.txt
+      - name: Run the backend suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --junitxml "${RUNNER_TEMP}/pytest.xml"
+      - name: Every collected test ran
+        run: |
+          python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          ran = sum(1 for _ in ET.parse(sys.argv[1]).getroot().iter('testcase'))
+          m = re.search(r'(\d+) tests? collected', open(sys.argv[2]).read())
+          collected = int(m.group(1)) if m else -1
+          print(f'collected={collected} ran={ran}')
+          if collected < 1 or ran != collected:
+              sys.exit(f'FAIL: {ran} of {collected} collected tests reached the report; the run was truncated')
+          PY

--- a/.github/workflows/edge-tests.yml
+++ b/.github/workflows/edge-tests.yml
@@ -1,0 +1,44 @@
+name: edge-tests
+
+# The openswarm-edge pytest suite, on every pull request that touches it and on pushes to the
+# mainline branches.
+on:
+  pull_request:
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edge-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (openswarm-edge)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: openswarm-edge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: openswarm-edge/requirements.txt
+      - name: Install edge deps
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+      - name: Run the edge suite
+        run: python -m pytest tests -q -p no:cacheprovider

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,43 @@
+name: frontend-tests
+
+# Typecheck plus the renderer's node:test suite, on every pull request and on pushes to the mainline
+# branches. Until now neither ran in CI; the tests were run by hand, one file at a time.
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-tests:
+    name: tsc + node:test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.json
+      - name: Unit tests (node:test via tsx)
+        run: node scripts/run-tests.mjs

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,6 +9,9 @@
 
 pytest==8.3.4
 pytest-asyncio==0.25.2
+# Per-test wall-clock cap for CI (see .github/workflows/backend-tests.yml): a test that
+# blocks forever fails by name instead of stalling the whole run until the job cap.
+pytest-timeout==2.4.0
 
 # Used by linter/lint.py (the vulture dead-code check). watchfiles, also
 # needed by lint.py, already comes in transitively via uvicorn[standard].

--- a/backend/tests/test_ws_integration.py
+++ b/backend/tests/test_ws_integration.py
@@ -6,6 +6,8 @@ extracted handlers + the broadcast, which the in-process harness (no server, no 
 The SDK and WS auth are mocked; everything else is the real running stack."""
 
 import asyncio
+import queue
+import threading
 
 import pytest
 
@@ -17,6 +19,29 @@ from fastapi.testclient import TestClient
 import backend.main as main_mod
 from backend.apps.agents.agent_manager import agent_manager
 from backend.apps.agents.core.models import AgentSession
+import backend.apps.agents.manager.run.RunOptions as run_options_mod
+
+
+def p_receive_json(ws, timeout: float = 5.0):
+    """ws.receive_json() blocks forever when the event never comes; a regression in the loop then
+    hangs the whole pytest run instead of failing this test. Bound every receive."""
+    out = queue.Queue(maxsize=1)
+
+    def p_recv():
+        try:
+            out.put((True, ws.receive_json()))
+        except BaseException as exc:
+            out.put((False, exc))
+
+    thread = threading.Thread(target=p_recv, daemon=True)
+    thread.start()
+    try:
+        ok, value = out.get(timeout=timeout)
+    except queue.Empty as exc:
+        raise AssertionError(f"timed out waiting for websocket event after {timeout}s") from exc
+    if ok:
+        return value
+    raise value
 
 
 def p_assistant():
@@ -32,6 +57,20 @@ def p_result():
 
 def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
     monkeypatch.setattr(main_mod, "p_ws_auth_ok", lambda ws: True, raising=True)
+
+    # The contract of this test is "SDK and WS auth mocked, everything else real", but two things on
+    # the turn path reach outside the process and must not decide the outcome: configure_provider_env
+    # can wander into 9Router revival (spawn/npm install, serialized on a module-level lock) whenever
+    # earlier tests left provider evidence behind, and the background turn-label aux call does the
+    # same. Pin both out; the persistent-client path is pinned off suite-wide in conftest.
+    async def p_noop_provider_env(*args, **kwargs):
+        return None
+
+    async def p_noop_turn_label(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(run_options_mod, "configure_provider_env", p_noop_provider_env, raising=True)
+    monkeypatch.setattr(agent_manager, "generate_turn_label", p_noop_turn_label, raising=True)
 
     async def fake_query(*args, **kwargs):
         yield p_assistant()
@@ -49,10 +88,15 @@ def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
             ws.send_json({"event": "agent:send_message", "data": {"prompt": "hi"}})
             seen = []
             for _ in range(40):
-                ev = ws.receive_json()
+                ev = p_receive_json(ws)
                 seen.append(ev.get("event"))
-                if ev.get("event") == "agent:message" and "hello from the loop" in str(ev.get("data", {})):
+                if (
+                    ev.get("event") == "agent:status"
+                    and ev.get("data", {}).get("status") == "completed"
+                ):
                     break
+            else:
+                raise AssertionError(f"did not receive completed status; saw events={seen}")
         # the real loop's assistant reply made it all the way back over the WS
         assert "agent:message" in seen
         assert any(m.role == "assistant" and "hello from the loop" in str(m.content)

--- a/frontend/scripts/run-tests.mjs
+++ b/frontend/scripts/run-tests.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Runs every renderer unit test (src/**/*.test.ts, *.test.tsx) under node:test, with tsx doing the
+// TypeScript. One command for CI and for a dev machine: `node scripts/run-tests.mjs`, optionally
+// followed by file paths to run a subset. Exits non-zero if any test fails or nothing was found.
+import { spawnSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const testFile = (p) => /\.test\.tsx?$/.test(p);
+
+function walk(dir, out) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (testFile(p)) out.push(p);
+  }
+  return out;
+}
+
+const files = process.argv.length > 2 ? process.argv.slice(2) : walk(join(root, 'src'), []).sort();
+if (files.length === 0) {
+  console.error('run-tests: no test files found under src/');
+  process.exit(1);
+}
+const result = spawnSync(process.execPath, ['--import', 'tsx', '--test', ...files], { cwd: root, stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/frontend/src/app/pages/Dashboard/canvas/DashboardHeader.tsx
+++ b/frontend/src/app/pages/Dashboard/canvas/DashboardHeader.tsx
@@ -65,6 +65,8 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   const c = useClaudeTokens();
   const dispatch = useAppDispatch();
   const creationOrder = useAppSelector((s) => s.dashboardLayout.creationOrder);
+  // saveLayout only accepts a payload carrying the current per-dashboard baseline (see useLayoutSave).
+  const saveAuthority = useAppSelector((s) => s.dashboardLayout.unknownPersistedLayoutFieldsByDashboard[dashboardId ?? '']);
   const [expanded, setExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -235,7 +237,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
               onOpen={() => {
                 // Layout saves are debounced, so a just-added app/agent card may not be on disk yet. The export reads disk, flush the live layout now so Share captures the current board, not a stale one.
                 if (!dashboardId) return;
-                dispatch(saveLayout({ dashboardId, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder }));
+                dispatch(saveLayout({ dashboardId, saveAuthority, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder }));
               }}
             />
           </Box>

--- a/frontend/src/app/pages/Dashboard/hooks/state/useLayoutSave.ts
+++ b/frontend/src/app/pages/Dashboard/hooks/state/useLayoutSave.ts
@@ -36,6 +36,12 @@ export function useLayoutSave({
   captureNow,
 }: UseLayoutSaveArgs) {
   const dispatch = useAppDispatch();
+  // The per-dashboard baseline object created by the last successful fetch. saveLayout refuses a
+  // payload whose authority is not the current baseline, so a delayed/unmount save captured before a
+  // rejected or superseded fetch cannot erase the server's layout.
+  const saveAuthority = useAppSelector(
+    (state) => state.dashboardLayout.unknownPersistedLayoutFieldsByDashboard[dashboardId],
+  );
   const creationOrder = useAppSelector((s) => s.dashboardLayout.creationOrder);
   const skipInitialSave = useRef(true);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -48,7 +54,7 @@ export function useLayoutSave({
       skipInitialSave.current = false;
       return;
     }
-    const payload = { dashboardId, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder };
+    const payload = { dashboardId, saveAuthority, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder };
     pendingSaveRef.current = payload;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
@@ -57,7 +63,7 @@ export function useLayoutSave({
       saveTimerRef.current = null;
       captureNow();
     }, 500);
-  }, [isActive, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder, layoutInitialized, dashboardId, dispatch, captureNow]);
+  }, [isActive, cards, viewCards, browserCards, workflowCards, workflowsHub, expandedSessionIds, creationOrder, layoutInitialized, dashboardId, saveAuthority, dispatch, captureNow]);
 
   useEffect(() => {
     return () => {

--- a/frontend/src/shared/backendConnection.ts
+++ b/frontend/src/shared/backendConnection.ts
@@ -80,4 +80,7 @@ export function noteRequestStalled(): void {
 }
 
 // Harness/debug handle: lets a live session (CDP, support) read the signal without a store import.
-(window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+// Guarded: reducers that import this module also run under node:test, where there is no window.
+if (typeof window !== 'undefined') {
+  (window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+}

--- a/frontend/src/shared/config.ts
+++ b/frontend/src/shared/config.ts
@@ -1,6 +1,9 @@
 import { noteBackendFailure, noteBackendSuccess, noteRequestStalled, setBackendProber } from '@/shared/backendConnection';
 
-const _w = window as any;
+// Import-safe outside a renderer: reducers that import API_BASE also run under node:test, where there
+// is no window. The module then answers with the defaults and installs nothing.
+const hasWindow = typeof window !== 'undefined';
+const _w = (hasWindow ? window : {}) as any;
 // Prefer the preload-injected port; if it's missing (preload raced the backend port being picked), re-query the live value before falling back to 8324. The bare 8324 guess is wrong on any machine where the backend landed on a fallback port (e.g. 8324 was held by a leftover backend); see the self-heal below.
 const port =
   _w.__OPENSWARM_PORT__ ||
@@ -8,7 +11,7 @@ const port =
     ? _w.openswarm.getBackendPortLive()
     : 0) ||
   8324;
-const host = window.location.hostname || 'localhost';
+const host = (hasWindow && window.location.hostname) || 'localhost';
 
 export const API_BASE = `http://${host}:${port}/api`;
 export const WS_BASE = `ws://${host}:${port}`;
@@ -217,5 +220,7 @@ function _installAuthFetchInterceptor() {
   };
 }
 
-_installAuthFetchInterceptor();
-ensureAuthToken();
+if (hasWindow) {
+  _installAuthFetchInterceptor();
+  ensureAuthToken();
+}

--- a/frontend/src/shared/safeMode.ts
+++ b/frontend/src/shared/safeMode.ts
@@ -11,7 +11,10 @@ export interface SafeModeInfo {
 
 let cached: SafeModeInfo = { safeMode: false, dirtyCount: 0, fingerprint: null };
 
-const api = (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
+// Import-safe outside a renderer: the layout slice imports this, and its reducer tests run under node:test.
+const api = typeof window === 'undefined'
+  ? undefined
+  : (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
 if (api?.getSafeMode) {
   void api.getSafeMode().then((info) => {
     if (info && typeof info.safeMode === 'boolean') cached = info;

--- a/frontend/src/shared/state/dashboardLayoutAgentReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutAgentReducers.ts
@@ -1,0 +1,133 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  DEFAULT_CARD_H,
+  DEFAULT_CARD_W,
+  type CardPosition,
+  type DashboardLayoutState,
+} from './dashboardLayoutModel';
+import {
+  collectOccupiedRects,
+  findOpenGridCell,
+  findOpenSpotNear,
+} from './dashboardLayoutGeometry';
+import { ledgerAdd, ledgerRemove } from './dashboardLayoutCardState';
+
+export const agentCardReducers = {
+  setCardPosition(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ sessionId: string; x: number; y: number }>,
+  ) {
+    const { sessionId, x, y } = action.payload;
+    const card = state.cards[sessionId];
+    if (card) {
+      card.x = x;
+      card.y = y;
+    }
+  },
+
+  setCardSize(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ sessionId: string; width: number; height: number }>,
+  ) {
+    const { sessionId, width, height } = action.payload;
+    const card = state.cards[sessionId];
+    if (card) {
+      card.width = Math.max(480, width);
+      card.height = Math.max(180, height);
+    }
+  },
+
+  placeCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{
+      sessionId: string;
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      expandedSessionIds?: string[];
+      exact?: boolean;
+    }>,
+  ) {
+    const { sessionId, x, y, width, height, expandedSessionIds, exact } = action.payload;
+    const pos = exact ? { x, y } : findOpenSpotNear(x, y, collectOccupiedRects(state, expandedSessionIds), width, height);
+    state.cards[sessionId] = {
+      session_id: sessionId,
+      x: pos.x,
+      y: pos.y,
+      width,
+      height,
+      zOrder: state.nextZOrder++,
+    };
+    ledgerAdd(state.creationOrder, sessionId);
+  },
+
+  removeCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.cards[action.payload];
+    delete state.tiledCards[action.payload];
+    delete state.minimizedCards[action.payload];
+    ledgerRemove(state.creationOrder, action.payload);
+  },
+
+  reconcileSessions(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ sessionIds: string[]; expandedSessionIds: string[] }>,
+  ) {
+    const { sessionIds, expandedSessionIds } = action.payload;
+    const liveIds = new Set(sessionIds);
+
+    for (const id of Object.keys(state.cards)) {
+      if (!liveIds.has(id)) {
+        state.closedCardPositions[id] = { ...state.cards[id] };
+        delete state.cards[id];
+        // A dead card must never keep owning a tile: an orphaned 'fullscreen' entry hides ALL chrome until reload.
+        delete state.tiledCards[id];
+        delete state.minimizedCards[id];
+        ledgerRemove(state.creationOrder, id);
+      }
+    }
+
+    const hasDraftCard = Object.keys(state.cards).some((id) => id.startsWith('draft-'));
+    const newIds = sessionIds.filter((id) => !state.cards[id]);
+    for (const id of newIds) {
+      if (hasDraftCard && !id.startsWith('draft-')) continue;
+      const savedPos = state.closedCardPositions[id];
+      if (savedPos) {
+        state.cards[id] = { ...savedPos, session_id: id, zOrder: savedPos.zOrder || state.nextZOrder++ };
+        ledgerAdd(state.creationOrder, id);
+        delete state.closedCardPositions[id];
+      } else {
+        const rects = collectOccupiedRects(state, expandedSessionIds);
+        const pos = findOpenGridCell(rects, DEFAULT_CARD_W, DEFAULT_CARD_H);
+        state.cards[id] = {
+          session_id: id,
+          x: pos.x,
+          y: pos.y,
+          width: DEFAULT_CARD_W,
+          height: DEFAULT_CARD_H,
+          zOrder: state.nextZOrder++,
+        };
+        ledgerAdd(state.creationOrder, id);
+      }
+    }
+  },
+
+  seedClosedAgentPosition(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ sessionId: string; position: CardPosition }>,
+  ) {
+    state.closedCardPositions[action.payload.sessionId] = action.payload.position;
+  },
+
+  replaceDraftId(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ oldId: string; newId: string }>,
+  ) {
+    const { oldId, newId } = action.payload;
+    const card = state.cards[oldId];
+    if (card) {
+      delete state.cards[oldId];
+      state.cards[newId] = { ...card, session_id: newId };
+    }
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutBrowserReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutBrowserReducers.ts
@@ -1,0 +1,353 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { getLastDashboardId } from '@/shared/lastDashboardId';
+import {
+  DEFAULT_BROWSER_CARD_H,
+  DEFAULT_BROWSER_CARD_W,
+  type BrowserCardPosition,
+  type BrowserTab,
+  type DashboardLayoutState,
+} from './dashboardLayoutModel';
+import {
+  collectOccupiedRects,
+  findOpenGridCell,
+  findOpenSpotNear,
+} from './dashboardLayoutGeometry';
+import { ledgerAdd, ledgerRemove } from './dashboardLayoutCardState';
+
+export function generateTabId(): string {
+  return `tab-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export const browserCardReducers = {
+  addBrowserCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ url: string; expandedSessionIds?: string[]; x?: number; y?: number }>,
+  ) {
+    const id = `browser-${Date.now().toString(36)}`;
+    const tabId = generateTabId();
+    const pos = action.payload.x != null && action.payload.y != null
+      ? { x: action.payload.x, y: action.payload.y }
+      : findOpenGridCell(collectOccupiedRects(state, action.payload.expandedSessionIds), DEFAULT_BROWSER_CARD_W, DEFAULT_BROWSER_CARD_H);
+    state.browserCards[id] = {
+      browser_id: id,
+      url: action.payload.url,
+      tabs: [{ id: tabId, url: action.payload.url, title: '' }],
+      activeTabId: tabId,
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_BROWSER_CARD_W,
+      height: DEFAULT_BROWSER_CARD_H,
+      zOrder: state.nextZOrder++,
+      dashboard_id: getLastDashboardId() ?? undefined,
+    };
+    ledgerAdd(state.creationOrder, id);
+    state.pendingFocusBrowserId = id;
+  },
+
+  clearPendingFocusBrowserId(state: DashboardLayoutState) {
+    state.pendingFocusBrowserId = null;
+  },
+
+  addBrowserCardFromBackend(state: DashboardLayoutState, action: PayloadAction<BrowserCardPosition>) {
+    const card = action.payload;
+    if (state.browserCards[card.browser_id]) return;
+    const width = card.width || DEFAULT_BROWSER_CARD_W;
+    const height = card.height || DEFAULT_BROWSER_CARD_H;
+    const rects = collectOccupiedRects(state);
+    const pos = findOpenSpotNear(card.x, card.y, rects, width, height);
+    state.browserCards[card.browser_id] = {
+      ...card,
+      x: pos.x,
+      y: pos.y,
+      width,
+      height,
+      zOrder: card.zOrder || state.nextZOrder++,
+      dashboard_id: card.dashboard_id ?? getLastDashboardId() ?? undefined,
+    };
+    ledgerAdd(state.creationOrder, card.browser_id);
+  },
+
+  setBrowserCardPosition(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; x: number; y: number }>,
+  ) {
+    const { browserId, x, y } = action.payload;
+    const card = state.browserCards[browserId];
+    if (card) {
+      card.x = x;
+      card.y = y;
+    }
+  },
+
+  setBrowserCardSize(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; width: number; height: number }>,
+  ) {
+    const { browserId, width, height } = action.payload;
+    const card = state.browserCards[browserId];
+    if (card) {
+      card.width = Math.max(400, width);
+      card.height = Math.max(300, height);
+    }
+  },
+
+  removeBrowserCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.browserCards[action.payload];
+    delete state.suspendedBrowserCards[action.payload];
+    delete state.endingBrowserCards[action.payload];
+    delete state.tiledCards[action.payload];
+    delete state.minimizedCards[action.payload];
+    ledgerRemove(state.creationOrder, action.payload);
+  },
+
+  markBrowserCardEnding(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; status: 'completed' | 'error' }>,
+  ) {
+    if (!state.browserCards[action.payload.browserId]) return;
+    state.endingBrowserCards[action.payload.browserId] = {
+      status: action.payload.status,
+      at: Date.now(),
+    };
+  },
+
+  cancelBrowserCardEnding(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.endingBrowserCards[action.payload];
+  },
+
+  keepBrowserCardOpen(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const card = state.browserCards[action.payload];
+    if (!card) return;
+    card.keep_open = true;
+    delete state.endingBrowserCards[action.payload];
+  },
+
+  suspendBrowserCard(state: DashboardLayoutState, action: PayloadAction<{ browserId: string; dataUrl: string }>) {
+    if (!state.browserCards[action.payload.browserId]) return;
+    state.suspendedBrowserCards[action.payload.browserId] = {
+      dataUrl: action.payload.dataUrl,
+      capturedAt: Date.now(),
+    };
+  },
+
+  resumeBrowserCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.suspendedBrowserCards[action.payload];
+  },
+
+  pasteBrowserCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{
+      tabs: BrowserTab[]; url: string; expandedSessionIds?: string[];
+      id?: string; x?: number; y?: number; width?: number; height?: number;
+    }>,
+  ) {
+    const { x, y, width, height } = action.payload;
+    const id = action.payload.id || `browser-${Date.now().toString(36)}`;
+    const newTabs = action.payload.tabs.map((tab) => ({
+      id: generateTabId(),
+      url: tab.url,
+      title: '',
+      favicon: undefined,
+    }));
+    const activeTab = newTabs[0];
+    let posX: number, posY: number;
+    if (x != null && y != null) {
+      posX = x;
+      posY = y;
+    } else {
+      const rects = collectOccupiedRects(state, action.payload.expandedSessionIds);
+      const pos = findOpenGridCell(rects, DEFAULT_BROWSER_CARD_W, DEFAULT_BROWSER_CARD_H);
+      posX = pos.x;
+      posY = pos.y;
+    }
+    state.browserCards[id] = {
+      browser_id: id,
+      url: activeTab?.url || action.payload.url,
+      tabs: newTabs.length > 0 ? newTabs : [{ id: generateTabId(), url: action.payload.url, title: '' }],
+      activeTabId: activeTab?.id || generateTabId(),
+      x: posX,
+      y: posY,
+      width: width || DEFAULT_BROWSER_CARD_W,
+      height: height || DEFAULT_BROWSER_CARD_H,
+      zOrder: state.nextZOrder++,
+      dashboard_id: getLastDashboardId() ?? undefined,
+    };
+  },
+
+  updateBrowserCardUrl(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; url: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (card) {
+      card.url = action.payload.url;
+      const tab = card.tabs.find((candidate) => candidate.id === card.activeTabId);
+      if (tab) tab.url = action.payload.url;
+    }
+  },
+
+  addBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; url: string; makeActive?: boolean }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const tabId = generateTabId();
+    card.tabs.push({ id: tabId, url: action.payload.url, title: '' });
+    if (action.payload.makeActive !== false) {
+      card.activeTabId = tabId;
+      card.url = action.payload.url;
+    }
+  },
+
+  removeBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const idx = card.tabs.findIndex((tab) => tab.id === action.payload.tabId);
+    if (idx === -1) return;
+    card.tabs.splice(idx, 1);
+    if (card.tabs.length === 0) {
+      delete state.browserCards[action.payload.browserId];
+      delete state.suspendedBrowserCards[action.payload.browserId];
+      return;
+    }
+    if (card.activeTabId === action.payload.tabId) {
+      const newActive = card.tabs[Math.min(idx, card.tabs.length - 1)];
+      card.activeTabId = newActive.id;
+      card.url = newActive.url;
+    }
+  },
+
+  setActiveBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const tab = card.tabs.find((candidate) => candidate.id === action.payload.tabId);
+    if (tab) {
+      card.activeTabId = tab.id;
+      card.url = tab.url;
+    }
+  },
+
+  cycleBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; dir: 1 | -1 }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card || card.tabs.length < 2) return;
+    const idx = card.tabs.findIndex((tab) => tab.id === card.activeTabId);
+    if (idx === -1) return;
+    const tabCount = card.tabs.length;
+    const next = card.tabs[(idx + action.payload.dir + tabCount) % tabCount];
+    card.activeTabId = next.id;
+    card.url = next.url;
+  },
+
+  updateBrowserTabUrl(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string; url: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const tab = card.tabs.find((candidate) => candidate.id === action.payload.tabId);
+    if (tab) {
+      tab.url = action.payload.url;
+      if (action.payload.tabId === card.activeTabId) {
+        card.url = action.payload.url;
+      }
+    }
+  },
+
+  updateBrowserTabTitle(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string; title: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const tab = card.tabs.find((candidate) => candidate.id === action.payload.tabId);
+    if (tab) tab.title = action.payload.title;
+  },
+
+  updateBrowserTabFavicon(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string; favicon: string }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const tab = card.tabs.find((candidate) => candidate.id === action.payload.tabId);
+    if (tab) tab.favicon = action.payload.favicon;
+  },
+
+  reorderBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserId: string; tabId: string; toIndex: number }>,
+  ) {
+    const card = state.browserCards[action.payload.browserId];
+    if (!card) return;
+    const fromIdx = card.tabs.findIndex((tab) => tab.id === action.payload.tabId);
+    if (fromIdx === -1) return;
+    const [tab] = card.tabs.splice(fromIdx, 1);
+    card.tabs.splice(Math.max(0, Math.min(action.payload.toIndex, card.tabs.length)), 0, tab);
+  },
+
+  moveBrowserTab(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ fromBrowserId: string; tabId: string; toBrowserId?: string; x?: number; y?: number }>
+  ) {
+    const { fromBrowserId, tabId, toBrowserId, x, y } = action.payload;
+    if (toBrowserId === fromBrowserId) return;
+    const source = state.browserCards[fromBrowserId];
+    if (!source) return;
+    const idx = source.tabs.findIndex((t) => t.id === tabId);
+    if (idx === -1) return;
+    const target = toBrowserId ? state.browserCards[toBrowserId] : undefined;
+    if (toBrowserId && !target) return;
+    const [moved] = source.tabs.splice(idx, 1);
+    // Fresh id: reusing the old one makes the receiving BrowserCard think the tab is already initialized, so its webview never loads the URL and sits at about:blank.
+    const tab = { ...moved, id: generateTabId() };
+    const spun = {
+      owner: source.spawned_by ?? null,
+      x: source.x, y: source.y, width: source.width, height: source.height, dashboard_id: source.dashboard_id,
+    };
+    const dissolved = source.tabs.length === 0;
+    if (dissolved) {
+      delete state.browserCards[fromBrowserId];
+      delete state.suspendedBrowserCards[fromBrowserId];
+    } else if (source.activeTabId === tabId) {
+      const nextActive = source.tabs[Math.min(idx, source.tabs.length - 1)];
+      source.activeTabId = nextActive.id;
+      source.url = nextActive.url;
+    }
+    if (target) {
+      target.tabs.push(tab);
+      target.activeTabId = tab.id;
+      target.url = tab.url;
+      target.zOrder = state.nextZOrder++;
+    } else {
+      // The last tab leaving is the card MOVING, so it keeps its id; either way it keeps its agent
+      // owner, or the agent stops recognising its own browser and spawns a second one next time it
+      // browses. keep_open because pulling it out is the user claiming it: the owner finishing must
+      // not delete it out from under them, exactly as when it had no owner at all.
+      const id = dissolved ? fromBrowserId : `browser-${Date.now().toString(36)}`;
+      state.browserCards[id] = {
+        browser_id: id,
+        url: tab.url,
+        tabs: [tab],
+        activeTabId: tab.id,
+        x: x ?? spun.x + 60,
+        y: y ?? spun.y + 60,
+        width: spun.width,
+        height: spun.height,
+        zOrder: state.nextZOrder++,
+        dashboard_id: spun.dashboard_id,
+        spawned_by: spun.owner,
+        keep_open: true,
+      };
+    }
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutCanvasReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutCanvasReducers.ts
@@ -1,0 +1,177 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  EXPANDED_CARD_MIN_H,
+  viewCardKey,
+  type CardType,
+  type DashboardLayoutState,
+  SETTINGS_CARD_ID,
+  MARKETPLACE_CARD_ID
+} from './dashboardLayoutModel';
+import {
+  findOpenGridCell,
+  type Rect,
+  tidyColumnCount
+} from './dashboardLayoutGeometry';
+import { getDashboardCardState, maxDashboardCardZOrder } from './dashboardLayoutCardState';
+
+export const canvasReducers = {
+  bringToFront(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ id: string; type: CardType }>,
+  ) {
+    const { id, type } = action.payload;
+    // Focus writes ONLY the override map: the old form mutated the card object, which replaced its dict, re-rendered the controller + tethers + dock + minimap, and armed a layout PUT + thumbnail capture on every press. The nextZOrder-1 holder is always the top card, so the already-on-top guard is one compare.
+    const base = getDashboardCardState(state, id, type)?.zOrder ?? 0;
+    const effective = state.zOrders[id] ?? base;
+    // A persisted layout can outrank a stale counter; repair it first so the raise always lands on top and the already-on-top compare below is against the repaired counter.
+    state.nextZOrder = Math.max(state.nextZOrder, maxDashboardCardZOrder(state) + 1);
+    // Zero is the legacy every-card tie (backend-synced cards arrive without z); never short-circuit on it.
+    if (effective > 0 && effective === state.nextZOrder - 1) return;
+    state.zOrders[id] = state.nextZOrder++;
+  },
+
+  tidyLayout(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ expandedSessionIds: string[] }>,
+  ) {
+    const expanded = new Set(action.payload.expandedSessionIds);
+    const agentCards = Object.values(state.cards);
+    const viewCards = Object.values(state.viewCards);
+    const browserCards = Object.values(state.browserCards);
+    const workflowCards = Object.values(state.workflowCards);
+    const hub = state.workflowsHub;
+    const monitor = state.workflowsMonitorCard;
+    const settings = state.settingsCard;
+    const market = state.marketplaceCard;
+    const total = agentCards.length + viewCards.length + browserCards.length + workflowCards.length + (hub ? 1 : 0) + (monitor ? 1 : 0) + (settings ? 1 : 0) + (market ? 1 : 0);
+    if (total === 0) return;
+
+    const allItems = [
+      ...agentCards.map((card) => ({ kind: 'agent' as const, id: card.session_id, x: card.x, y: card.y, storedW: card.width, storedH: card.height })),
+      ...viewCards.map((card) => ({ kind: 'view' as const, id: viewCardKey(card.output_id, card.instance), x: card.x, y: card.y, storedW: card.width, storedH: card.height })),
+      ...browserCards.map((card) => ({ kind: 'browser' as const, id: card.browser_id, x: card.x, y: card.y, storedW: card.width, storedH: card.height })),
+      ...workflowCards.map((card) => ({ kind: 'workflow' as const, id: card.workflow_id, x: card.x, y: card.y, storedW: card.width, storedH: card.height })),
+      ...(hub ? [{ kind: 'workflows-hub' as const, id: 'workflows-hub', x: hub.x, y: hub.y, storedW: hub.width, storedH: hub.height }] : []),
+      ...(monitor ? [{ kind: 'workflows-monitor' as const, id: 'workflows-monitor', x: monitor.x, y: monitor.y, storedW: monitor.width, storedH: monitor.height }] : []),
+      ...(settings ? [{ kind: 'settings' as const, id: SETTINGS_CARD_ID, x: settings.x, y: settings.y, storedW: settings.width, storedH: settings.height }] : []),
+      ...(market ? [{ kind: 'marketplace' as const, id: MARKETPLACE_CARD_ID, x: market.x, y: market.y, storedW: market.width, storedH: market.height }] : []),
+    ];
+    allItems.sort((a, b) => a.y - b.y || a.x - b.x);
+
+    const sizeOf = (item: typeof allItems[number]): { w: number; h: number } => ({
+      w: item.storedW,
+      h: item.kind === 'agent' && expanded.has(item.id)
+        ? Math.max(EXPANDED_CARD_MIN_H, item.storedH)
+        : item.storedH,
+    });
+    // Pack into the grid shape that fills the SCREEN best, not the 2-wide ribbon window.innerWidth-as-world-units produced.
+    const cols = tidyColumnCount(allItems.map(sizeOf));
+    const placedRects: Rect[] = [];
+
+    for (const item of allItems) {
+      const { w: width, h: height } = sizeOf(item);
+
+      const pos = findOpenGridCell(placedRects, width, height, cols);
+      placedRects.push({ x: pos.x, y: pos.y, w: width, h: height });
+
+      if (item.kind === 'agent') {
+        const card = state.cards[item.id];
+        if (card) {
+          card.x = pos.x;
+          card.y = pos.y;
+        }
+      } else if (item.kind === 'view') {
+        const card = state.viewCards[item.id];
+        if (card) {
+          card.x = pos.x;
+          card.y = pos.y;
+        }
+      } else if (item.kind === 'workflow') {
+        const card = state.workflowCards[item.id];
+        if (card) {
+          card.x = pos.x;
+          card.y = pos.y;
+        }
+      } else if (item.kind === 'workflows-hub') {
+        if (state.workflowsHub) {
+          state.workflowsHub.x = pos.x;
+          state.workflowsHub.y = pos.y;
+        }
+      } else if (item.kind === 'workflows-monitor') {
+        if (state.workflowsMonitorCard) {
+          state.workflowsMonitorCard.x = pos.x;
+          state.workflowsMonitorCard.y = pos.y;
+        }
+      } else if (item.kind === 'settings') {
+        if (state.settingsCard) {
+          state.settingsCard.x = pos.x;
+          state.settingsCard.y = pos.y;
+        }
+      } else if (item.kind === 'marketplace') {
+        if (state.marketplaceCard) {
+          state.marketplaceCard.x = pos.x;
+          state.marketplaceCard.y = pos.y;
+        }
+      } else {
+        const card = state.browserCards[item.id];
+        if (card) {
+          card.x = pos.x;
+          card.y = pos.y;
+        }
+      }
+    }
+  },
+
+  moveCards(
+    state: DashboardLayoutState,
+    action: PayloadAction<{
+      items: Array<{ id: string; type: CardType }>;
+      dx: number;
+      dy: number;
+    }>,
+  ) {
+    const { items, dx, dy } = action.payload;
+    for (const item of items) {
+      if (item.type === 'agent') {
+        const card = state.cards[item.id];
+        if (card) {
+          card.x += dx;
+          card.y += dy;
+        }
+      } else if (item.type === 'view') {
+        const card = state.viewCards[item.id];
+        if (card) {
+          card.x += dx;
+          card.y += dy;
+        }
+      } else if (item.type === 'workflow') {
+        const card = state.workflowCards[item.id];
+        if (card) {
+          card.x += dx;
+          card.y += dy;
+        }
+      } else if (item.type === 'settings') {
+        if (state.settingsCard) {
+          state.settingsCard.x += dx;
+          state.settingsCard.y += dy;
+        }
+      } else if (item.type === 'marketplace') {
+        if (state.marketplaceCard) {
+          state.marketplaceCard.x += dx;
+          state.marketplaceCard.y += dy;
+        }
+      } else if (item.type === 'workflows-hub') {
+        if (state.workflowsHub) {
+          state.workflowsHub.x += dx;
+          state.workflowsHub.y += dy;
+        }
+      } else {
+        const card = state.browserCards[item.id];
+        if (card) {
+          card.x += dx;
+          card.y += dy;
+        }
+      }
+    }
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutCardState.test.ts
+++ b/frontend/src/shared/state/dashboardLayoutCardState.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { initialDashboardLayoutState, type DashboardLayoutState } from './dashboardLayoutModel';
+import {
+  dashboardCardStateEntries,
+  dashboardCardStateRegistry,
+  getDashboardCardState,
+  maxDashboardCardZOrder,
+} from './dashboardLayoutCardState';
+import { canvasReducers } from './dashboardLayoutCanvasReducers';
+
+function layoutWithEveryCardType(): DashboardLayoutState {
+  return {
+    ...initialDashboardLayoutState,
+    cards: {
+      agent: { session_id: 'agent', x: 1, y: 2, width: 480, height: 280, zOrder: 1 },
+    },
+    viewCards: {
+      'view#2': { output_id: 'view', instance: 2, x: 3, y: 4, width: 1280, height: 800, zOrder: 2 },
+    },
+    browserCards: {
+      browser: {
+        browser_id: 'browser', url: 'https://example.test',
+        tabs: [{ id: 'tab', url: 'https://example.test', title: 'Example' }], activeTabId: 'tab',
+        x: 5, y: 6, width: 1280, height: 800, zOrder: 3,
+      },
+    },
+    workflowCards: {
+      workflow: { workflow_id: 'workflow', x: 11, y: 12, width: 480, height: 520, zOrder: 6 },
+    },
+    workflowsHub: { x: 13, y: 14, width: 1280, height: 800, zOrder: 7 },
+    settingsCard: { x: 17, y: 18, width: 1280, height: 800, zOrder: 9 },
+    marketplaceCard: { x: 19, y: 20, width: 1280, height: 800, zOrder: 10 },
+    workflowsMonitorCard: { x: 15, y: 16, width: 520, height: 560, zOrder: 8 },
+  };
+}
+
+test('card-state registry owns one canonical accessor for every CardType', () => {
+  const state = layoutWithEveryCardType();
+  const expectedTypes = ['agent', 'view', 'browser', 'workflow', 'workflows-hub', 'settings', 'marketplace', 'workflows-monitor'];
+  const expectedIds = ['agent', 'view#2', 'browser', 'workflow', 'workflows-hub', 'settings', 'marketplace', 'workflows-monitor'];
+  const entries = dashboardCardStateEntries(state);
+
+  assert.deepEqual(Object.keys(dashboardCardStateRegistry), expectedTypes);
+  assert.deepEqual(entries.map(({ id }) => id), expectedIds);
+  assert.deepEqual(entries.map(({ type }) => type), expectedTypes);
+
+  for (const entry of entries) {
+    assert.equal(getDashboardCardState(state, entry.id, entry.type), entry.data);
+  }
+  assert.equal(getDashboardCardState(state, 'view', 'view'), undefined);
+  assert.equal(getDashboardCardState(state, 'missing', 'agent'), undefined);
+});
+
+test('unknown card kinds are ignored without mutating opaque legacy data', () => {
+  const legacy = { future_cards: { future: { payload: 'recoverable' } } };
+  const state = Object.assign(layoutWithEveryCardType(), legacy);
+
+  assert.equal(getDashboardCardState(state, 'future', 'future-card'), undefined);
+  assert.equal(maxDashboardCardZOrder(state), 10);
+  assert.equal(state.future_cards, legacy.future_cards);
+});
+
+test('bring-to-front raises every registered card kind through the override map, never the card dict', () => {
+  const base = layoutWithEveryCardType();
+
+  for (const target of dashboardCardStateEntries(base)) {
+    const state = structuredClone(base);
+    for (const entry of dashboardCardStateEntries(state)) entry.data.zOrder = 100;
+    getDashboardCardState(state, target.id, target.type)!.zOrder = 1;
+    const before = { ...getDashboardCardState(state, target.id, target.type)! };
+    state.nextZOrder = 2;
+
+    canvasReducers.bringToFront(state, {
+      type: 'dashboardLayout/bringToFront',
+      payload: { id: target.id, type: target.type },
+    });
+
+    // Focus writes ONLY zOrders: the card dict keeps its identity and geometry (no re-render storm, no layout PUT), and a stale counter is repaired past the persisted maximum first.
+    assert.deepEqual(getDashboardCardState(state, target.id, target.type), before);
+    assert.equal(state.zOrders[target.id], 101);
+    assert.equal(state.nextZOrder, 102);
+  }
+});

--- a/frontend/src/shared/state/dashboardLayoutCardState.ts
+++ b/frontend/src/shared/state/dashboardLayoutCardState.ts
@@ -1,0 +1,130 @@
+import type { CardType, DashboardLayoutState } from './dashboardLayoutModel';
+
+export interface DashboardCardStateData {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+}
+
+export interface DashboardCardStateInstance<TType extends string = CardType> {
+  id: string;
+  type: TType;
+  data: DashboardCardStateData;
+}
+
+export interface DashboardCardStateContract<TType extends string = CardType> {
+  readonly type: TType;
+  entries: (state: DashboardLayoutState) => readonly DashboardCardStateInstance<TType>[];
+  get: (state: DashboardLayoutState, id: string) => DashboardCardStateData | undefined;
+}
+
+function recordEntries<TType extends CardType>(
+  type: TType,
+  cards: Record<string, DashboardCardStateData>,
+): DashboardCardStateInstance<TType>[] {
+  return Object.entries(cards).map(([id, data]) => ({ id, type, data }));
+}
+
+function singletonEntries<TType extends CardType>(
+  type: TType,
+  id: string,
+  data: DashboardCardStateData | null,
+): DashboardCardStateInstance<TType>[] {
+  return data ? [{ id, type, data }] : [];
+}
+
+export const dashboardCardStateRegistry = {
+  agent: {
+    type: 'agent',
+    entries: (state) => recordEntries('agent', state.cards),
+    get: (state, id) => state.cards[id],
+  },
+  view: {
+    type: 'view',
+    entries: (state) => recordEntries('view', state.viewCards),
+    get: (state, id) => state.viewCards[id],
+  },
+  browser: {
+    type: 'browser',
+    entries: (state) => recordEntries('browser', state.browserCards),
+    get: (state, id) => state.browserCards[id],
+  },
+  workflow: {
+    type: 'workflow',
+    entries: (state) => recordEntries('workflow', state.workflowCards),
+    get: (state, id) => state.workflowCards[id],
+  },
+  'workflows-hub': {
+    type: 'workflows-hub',
+    entries: (state) => singletonEntries('workflows-hub', 'workflows-hub', state.workflowsHub),
+    get: (state, id) => id === 'workflows-hub' ? state.workflowsHub ?? undefined : undefined,
+  },
+  settings: {
+    type: 'settings',
+    entries: (state) => singletonEntries('settings', 'settings', state.settingsCard),
+    get: (state, id) => id === 'settings' ? state.settingsCard ?? undefined : undefined,
+  },
+  marketplace: {
+    type: 'marketplace',
+    entries: (state) => singletonEntries('marketplace', 'marketplace', state.marketplaceCard),
+    get: (state, id) => id === 'marketplace' ? state.marketplaceCard ?? undefined : undefined,
+  },
+  'workflows-monitor': {
+    type: 'workflows-monitor',
+    entries: (state) => singletonEntries('workflows-monitor', 'workflows-monitor', state.workflowsMonitorCard),
+    get: (state, id) => id === 'workflows-monitor' ? state.workflowsMonitorCard ?? undefined : undefined,
+  },
+} satisfies { [TType in CardType]: DashboardCardStateContract<TType> };
+
+export function getDashboardCardStateContract(type: string): DashboardCardStateContract | undefined {
+  return (dashboardCardStateRegistry as Partial<Record<string, DashboardCardStateContract>>)[type];
+}
+
+export function getDashboardCardState(
+  state: DashboardLayoutState,
+  id: string,
+  type: string,
+): DashboardCardStateData | undefined {
+  return getDashboardCardStateContract(type)?.get(state, id);
+}
+
+export function dashboardCardStateEntries(state: DashboardLayoutState): DashboardCardStateInstance[] {
+  const entries: DashboardCardStateInstance[] = [];
+  for (const contract of Object.values(dashboardCardStateRegistry) as DashboardCardStateContract[]) {
+    entries.push(...contract.entries(state));
+  }
+  return entries;
+}
+
+export function maxDashboardCardZOrder(state: DashboardLayoutState): number {
+  let maxZ = 0;
+  for (const { data } of dashboardCardStateEntries(state)) {
+    if (typeof data.zOrder === 'number' && data.zOrder > maxZ) maxZ = data.zOrder;
+  }
+  // Focus overrides live outside the card dicts; a fresh card must still land above them.
+  for (const z of Object.values(state.zOrders)) { if (z > maxZ) maxZ = z; }
+  return maxZ;
+}
+
+export function reconcileDashboardCardZOrder(state: DashboardLayoutState): void {
+  for (const { data } of dashboardCardStateEntries(state)) {
+    if (!data.zOrder) data.zOrder = 0;
+  }
+  state.nextZOrder = maxDashboardCardZOrder(state) + 1;
+}
+
+// creationOrder ledger: card ids in creation order, persisted so the dock/rail can order without timestamps. Idempotent adds; rekey keeps the slot.
+export function ledgerAdd(ledger: string[], id: string): void {
+  if (!ledger.includes(id)) ledger.push(id);
+}
+export function ledgerRemove(ledger: string[], id: string): void {
+  const i = ledger.indexOf(id);
+  if (i !== -1) ledger.splice(i, 1);
+}
+export function ledgerRekey(ledger: string[], oldId: string, newId: string): void {
+  const i = ledger.indexOf(oldId);
+  if (i !== -1) ledger[i] = newId;
+  else ledgerAdd(ledger, newId);
+}

--- a/frontend/src/shared/state/dashboardLayoutClosedReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutClosedReducers.ts
@@ -1,0 +1,64 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  RECENTLY_CLOSED_CAP,
+  viewCardKey,
+  type ClosedCard,
+  type ClosedCardKind,
+  type DashboardLayoutState,
+} from './dashboardLayoutModel';
+import { generateTabId } from './dashboardLayoutBrowserReducers';
+
+export const closedCardReducers = {
+  recordClosedCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ kind: ClosedCardKind; id: string; browserId?: string }>,
+  ) {
+    const { kind, id, browserId } = action.payload;
+    const closedAt = Date.now();
+    const uid = `${kind}-${id}-${closedAt}`;
+    let entry: ClosedCard | null = null;
+    if (kind === 'browser' && state.browserCards[id]) {
+      entry = { uid, kind, closedAt, card: { ...state.browserCards[id], tabs: state.browserCards[id].tabs.map((tab) => ({ ...tab })) } };
+    } else if (kind === 'view' && state.viewCards[id]) {
+      entry = { uid, kind, closedAt, card: { ...state.viewCards[id] } };
+    } else if (kind === 'workflow' && state.workflowCards[id]) {
+      entry = { uid, kind, closedAt, card: { ...state.workflowCards[id] } };
+    } else if (kind === 'agent') {
+      entry = { uid, kind, closedAt, sessionId: id, position: state.cards[id] ? { ...state.cards[id] } : null };
+    } else if (kind === 'tab' && browserId && state.browserCards[browserId]) {
+      const card = state.browserCards[browserId];
+      const index = card.tabs.findIndex((tab) => tab.id === id);
+      if (index >= 0 && card.tabs.length > 1) entry = { uid, kind, closedAt, browserId, index, tab: { ...card.tabs[index] } };
+    }
+    if (!entry) return;
+    state.recentlyClosed.push(entry);
+    if (state.recentlyClosed.length > RECENTLY_CLOSED_CAP) state.recentlyClosed.shift();
+  },
+
+  restoreClosedCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ entry: ClosedCard; dashboardId?: string }>,
+  ) {
+    const { entry, dashboardId } = action.payload;
+    const zOrder = state.nextZOrder++;
+    if (entry.kind === 'browser') {
+      state.browserCards[entry.card.browser_id] = { ...entry.card, zOrder, dashboard_id: dashboardId ?? entry.card.dashboard_id };
+    } else if (entry.kind === 'view') {
+      state.viewCards[viewCardKey(entry.card.output_id, entry.card.instance)] = { ...entry.card, zOrder };
+    } else if (entry.kind === 'workflow') {
+      state.workflowCards[entry.card.workflow_id] = { ...entry.card, zOrder };
+    } else if (entry.kind === 'tab') {
+      const card = state.browserCards[entry.browserId];
+      if (card) {
+        const tab = { ...entry.tab, id: generateTabId() };
+        card.tabs.splice(Math.min(entry.index, card.tabs.length), 0, tab);
+        card.activeTabId = tab.id;
+        card.url = tab.url;
+      }
+    }
+  },
+
+  popClosedCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    state.recentlyClosed = state.recentlyClosed.filter((entry) => entry.uid !== action.payload);
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutFetchAuthority.test.ts
+++ b/frontend/src/shared/state/dashboardLayoutFetchAuthority.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import { configureStore } from '@reduxjs/toolkit';
+import { afterEach, mock, test } from 'node:test';
+import dashboardLayoutReducer, {
+  fetchLayout,
+  saveLayout,
+  type DashboardLayoutState,
+} from './dashboardLayoutSlice';
+import { API_BASE } from '@/shared/config';
+
+// node:test has no fluent response queue; this stand-in gives the fetch stub the same
+// mockResolvedValue / mockResolvedValueOnce / mockImplementationOnce shape the cases read with.
+function fetchMock() {
+  const once: Array<() => Promise<Response>> = [];
+  let fallback: (() => Promise<Response>) | null = null;
+  const fn = mock.fn((..._args: unknown[]) => {
+    const next = once.shift() ?? fallback;
+    if (!next) throw new Error('fetchMock: no response queued');
+    return next();
+  });
+  const api = Object.assign(fn, {
+    mockResolvedValue(response: Response) { fallback = () => Promise.resolve(response); return api; },
+    mockResolvedValueOnce(response: Response) { once.push(() => Promise.resolve(response)); return api; },
+    mockImplementationOnce(impl: () => Promise<Response>) { once.push(impl); return api; },
+  });
+  return api;
+}
+const realFetch = globalThis.fetch;
+
+function savePayload(dashboardId: string, state: DashboardLayoutState) {
+  return {
+    dashboardId,
+    saveAuthority: state.unknownPersistedLayoutFieldsByDashboard[dashboardId],
+    cards: state.cards,
+    viewCards: state.viewCards,
+    browserCards: state.browserCards,
+    workflowCards: state.workflowCards,
+    workflowsHub: state.workflowsHub,
+    expandedSessionIds: state.persistedExpandedSessionIds,
+  };
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function layoutResponse(layout: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(status === 200 ? { layout } : layout), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = realFetch;
+});
+
+test('a late dashboard fetch cannot replace the active dashboard or be saved under its id', async () => {
+  const dashboardAResponse = deferredResponse();
+  const dashboardBResponse = deferredResponse();
+  const fetchSpy = fetchMock()
+    .mockImplementationOnce(() => dashboardAResponse.promise)
+    .mockImplementationOnce(() => dashboardBResponse.promise)
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({ reducer: { dashboardLayout: dashboardLayoutReducer } });
+
+  const dashboardARequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const dashboardBRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+  dashboardBResponse.resolve(layoutResponse({
+    cards: {
+      'dashboard-b-card': {
+        session_id: 'dashboard-b-card', x: 20, y: 30, width: 480, height: 280, zOrder: 1,
+      },
+    },
+    future_cards: { b: { dashboard: 'B' } },
+  }));
+  await dashboardBRequest;
+  dashboardAResponse.resolve(layoutResponse({
+    cards: {
+      'dashboard-a-card': {
+        session_id: 'dashboard-a-card', x: 40, y: 50, width: 480, height: 280, zOrder: 1,
+      },
+    },
+    future_cards: { a: { dashboard: 'A' } },
+  }));
+  await dashboardARequest;
+
+  const activeDashboard = testStore.getState().dashboardLayout;
+  assert.deepEqual(Object.keys(activeDashboard.cards), ['dashboard-b-card']);
+  await testStore.dispatch(saveLayout(savePayload('dashboard-b', activeDashboard)));
+  assert.equal(fetchSpy.mock.calls.length, 3);
+  assert.equal(fetchSpy.mock.calls[2].arguments[0], `${API_BASE}/dashboards/dashboard-b`);
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(Object.keys(saved.cards), ['dashboard-b-card']);
+  assert.deepEqual(saved.future_cards, { b: { dashboard: 'B' } });
+});
+
+test('a late rejected request cannot revoke a superseded dashboard baseline', async () => {
+  const staleDashboardAResponse = deferredResponse();
+  const dashboardBResponse = deferredResponse();
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { a: { dashboard: 'A' } } }))
+    .mockImplementationOnce(() => staleDashboardAResponse.promise)
+    .mockImplementationOnce(() => dashboardBResponse.promise)
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({ reducer: { dashboardLayout: dashboardLayoutReducer } });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const dashboardAAuthority = testStore.getState().dashboardLayout
+    .unknownPersistedLayoutFieldsByDashboard['dashboard-a'];
+  const staleDashboardARequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const dashboardBRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+  dashboardBResponse.resolve(layoutResponse({ future_cards: { b: { dashboard: 'B' } } }));
+  await dashboardBRequest;
+  staleDashboardAResponse.resolve(layoutResponse({ detail: 'dashboard A unavailable' }, 503));
+  await staleDashboardARequest;
+
+  const activeDashboard = testStore.getState().dashboardLayout;
+  assert.strictEqual(
+    activeDashboard.unknownPersistedLayoutFieldsByDashboard['dashboard-a'],
+    dashboardAAuthority,
+  );
+  await testStore.dispatch(saveLayout(savePayload('dashboard-b', activeDashboard)));
+  assert.equal(fetchSpy.mock.calls.length, 4);
+  assert.equal(fetchSpy.mock.calls[3].arguments[0], `${API_BASE}/dashboards/dashboard-b`);
+});
+
+test('only the latest request generation may fulfill for the active dashboard', async () => {
+  const olderResponse = deferredResponse();
+  const latestResponse = deferredResponse();
+  const fetchSpy = fetchMock()
+    .mockImplementationOnce(() => olderResponse.promise)
+    .mockImplementationOnce(() => latestResponse.promise);
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({ reducer: { dashboardLayout: dashboardLayoutReducer } });
+
+  const olderRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const latestRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  latestResponse.resolve(layoutResponse({
+    cards: {
+      latest: { session_id: 'latest', x: 20, y: 30, width: 480, height: 280, zOrder: 1 },
+    },
+    future_cards: { version: 2 },
+  }));
+  await latestRequest;
+  olderResponse.resolve(layoutResponse({
+    cards: {
+      older: { session_id: 'older', x: 40, y: 50, width: 480, height: 280, zOrder: 1 },
+    },
+    future_cards: { version: 1 },
+  }));
+  await olderRequest;
+
+  const current = testStore.getState().dashboardLayout;
+  assert.deepEqual(Object.keys(current.cards), ['latest']);
+  assert.deepEqual(
+    current.unknownPersistedLayoutFieldsByDashboard['dashboard-a'].future_cards,
+    { version: 2 },
+  );
+});
+
+test('an older rejected generation cannot revoke the latest active baseline', async () => {
+  const olderResponse = deferredResponse();
+  const latestResponse = deferredResponse();
+  const fetchSpy = fetchMock()
+    .mockImplementationOnce(() => olderResponse.promise)
+    .mockImplementationOnce(() => latestResponse.promise);
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({ reducer: { dashboardLayout: dashboardLayoutReducer } });
+
+  const olderRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const latestRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  latestResponse.resolve(layoutResponse({ future_cards: { version: 2 } }));
+  await latestRequest;
+  const latestAuthority = testStore.getState().dashboardLayout
+    .unknownPersistedLayoutFieldsByDashboard['dashboard-a'];
+  olderResponse.resolve(layoutResponse({ detail: 'older request failed' }, 503));
+  await olderRequest;
+
+  const current = testStore.getState().dashboardLayout;
+  assert.strictEqual(
+    current.unknownPersistedLayoutFieldsByDashboard['dashboard-a'],
+    latestAuthority,
+  );
+});

--- a/frontend/src/shared/state/dashboardLayoutGeometry.ts
+++ b/frontend/src/shared/state/dashboardLayoutGeometry.ts
@@ -1,0 +1,266 @@
+import {
+  DEFAULT_CARD_H,
+  DEFAULT_CARD_W,
+  EXPANDED_CARD_MIN_H,
+  GRID_GAP,
+  type CardType,
+  type DashboardLayoutState,
+} from './dashboardLayoutModel';
+
+// The renderer's viewport, with the same fallbacks the callers always used; outside a window (the
+// reducer tests run under node:test) it is just the fallback.
+function viewportSize(): { w: number; h: number } {
+  if (typeof window === 'undefined') return { w: 1440, h: 900 };
+  return { w: window.innerWidth || 1440, h: window.innerHeight || 900 };
+}
+
+const GRID_ORIGIN = { x: 40, y: 100 };
+const GRID_COLS_FALLBACK = 4;
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface CardPlacementExclusion {
+  type: CardType;
+  id: string;
+}
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+export function collectOccupiedRects(
+  state: DashboardLayoutState,
+  expandedSessionIds?: string[],
+  exclude?: CardPlacementExclusion,
+): Rect[] {
+  const expanded = new Set(expandedSessionIds);
+  const rects: Rect[] = [];
+  for (const c of Object.values(state.cards)) {
+    if (exclude?.type === 'agent' && exclude.id === c.session_id) continue;
+    const h = expanded.has(c.session_id) ? Math.max(EXPANDED_CARD_MIN_H, c.height) : c.height;
+    rects.push({ x: c.x, y: c.y, w: c.width, h });
+  }
+  for (const c of Object.values(state.viewCards)) {
+    if (exclude?.type === 'view' && exclude.id === c.output_id) continue;
+    rects.push({ x: c.x, y: c.y, w: c.width, h: c.height });
+  }
+  for (const c of Object.values(state.browserCards)) {
+    if (exclude?.type === 'browser' && exclude.id === c.browser_id) continue;
+    rects.push({ x: c.x, y: c.y, w: c.width, h: c.height });
+  }
+  for (const w of Object.values(state.workflowCards)) {
+    rects.push({ x: w.x, y: w.y, w: w.width, h: w.height });
+  }
+  if (state.workflowsHub) {
+    rects.push({ x: state.workflowsHub.x, y: state.workflowsHub.y, w: state.workflowsHub.width, h: state.workflowsHub.height });
+  }
+  return rects;
+}
+
+export function findOpenGridCell(
+  occupiedRects: Rect[],
+  newW: number,
+  newH: number,
+  colLimit?: number,
+): { x: number; y: number } {
+  const cellW = DEFAULT_CARD_W + GRID_GAP;
+  const cellH = DEFAULT_CARD_H + GRID_GAP;
+  const maxCols = colLimit ?? Math.max(
+    1,
+    Math.floor((viewportSize().w - GRID_ORIGIN.x) / cellW) || GRID_COLS_FALLBACK,
+  );
+
+  for (let row = 0; ; row++) {
+    for (let col = 0; col < maxCols; col++) {
+      const x = GRID_ORIGIN.x + col * cellW;
+      const y = GRID_ORIGIN.y + row * cellH;
+      const candidate: Rect = { x, y, w: newW, h: newH };
+      if (!occupiedRects.some((r) => rectsOverlap(candidate, r))) {
+        return { x, y };
+      }
+    }
+  }
+}
+
+// Like findOpenGridCell but biased to stay near a proposed (x,y) anchor. Used when the backend hands us a card with a position that's already occupied (sub-agent or sub-browser spawning on top of its parent or a sibling). Spirals outward from the anchor on a grid, snapping to cell-aligned positions so the result still looks intentional, not dropped from orbit. Caps the spiral search at ~1000 cells to avoid pathological work in adversarial layouts, falls back to findOpenGridCell after that. Cost: O(rects x cells_scanned). Spawn events are rare (not per-frame), so this only runs when a new card appears. Typical scan resolves in <10 cells, well below the cap. No perf impact on steady-state UI.
+export function findOpenSpotNear(
+  anchorX: number,
+  anchorY: number,
+  occupiedRects: Rect[],
+  newW: number,
+  newH: number,
+): { x: number; y: number } {
+  const cellW = DEFAULT_CARD_W + GRID_GAP;
+  const cellH = DEFAULT_CARD_H + GRID_GAP;
+  // Snap the anchor to the nearest grid cell so cards align.
+  const baseCol = Math.round((anchorX - GRID_ORIGIN.x) / cellW);
+  const baseRow = Math.round((anchorY - GRID_ORIGIN.y) / cellH);
+
+  const cellFree = (col: number, row: number): boolean => {
+    const x = GRID_ORIGIN.x + col * cellW;
+    const y = GRID_ORIGIN.y + row * cellH;
+    const candidate: Rect = { x, y, w: newW, h: newH };
+    return !occupiedRects.some((r) => rectsOverlap(candidate, r));
+  };
+
+  if (cellFree(baseCol, baseRow)) {
+    return {
+      x: GRID_ORIGIN.x + baseCol * cellW,
+      y: GRID_ORIGIN.y + baseRow * cellH,
+    };
+  }
+
+  // Spiral by ring perimeter; right/down preference for stability.
+  const MAX_RING = 32;
+  for (let r = 1; r <= MAX_RING; r++) {
+    for (let dy = -r; dy <= r; dy++) {
+      for (let dx = -r; dx <= r; dx++) {
+        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
+        const col = baseCol + dx;
+        const row = baseRow + dy;
+        if (col < 0 || row < 0) continue;
+        if (cellFree(col, row)) {
+          return {
+            x: GRID_ORIGIN.x + col * cellW,
+            y: GRID_ORIGIN.y + row * cellH,
+          };
+        }
+      }
+    }
+  }
+
+  // Pathological, full canvas occupied near anchor. Fall back to the global first-empty scan so we never return an overlap.
+  return findOpenGridCell(occupiedRects, newW, newH);
+}
+
+// Dock a new card to the right of an anchor card, stacking under any cards already in that right-hand column. Anchor is any rect, so a browser can dock beside a normal agent card OR a workflow run/monitor card that has no session entry in state.cards.
+export function placeBesideCard(
+  state: DashboardLayoutState,
+  anchor: { x: number; y: number; width: number; height: number },
+  newW: number,
+  newH: number,
+  expandedSessionIds?: string[],
+  exclude?: CardPlacementExclusion,
+  gap: number = GRID_GAP * 12,
+  exact: boolean = false,
+): { x: number; y: number } {
+  const rects = collectOccupiedRects(state, expandedSessionIds, exclude);
+  const targetX = anchor.x + anchor.width + gap;
+  const columnCards = [
+    ...Object.values(state.browserCards).filter(
+      (c) => !(exclude?.type === 'browser' && exclude.id === c.browser_id),
+    ),
+    ...Object.values(state.viewCards).filter(
+      (c) => !(exclude?.type === 'view' && exclude.id === c.output_id),
+    ),
+  ].filter((c) => Math.abs(c.x - targetX) < 50);
+  const targetY = columnCards.length > 0
+    ? Math.max(...columnCards.map((c) => c.y + c.height)) + GRID_GAP
+    : anchor.y;
+
+  // exact keeps the precise gap (so the card mirrors however its anchor was placed, e.g. a run browser matching the hub->monitor gap); grid-snapping would knock that gap off. Fall back to the snapped search only if the exact spot is taken.
+  if (exact && !rects.some((r) => rectsOverlap({ x: targetX, y: targetY, w: newW, h: newH }, r))) {
+    return { x: targetX, y: targetY };
+  }
+  return findOpenSpotNear(targetX, targetY, rects, newW, newH);
+}
+
+// Dock a chat-spawned browser to the right of its chat card. Unlike placeBesideCard, this ALWAYS lands beside the chat (overlap is fine, the new card sits on top via zOrder) so an occupied spot can never fling the browser to a far grid cell or stack it under an unrelated card. Only this chat's OWN browsers (same spawned_by, still in the column) stack under each other so siblings don't fully cover one another; every other card is ignored.
+export function placeBrowserBesideChat(
+  state: DashboardLayoutState,
+  chat: { x: number; y: number; width: number; height: number },
+  parentSessionId: string,
+  newW: number,
+  newH: number,
+  excludeBrowserId?: string,
+): { x: number; y: number } {
+  const targetX = chat.x + chat.width + GRID_GAP * 12;
+  const siblings = Object.values(state.browserCards).filter(
+    (c) => c.browser_id !== excludeBrowserId && c.spawned_by === parentSessionId && Math.abs(c.x - targetX) < 50,
+  );
+  const targetY = siblings.length > 0
+    ? Math.max(...siblings.map((c) => c.y + c.height)) + GRID_GAP
+    : chat.y;
+  return { x: targetX, y: targetY };
+}
+
+// Dock a new card directly below an anchor card (left edges aligned). Used for a browser spawned by a Workflows-hub chat, which has no agent card to sit beside.
+export function placeBelowCard(
+  state: DashboardLayoutState,
+  anchor: { x: number; y: number; width: number; height: number },
+  newW: number,
+  newH: number,
+  expandedSessionIds?: string[],
+  exclude?: CardPlacementExclusion,
+): { x: number; y: number } {
+  const rects = collectOccupiedRects(state, expandedSessionIds, exclude);
+  return findOpenSpotNear(anchor.x, anchor.y + anchor.height + GRID_GAP, rects, newW, newH);
+}
+
+export function placeInParentColumn(
+  state: DashboardLayoutState,
+  parentSessionId: string | null | undefined,
+  newW: number,
+  newH: number,
+  expandedSessionIds?: string[],
+  exclude?: CardPlacementExclusion,
+): { x: number; y: number } {
+  const parentCard = parentSessionId ? state.cards[parentSessionId] : null;
+  if (!parentCard) {
+    return findOpenGridCell(collectOccupiedRects(state, expandedSessionIds, exclude), newW, newH);
+  }
+  return placeBesideCard(state, parentCard, newW, newH, expandedSessionIds, exclude);
+}
+
+// Where a user-created card (chat/app/browser) should land. Resolved in the UI layer where selection + viewport are known, then handed to the add reducers as an explicit x/y. `beside` (the currently selected card) docks the new card to its right, stacking under that column (collision-aware); `viewportCenter` (canvas-space center of what the user is looking at) drops it dead-center "in front of you", overlapping whatever's there. With neither, falls back to the legacy top-left grid scan.
+export interface SpawnAnchor {
+  beside?: { x: number; y: number; width: number; height: number };
+  viewportCenter?: { x: number; y: number };
+}
+
+export function computeSpawnPosition(
+  state: DashboardLayoutState,
+  newW: number,
+  newH: number,
+  anchor: SpawnAnchor,
+  expandedSessionIds?: string[],
+): { x: number; y: number } {
+  if (anchor.beside) {
+    return placeBesideCard(state, anchor.beside, newW, newH, expandedSessionIds);
+  }
+  if (anchor.viewportCenter) {
+    // Land dead-center, "in front of you", even if a card is already there. Overlap is intentional (new card sits on top via its higher zOrder); dodging to free space is exactly the "spawned off to the side" behavior we're removing.
+    return { x: anchor.viewportCenter.x - newW / 2, y: anchor.viewportCenter.y - newH / 2 };
+  }
+  return findOpenGridCell(collectOccupiedRects(state, expandedSessionIds), newW, newH);
+}
+
+// Tidy packs into the grid shape that fills the SCREEN best. The default column count is derived from window.innerWidth, which is screen pixels pretending to be world units: it laid 8 cards out as a 2-wide, 4-tall ribbon that the camera then had to pull back to 41% to show.
+export function tidyColumnCount(itemSizes: Array<{ w: number; h: number }>): number {
+  const cellW = DEFAULT_CARD_W + GRID_GAP;
+  const cellH = DEFAULT_CARD_H + GRID_GAP;
+  let cells = 0;
+  let widest = 1;
+  for (const s of itemSizes) {
+    const cols = Math.max(1, Math.ceil(s.w / cellW));
+    cells += cols * Math.max(1, Math.ceil(s.h / cellH));
+    widest = Math.max(widest, cols);
+  }
+  const { w: vw, h: vh } = viewportSize();
+  let best = widest;
+  let bestZoom = 0;
+  for (let cols = widest; cols <= Math.max(widest, cells); cols++) {
+    const rows = Math.ceil(cells / cols);
+    const zoom = Math.min(vw / (cols * cellW), vh / (rows * cellH));
+    if (zoom > bestZoom) {
+      bestZoom = zoom;
+      best = cols;
+    }
+  }
+  return best;
+}

--- a/frontend/src/shared/state/dashboardLayoutGlowReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutGlowReducers.ts
@@ -1,0 +1,49 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import type { DashboardLayoutState } from './dashboardLayoutModel';
+
+export const glowReducers = {
+  setGlowingBrowserCards(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ browserIds: string[]; sessionId: string; label?: string }>,
+  ) {
+    const { browserIds, sessionId, label } = action.payload;
+    for (const id of browserIds) {
+      state.glowingBrowserCards[id] = { sourceId: sessionId, fading: false, label };
+    }
+  },
+
+  fadeGlowingBrowserCards(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const sessionId = action.payload;
+    for (const entry of Object.values(state.glowingBrowserCards)) {
+      if (entry.sourceId === sessionId) entry.fading = true;
+    }
+  },
+
+  clearGlowingBrowserCards(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const sessionId = action.payload;
+    for (const [browserId, entry] of Object.entries(state.glowingBrowserCards)) {
+      if (entry.sourceId === sessionId) delete state.glowingBrowserCards[browserId];
+    }
+  },
+
+  clearAllGlowingBrowserCards(state: DashboardLayoutState) {
+    state.glowingBrowserCards = {};
+  },
+
+  setGlowingAgentCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ sessionId: string; sourceId: string; sourceYRatio?: number; label?: string }>,
+  ) {
+    const { sessionId, sourceId, sourceYRatio, label } = action.payload;
+    state.glowingAgentCards[sessionId] = { sourceId, fading: false, sourceYRatio, label };
+  },
+
+  fadeGlowingAgentCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const entry = state.glowingAgentCards[action.payload];
+    if (entry) entry.fading = true;
+  },
+
+  clearGlowingAgentCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.glowingAgentCards[action.payload];
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutModel.ts
+++ b/frontend/src/shared/state/dashboardLayoutModel.ts
@@ -1,0 +1,224 @@
+export const DEFAULT_CARD_W = 480;
+export const DEFAULT_CARD_H = 280;
+export const DEFAULT_VIEW_CARD_W = 1280;
+export const DEFAULT_VIEW_CARD_H = 800;
+export const DEFAULT_BROWSER_CARD_W = 1280;
+export const DEFAULT_BROWSER_CARD_H = 800;
+export const DEFAULT_SETTINGS_CARD_W = DEFAULT_BROWSER_CARD_W;
+export const DEFAULT_SETTINGS_CARD_H = DEFAULT_BROWSER_CARD_H;
+export const WORKFLOWS_HUB_ID = 'workflows-hub';
+export const SETTINGS_CARD_ID = 'settings';
+export const MARKETPLACE_CARD_ID = 'marketplace';
+export const DEFAULT_MARKETPLACE_CARD_W = DEFAULT_BROWSER_CARD_W;
+export const DEFAULT_MARKETPLACE_CARD_H = DEFAULT_BROWSER_CARD_H;
+export const DEFAULT_WORKFLOW_CARD_W = 480;
+export const DEFAULT_WORKFLOW_CARD_H = 520;
+// Open at the same default footprint as a browser/view card so it lands at a comfortable size automatically.
+export const DEFAULT_WORKFLOWS_HUB_W = DEFAULT_BROWSER_CARD_W;
+export const DEFAULT_WORKFLOWS_HUB_H = DEFAULT_BROWSER_CARD_H;
+export const EXPANDED_CARD_MIN_H = 620;
+export const GRID_GAP = 24;
+// Gap between the Workflows window and the cards it spawns (run monitor, that monitor's browser). Keeps the hub -> monitor -> browser row evenly spaced.
+export const WORKFLOW_CARD_GAP = 140;
+
+export type CardType = 'agent' | 'view' | 'browser' | 'workflow' | 'workflows-hub' | 'workflows-monitor' | 'settings' | 'marketplace';
+
+export interface CardPosition {
+  session_id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+}
+
+export interface ViewCardPosition {
+  output_id: string;
+  // Which instance of the app this card is (1 = primary, absent on pre-instance layouts). Each instance is a fully independent runtime on its own ports.
+  instance?: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+  parent_session_id?: string | null;
+  /** Chat this view card is parked inside while that chat is expanded; null/undefined = free on the canvas. */
+  docked_to?: string | null;
+  /** A view card whose live preview has not been activated yet (serve-static / lazy boot). */
+  preview_deferred?: boolean;
+}
+
+// Record key + card identity for a view card. The primary keeps the bare output_id so persisted layouts and every existing by-output lookup stay valid; secondaries append #N.
+export function viewCardKey(outputId: string, instance?: number): string {
+  return (instance ?? 1) > 1 ? `${outputId}#${instance}` : outputId;
+}
+
+export interface BrowserTab {
+  id: string;
+  url: string;
+  title: string;
+  favicon?: string;
+}
+
+export interface BrowserCardPosition {
+  browser_id: string;
+  url: string;
+  tabs: BrowserTab[];
+  activeTabId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+  /** Agent session that spawned this browser; auto-removed when its owner reaches terminal state. */
+  spawned_by?: string | null;
+  keep_open?: boolean;
+  /** Dashboard this card belongs to; cards render and persist only on their owning dashboard. */
+  dashboard_id?: string;
+  /** Chat this browser is parked inside while that chat is expanded; null/undefined = free on the canvas. */
+  docked_to?: string | null;
+}
+
+export interface WorkflowCardPosition {
+  workflow_id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+  source_session_id?: string | null;
+}
+
+/** Singleton per dashboard; only one Workflows Hub card open at a time. */
+export interface WorkflowsHubPosition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  zOrder: number;
+}
+
+
+// One entry in the Ctrl/Cmd+Shift+T "reopen last closed" stack: a full snapshot for browser/view/workflow/tab, just the session id for an agent (its session is brought back via resumeSession).
+export type ClosedCard =
+  | { uid: string; kind: 'browser'; closedAt: number; card: BrowserCardPosition }
+  | { uid: string; kind: 'view'; closedAt: number; card: ViewCardPosition }
+  | { uid: string; kind: 'workflow'; closedAt: number; card: WorkflowCardPosition }
+  | { uid: string; kind: 'tab'; closedAt: number; browserId: string; index: number; tab: BrowserTab }
+  | { uid: string; kind: 'agent'; closedAt: number; sessionId: string; position: CardPosition | null };
+
+export type ClosedCardKind = ClosedCard['kind'];
+
+export const RECENTLY_CLOSED_CAP = 25;
+
+export interface DashboardLayoutState {
+  cards: Record<string, CardPosition>;
+  viewCards: Record<string, ViewCardPosition>;
+  browserCards: Record<string, BrowserCardPosition>;
+  workflowCards: Record<string, WorkflowCardPosition>;
+  workflowsHub: WorkflowsHubPosition | null;
+  /** Unrecognized persisted layout partitions retained per dashboard for forward/legacy compatibility. */
+  unknownPersistedLayoutFieldsByDashboard: Record<string, Record<string, unknown>>;
+  closedCardPositions: Record<string, CardPosition>;
+  /** Session-global LIFO undo stack for Ctrl/Cmd+Shift+T; survives dashboard switches (resetLayout leaves it alone). */
+  recentlyClosed: ClosedCard[];
+  glowingBrowserCards: Record<string, { sourceId: string; fading: boolean; label?: string }>;
+  glowingAgentCards: Record<string, { sourceId: string; fading: boolean; sourceYRatio?: number; label?: string }>;
+  persistedExpandedSessionIds: string[];
+  nextZOrder: number;
+  loading: boolean;
+  initialized: boolean;
+  /** Dashboard whose latest layout request may update the global canvas. */
+  activeFetchDashboardId: string | null;
+  /** Exact latest request generation for activeFetchDashboardId. */
+  activeFetchRequestId: string | null;
+  /** Transient: new browser card id; Dashboard pans/zooms to it then clears via clearPendingFocusBrowserId. */
+  pendingFocusBrowserId: string | null;
+  // Set when a view card is opened from outside the canvas (sidebar app click / toolbar picker) so the dashboard fits+highlights it on arrival; holds the card key.
+  pendingFocusViewCardId: string | null;
+  /** Transient: snapshot stand-ins for off-screen webviews; never rides the layout PUT. */
+  suspendedBrowserCards: Record<string, { dataUrl: string; capturedAt: number }>;
+  /** Transient: spawned cards that are about to be removed; surfaces the fade + Keep pill. */
+  endingBrowserCards: Record<string, { status: 'completed' | 'error'; at: number }>;
+  /** Transient: id of the view card the user has clicked into; preload stops forwarding canvas gestures while set. */
+  activeViewCardId: string | null;
+  pendingFocusWorkflowId: string | null;
+  /** Transient: signals Dashboard to pan/zoom to the singleton Workflows Hub on open. */
+  pendingFocusWorkflowsHub: boolean;
+  /** Transient deep-link target: the Workflows card jumps to this workflow's detail on open, then clears it. */
+  workflowsAppTarget: string | null;
+  /** Workflow id whose live run is being watched in the Run Monitor card docked beside the window. Null = closed. */
+  workflowsMonitorId: string | null;
+  /** Specific run id to show in the monitor (e.g. clicked from history); null = follow the latest run. */
+  workflowsMonitorRunId: string | null;
+  /** Geometry of the spawned Run Monitor card (a real canvas card, tethered to the window). Ephemeral, not persisted. */
+  workflowsMonitorCard: WorkflowsHubPosition | null;
+  /** A run attached to a workflow's chat as a removable context chip; its transcript rides along each send until removed. */
+  workflowsRunContext: WorkflowsRunContext | null;
+  /** Cards parked in the minimize rail; the card renders off-canvas behind a frozen still. */
+  minimizedCards: Record<string, boolean>;
+  /** cardId -> tile zone; a tiled card is pinned to a screen zone until cleared. */
+  tiledCards: Record<string, string>;
+  /** False until a fetch has succeeded once; save() refuses to persist an un-hydrated (default) layout. */
+  saveArmed: boolean;
+  settingsCard: WorkflowsHubPosition | null;
+  pendingFocusSettingsCard: boolean;
+  settingsRequestedTab: string | null;
+  marketplaceCard: WorkflowsHubPosition | null;
+  pendingFocusMarketplaceCard: boolean;
+  marketplaceRequestedTab: string | null;
+  /** Focus bumps write here instead of into the card dicts, so a click never re-identifies a card and arms a layout PUT. */
+  zOrders: Record<string, number>;
+  /** Card ids in creation order; persisted so the dock/rail can order without timestamps. */
+  creationOrder: string[];
+}
+
+export interface WorkflowsRunContext {
+  workflowId: string;
+  runId: string;
+  title: string;
+  metaLabel: string;
+  color: string;
+}
+
+export const initialDashboardLayoutState: DashboardLayoutState = {
+  cards: {},
+  viewCards: {},
+  browserCards: {},
+  workflowCards: {},
+  workflowsHub: null,
+  unknownPersistedLayoutFieldsByDashboard: {},
+  closedCardPositions: {},
+  recentlyClosed: [],
+  glowingBrowserCards: {},
+  glowingAgentCards: {},
+  persistedExpandedSessionIds: [],
+  nextZOrder: 1,
+  loading: false,
+  initialized: false,
+  activeFetchDashboardId: null,
+  activeFetchRequestId: null,
+  pendingFocusBrowserId: null,
+  pendingFocusViewCardId: null,
+  suspendedBrowserCards: {},
+  endingBrowserCards: {},
+  activeViewCardId: null,
+  pendingFocusWorkflowId: null,
+  pendingFocusWorkflowsHub: false,
+  workflowsAppTarget: null,
+  workflowsMonitorId: null,
+  workflowsMonitorRunId: null,
+  workflowsMonitorCard: null,
+  workflowsRunContext: null,
+  minimizedCards: {},
+  tiledCards: {},
+  saveArmed: false,
+  settingsCard: null,
+  pendingFocusSettingsCard: false,
+  settingsRequestedTab: null,
+  marketplaceCard: null,
+  pendingFocusMarketplaceCard: false,
+  marketplaceRequestedTab: null,
+  creationOrder: [],
+  zOrders: {},
+};

--- a/frontend/src/shared/state/dashboardLayoutResetReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutResetReducers.ts
@@ -1,0 +1,39 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import type { DashboardLayoutState } from './dashboardLayoutModel';
+
+export const resetReducers = {
+  resetLayout(state: DashboardLayoutState, action: PayloadAction<{ keepBrowserIds?: string[] } | undefined>) {
+    const keep = new Set(action.payload?.keepBrowserIds || []);
+    const keptBrowsers: typeof state.browserCards = {};
+    const keptSuspended: typeof state.suspendedBrowserCards = {};
+    for (const id of keep) {
+      if (state.browserCards[id]) keptBrowsers[id] = state.browserCards[id];
+      if (state.suspendedBrowserCards[id]) keptSuspended[id] = state.suspendedBrowserCards[id];
+    }
+    state.cards = {};
+    state.viewCards = {};
+    state.browserCards = keptBrowsers;
+    state.tiledCards = {};
+    state.minimizedCards = {};
+    state.settingsCard = null;
+    state.pendingFocusSettingsCard = false;
+    state.settingsRequestedTab = null;
+    state.marketplaceCard = null;
+    state.pendingFocusMarketplaceCard = false;
+    state.marketplaceRequestedTab = null;
+    state.saveArmed = false;
+    // Per-dashboard, same as the cards it tracks; fetchLayout.fulfilled rebuilds it for the new dashboard.
+    state.creationOrder = [];
+    state.workflowCards = {};
+    state.workflowsHub = null;
+    state.closedCardPositions = {};
+    state.glowingBrowserCards = {};
+    state.glowingAgentCards = {};
+    state.persistedExpandedSessionIds = [];
+    state.nextZOrder = 1;
+    state.initialized = false;
+    state.suspendedBrowserCards = keptSuspended;
+    state.endingBrowserCards = {};
+    state.pendingFocusWorkflowId = null;
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutSaveAuthority.test.ts
+++ b/frontend/src/shared/state/dashboardLayoutSaveAuthority.test.ts
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import { configureStore } from '@reduxjs/toolkit';
+import { afterEach, mock, test } from 'node:test';
+import dashboardLayoutReducer, {
+  fetchLayout,
+  saveLayout,
+  type DashboardLayoutState,
+} from './dashboardLayoutSlice';
+import { API_BASE } from '@/shared/config';
+
+// node:test has no fluent response queue; this stand-in gives the fetch stub the same
+// mockResolvedValue / mockResolvedValueOnce / mockImplementationOnce shape the cases read with.
+function fetchMock() {
+  const once: Array<() => Promise<Response>> = [];
+  let fallback: (() => Promise<Response>) | null = null;
+  const fn = mock.fn((..._args: unknown[]) => {
+    const next = once.shift() ?? fallback;
+    if (!next) throw new Error('fetchMock: no response queued');
+    return next();
+  });
+  const api = Object.assign(fn, {
+    mockResolvedValue(response: Response) { fallback = () => Promise.resolve(response); return api; },
+    mockResolvedValueOnce(response: Response) { once.push(() => Promise.resolve(response)); return api; },
+    mockImplementationOnce(impl: () => Promise<Response>) { once.push(impl); return api; },
+  });
+  return api;
+}
+const realFetch = globalThis.fetch;
+
+function initialState(): DashboardLayoutState {
+  return dashboardLayoutReducer(undefined, { type: '@@dashboardLayout/test-init' });
+}
+
+function savePayload(dashboardId: string, state: DashboardLayoutState) {
+  return {
+    dashboardId,
+    saveAuthority: state.unknownPersistedLayoutFieldsByDashboard[dashboardId],
+    cards: state.cards,
+    viewCards: state.viewCards,
+    browserCards: state.browserCards,
+    workflowCards: state.workflowCards,
+    workflowsHub: state.workflowsHub,
+    expandedSessionIds: state.persistedExpandedSessionIds,
+  };
+}
+
+function layoutResponse(layout: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(status === 200 ? { layout } : layout), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = realFetch;
+});
+
+test('a rejected fetch blocks delayed and unmount saves from erasing server layout state', async () => {
+  const fetchSpy = fetchMock()
+    .mockResolvedValue(new Response(JSON.stringify({ detail: 'temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-one' }));
+  const emptyLayout = testStore.getState().dashboardLayout;
+  const delayedOrUnmountSave = savePayload('dashboard-one', emptyLayout);
+
+  await testStore.dispatch(saveLayout(delayedOrUnmountSave));
+  await testStore.dispatch(saveLayout(delayedOrUnmountSave));
+
+  assert.equal(fetchSpy.mock.calls.length, 1);
+  assert.equal(fetchSpy.mock.calls[0].arguments[1], undefined);
+});
+
+test('a rejected fetch blocks only that dashboard from saving', async () => {
+  const dashboardBFutureCards = { future: { card_id: 'future-b', payload: { dashboard: 'B' } } };
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(new Response(JSON.stringify({ detail: 'dashboard A unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { future_cards: dashboardBFutureCards },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+  const loadedDashboardB = testStore.getState().dashboardLayout;
+
+  await testStore.dispatch(saveLayout(savePayload('dashboard-a', initialState())));
+  await testStore.dispatch(saveLayout(savePayload('dashboard-b', loadedDashboardB)));
+
+  assert.equal(fetchSpy.mock.calls.length, 3);
+  assert.equal(fetchSpy.mock.calls[2].arguments[0], `${API_BASE}/dashboards/dashboard-b`);
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, dashboardBFutureCards);
+});
+
+test('a successful refetch restores save authority after a rejection', async () => {
+  const futureCards = { future: { card_id: 'future-a', payload: { recoverable: true } } };
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(new Response(JSON.stringify({ detail: 'temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { future_cards: futureCards },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const recovered = testStore.getState().dashboardLayout;
+  await testStore.dispatch(saveLayout(savePayload('dashboard-a', recovered)));
+
+  assert.equal(fetchSpy.mock.calls.length, 3);
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, futureCards);
+});
+
+test('a save captured before a successful refetch remains blocked after recovery', async () => {
+  const futureCards = { future: { card_id: 'future-a', payload: { recoverable: true } } };
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(new Response(JSON.stringify({ detail: 'temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { future_cards: futureCards },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const staleUnmountSave = savePayload('dashboard-a', testStore.getState().dashboardLayout);
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const recovered = testStore.getState().dashboardLayout;
+
+  await testStore.dispatch(saveLayout(staleUnmountSave));
+  await testStore.dispatch(saveLayout(savePayload('dashboard-a', recovered)));
+
+  assert.equal(fetchSpy.mock.calls.length, 3);
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, futureCards);
+});
+
+test('a defined but superseded successful baseline cannot authorize a stale save', async () => {
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { version: 1 } }))
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { version: 2 } }))
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const staleSave = savePayload('dashboard-a', testStore.getState().dashboardLayout);
+  assert.notEqual(staleSave.saveAuthority, undefined);
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const currentSave = savePayload('dashboard-a', testStore.getState().dashboardLayout);
+  assert.notStrictEqual(staleSave.saveAuthority, currentSave.saveAuthority);
+
+  await testStore.dispatch(saveLayout(staleSave));
+  await testStore.dispatch(saveLayout(currentSave));
+
+  assert.equal(fetchSpy.mock.calls.length, 3);
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, { version: 2 });
+});
+
+test('a pending refetch revokes the old baseline before another save can use it', async () => {
+  const pendingRefetch = deferredResponse();
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { version: 1 } }))
+    .mockImplementationOnce(() => pendingRefetch.promise)
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const staleSave = savePayload('dashboard-a', testStore.getState().dashboardLayout);
+  const newerRequest = testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+
+  await testStore.dispatch(saveLayout(staleSave));
+
+  assert.equal(fetchSpy.mock.calls.length, 2);
+  pendingRefetch.resolve(layoutResponse({ future_cards: { version: 2 } }));
+  await newerRequest;
+});
+
+test('rejecting one of two loaded dashboards preserves the other dashboard authority', async () => {
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { a: { dashboard: 'A' } } }))
+    .mockResolvedValueOnce(layoutResponse({ future_cards: { b: { dashboard: 'B' } } }))
+    .mockResolvedValueOnce(layoutResponse({ detail: 'dashboard B unavailable' }, 503))
+    .mockResolvedValue(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const dashboardA = testStore.getState().dashboardLayout;
+  const dashboardASave = savePayload('dashboard-a', dashboardA);
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+
+  const rejectedDashboardB = testStore.getState().dashboardLayout;
+  assert.strictEqual(
+    rejectedDashboardB.unknownPersistedLayoutFieldsByDashboard['dashboard-a'],
+    dashboardASave.saveAuthority,
+  );
+  assert.equal(rejectedDashboardB.unknownPersistedLayoutFieldsByDashboard['dashboard-b'], undefined);
+  await testStore.dispatch(saveLayout(dashboardASave));
+
+  assert.equal(fetchSpy.mock.calls.length, 4);
+  assert.equal(fetchSpy.mock.calls[3].arguments[0], `${API_BASE}/dashboards/dashboard-a`);
+});

--- a/frontend/src/shared/state/dashboardLayoutSlice.test.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.test.ts
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import { configureStore } from '@reduxjs/toolkit';
+import { afterEach, mock, test } from 'node:test';
+import dashboardLayoutReducer, {
+  addViewCard,
+  bringToFront,
+  DEFAULT_BROWSER_CARD_H,
+  DEFAULT_BROWSER_CARD_W,
+  DEFAULT_CARD_H,
+  DEFAULT_CARD_W,
+  fetchLayout,
+  GRID_GAP,
+  computeSpawnPosition,
+  findOpenGridCell,
+  placeCard,
+  popClosedCard,
+  recordClosedCard,
+  removeBrowserCard,
+  resetLayout,
+  restoreClosedCard,
+  saveLayout,
+  type BrowserCardPosition,
+  type DashboardLayoutState,
+} from './dashboardLayoutSlice';
+
+// node:test has no fluent response queue; this stand-in gives the fetch stub the same
+// mockResolvedValue / mockResolvedValueOnce / mockImplementationOnce shape the cases read with.
+function fetchMock() {
+  const once: Array<() => Promise<Response>> = [];
+  let fallback: (() => Promise<Response>) | null = null;
+  const fn = mock.fn((..._args: unknown[]) => {
+    const next = once.shift() ?? fallback;
+    if (!next) throw new Error('fetchMock: no response queued');
+    return next();
+  });
+  const api = Object.assign(fn, {
+    mockResolvedValue(response: Response) { fallback = () => Promise.resolve(response); return api; },
+    mockResolvedValueOnce(response: Response) { once.push(() => Promise.resolve(response)); return api; },
+    mockImplementationOnce(impl: () => Promise<Response>) { once.push(impl); return api; },
+  });
+  return api;
+}
+const realFetch = globalThis.fetch;
+
+function initialState(): DashboardLayoutState {
+  return dashboardLayoutReducer(undefined, { type: '@@dashboardLayout/test-init' });
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = realFetch;
+  delete (globalThis as { window?: unknown }).window;
+});
+
+// The geometry helpers size the grid from the renderer viewport; under node there is no window, so
+// the cases that depend on the column count install a minimal one.
+function stubViewport(innerWidth: number) {
+  (globalThis as { window?: unknown }).window = { innerWidth, innerHeight: 900 };
+}
+
+test('findOpenGridCell scans left-to-right then down from the legacy origin', () => {
+  stubViewport(1600);
+  const firstCell = { x: 40, y: 100, w: DEFAULT_CARD_W, h: DEFAULT_CARD_H };
+
+  assert.deepEqual(
+    findOpenGridCell([firstCell], DEFAULT_CARD_W, DEFAULT_CARD_H),
+    { x: 40 + DEFAULT_CARD_W + GRID_GAP, y: 100 },
+  );
+});
+
+test('computeSpawnPosition keeps viewport-centered spawns exact', () => {
+  const state = initialState();
+
+  assert.deepEqual(
+    computeSpawnPosition(state, 200, 120, { viewportCenter: { x: 700, y: 460 } }),
+    { x: 600, y: 400 },
+  );
+});
+
+test('placeCard collision-dodges unless the caller requests exact placement', () => {
+  stubViewport(1600);
+  let state = initialState();
+
+  state = dashboardLayoutReducer(state, placeCard({
+    sessionId: 'alpha',
+    x: 40,
+    y: 100,
+    width: DEFAULT_CARD_W,
+    height: DEFAULT_CARD_H,
+  }));
+  state = dashboardLayoutReducer(state, placeCard({
+    sessionId: 'beta',
+    x: 40,
+    y: 100,
+    width: DEFAULT_CARD_W,
+    height: DEFAULT_CARD_H,
+  }));
+  state = dashboardLayoutReducer(state, placeCard({
+    sessionId: 'gamma',
+    x: 40,
+    y: 100,
+    width: DEFAULT_CARD_W,
+    height: DEFAULT_CARD_H,
+    exact: true,
+  }));
+
+  assert.deepEqual(
+    { x: state.cards.alpha.x, y: state.cards.alpha.y },
+    { x: 40, y: 100 },
+  );
+  assert.deepEqual(
+    { x: state.cards.beta.x, y: state.cards.beta.y },
+    { x: 40 + DEFAULT_CARD_W + GRID_GAP, y: 100 },
+  );
+  assert.deepEqual(
+    { x: state.cards.gamma.x, y: state.cards.gamma.y },
+    { x: 40, y: 100 },
+  );
+});
+
+test('addViewCard refocuses and brings an existing app card forward', () => {
+  let state = dashboardLayoutReducer(initialState(), addViewCard({
+    outputId: 'app-one',
+    x: 80,
+    y: 120,
+  }));
+  state = {
+    ...state,
+    pendingFocusViewCardId: null,
+    nextZOrder: 9,
+  };
+
+  state = dashboardLayoutReducer(state, addViewCard({ outputId: 'app-one' }));
+
+  assert.deepEqual(Object.keys(state.viewCards), ['app-one']);
+  assert.equal(state.viewCards['app-one'].zOrder, 9);
+  assert.equal(state.nextZOrder, 10);
+  assert.equal(state.pendingFocusViewCardId, 'app-one');
+});
+
+test('browser reopen stack records, restores, and pops a dashboard-scoped browser card', () => {
+  mock.method(Date, 'now', () => 123456);
+  const card: BrowserCardPosition = {
+    browser_id: 'browser-one',
+    url: 'https://example.test',
+    tabs: [{ id: 'tab-one', url: 'https://example.test', title: 'Example' }],
+    activeTabId: 'tab-one',
+    x: 80,
+    y: 120,
+    width: DEFAULT_BROWSER_CARD_W,
+    height: DEFAULT_BROWSER_CARD_H,
+    zOrder: 7,
+    dashboard_id: 'dash-old',
+  };
+  let state: DashboardLayoutState = {
+    ...initialState(),
+    browserCards: { [card.browser_id]: card },
+    nextZOrder: 20,
+  };
+
+  state = dashboardLayoutReducer(state, recordClosedCard({ kind: 'browser', id: card.browser_id }));
+  const entry = state.recentlyClosed[0];
+  assert.equal(entry.kind, 'browser');
+  assert.equal(entry.uid, 'browser-browser-one-123456');
+
+  state = dashboardLayoutReducer(state, removeBrowserCard(card.browser_id));
+  assert.equal(state.browserCards[card.browser_id], undefined);
+
+  state = dashboardLayoutReducer(state, restoreClosedCard({ entry, dashboardId: 'dash-new' }));
+  assert.equal(state.browserCards[card.browser_id].dashboard_id, 'dash-new');
+  assert.equal(state.browserCards[card.browser_id].zOrder, 20);
+
+  state = dashboardLayoutReducer(state, popClosedCard(entry.uid));
+  assert.equal(state.recentlyClosed.length, 0);
+});
+
+test('layout rehydration advances z-order past a persisted workflows hub', () => {
+  const requestId = 'fetch-layout';
+  const requestArg = { dashboardId: 'dashboard-one' };
+  let state = dashboardLayoutReducer(initialState(), fetchLayout.pending(requestId, requestArg));
+  state = dashboardLayoutReducer(state, fetchLayout.fulfilled({
+    cards: {},
+    viewCards: {},
+    browserCards: {},
+    workflowCards: {},
+    workflowsHub: { x: 10, y: 20, width: 1280, height: 800, zOrder: 100 },
+    expandedSessionIds: [],
+    creationOrder: [],
+    zOrders: {},
+    unknownPersistedLayoutFields: {},
+  }, requestId, requestArg));
+
+  assert.equal(state.nextZOrder, 101);
+});
+
+test('bringToFront repairs a stale counter before raising a card', () => {
+  const state: DashboardLayoutState = {
+    ...initialState(),
+    cards: {
+      agent: { session_id: 'agent', x: 10, y: 20, width: 480, height: 280, zOrder: 1 },
+    },
+    workflowsHub: { x: 30, y: 40, width: 1280, height: 800, zOrder: 100 },
+    workflowsMonitorCard: { x: 50, y: 60, width: 520, height: 560, zOrder: 90 },
+    nextZOrder: 2,
+  };
+
+  const raised = dashboardLayoutReducer(state, bringToFront({ id: 'agent', type: 'agent' }));
+
+  // The raise lands in the focus override map above the persisted maximum; the card dict is untouched.
+  assert.equal(raised.zOrders.agent, 101);
+  assert.equal(raised.cards.agent.zOrder, 1);
+  assert.equal(raised.nextZOrder, 102);
+});
+
+test('bringToFront repairs a stale counter when the card is already topmost', () => {
+  const state: DashboardLayoutState = {
+    ...initialState(),
+    cards: {
+      agent: { session_id: 'agent', x: 10, y: 20, width: 480, height: 280, zOrder: 1 },
+    },
+    workflowsHub: { x: 30, y: 40, width: 1280, height: 800, zOrder: 100 },
+    nextZOrder: 2,
+  };
+
+  const raised = dashboardLayoutReducer(state, bringToFront({ id: 'workflows-hub', type: 'workflows-hub' }));
+
+  // Already on top after the repair: no override written, counter parked just above the maximum.
+  assert.equal(raised.workflowsHub?.zOrder, 100);
+  assert.equal(raised.zOrders['workflows-hub'], undefined);
+  assert.equal(raised.nextZOrder, 101);
+});
+
+test('fetch and save preserve unknown card partitions and legacy card fields', async () => {
+  const futureCards = {
+    future: { card_id: 'future', payload: { recoverable: true }, zOrder: 42 },
+  };
+  const legacyCard = {
+    session_id: 'legacy-agent', x: 10, y: 20, width: 480, height: 280,
+    legacy_payload: { recoverable: true },
+  };
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { cards: { 'legacy-agent': legacyCard }, future_cards: futureCards },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-one' }));
+  const loaded = testStore.getState().dashboardLayout;
+  assert.equal(loaded.cards['legacy-agent'].zOrder, 0);
+  assert.deepEqual(
+    (loaded.cards['legacy-agent'] as typeof loaded.cards[string] & { legacy_payload: unknown }).legacy_payload,
+    legacyCard.legacy_payload,
+  );
+
+  await testStore.dispatch(saveLayout({
+    dashboardId: 'dashboard-one',
+    saveAuthority: loaded.unknownPersistedLayoutFieldsByDashboard['dashboard-one'],
+    cards: loaded.cards,
+    viewCards: loaded.viewCards,
+    browserCards: loaded.browserCards,
+    workflowCards: loaded.workflowCards,
+    workflowsHub: loaded.workflowsHub,
+    expandedSessionIds: loaded.persistedExpandedSessionIds,
+  }));
+
+  const saved = JSON.parse(String((fetchSpy.mock.calls[1].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, futureCards);
+  assert.deepEqual(saved.cards['legacy-agent'].legacy_payload, legacyCard.legacy_payload);
+});
+
+test('a delayed save retains its own unknown fields after a reset and dashboard switch', async () => {
+  const futureCards = { future: { card_id: 'future', payload: { dashboard: 'A' } } };
+  const fetchSpy = fetchMock()
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { future_cards: futureCards },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      layout: { future_cards: { other: { card_id: 'other', payload: { dashboard: 'B' } } } },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  const testStore = configureStore({
+    reducer: { dashboardLayout: dashboardLayoutReducer },
+  });
+
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-a' }));
+  const dashboardA = testStore.getState().dashboardLayout;
+  const delayedSave = {
+    dashboardId: 'dashboard-a',
+    saveAuthority: dashboardA.unknownPersistedLayoutFieldsByDashboard['dashboard-a'],
+    cards: dashboardA.cards,
+    viewCards: dashboardA.viewCards,
+    browserCards: dashboardA.browserCards,
+    workflowCards: dashboardA.workflowCards,
+    workflowsHub: dashboardA.workflowsHub,
+    expandedSessionIds: dashboardA.persistedExpandedSessionIds,
+  };
+
+  testStore.dispatch(resetLayout());
+  await testStore.dispatch(fetchLayout({ dashboardId: 'dashboard-b' }));
+  await testStore.dispatch(saveLayout(delayedSave));
+
+  const saved = JSON.parse(String((fetchSpy.mock.calls[2].arguments[1] as RequestInit).body)).layout;
+  assert.deepEqual(saved.future_cards, futureCards);
+});

--- a/frontend/src/shared/state/dashboardLayoutSlice.ts
+++ b/frontend/src/shared/state/dashboardLayoutSlice.ts
@@ -1,9 +1,84 @@
 import { createSlice, createAsyncThunk, PayloadAction, createAction } from '@reduxjs/toolkit';
+import { isSafeMode } from '@/shared/safeMode';
 import { launchAndSendFirstMessage, resumeSession, collapseSession, collapseAllSessions, setExpandedSessionIds } from './agentsSlice';
 import { untileClosedChats } from './untileClosedChats';
 import { API_BASE } from '@/shared/config';
 import { getLastDashboardId } from '@/shared/lastDashboardId';
-import { isSafeMode } from '@/shared/safeMode';
+import {
+  DEFAULT_CARD_H,
+  DEFAULT_CARD_W,
+  initialDashboardLayoutState,
+  type BrowserCardPosition,
+  type CardPosition,
+  type DashboardLayoutState,
+  type ViewCardPosition,
+  type WorkflowCardPosition,
+  type WorkflowsHubPosition,
+} from './dashboardLayoutModel';
+import {
+  collectOccupiedRects,
+  findOpenGridCell,
+  findOpenSpotNear,
+  placeBrowserBesideChat,
+  type Rect,
+} from './dashboardLayoutGeometry';
+import { agentCardReducers } from './dashboardLayoutAgentReducers';
+import { browserCardReducers, generateTabId } from './dashboardLayoutBrowserReducers';
+import { canvasReducers } from './dashboardLayoutCanvasReducers';
+import { closedCardReducers } from './dashboardLayoutClosedReducers';
+import { glowReducers } from './dashboardLayoutGlowReducers';
+import { resetReducers } from './dashboardLayoutResetReducers';
+import { tileOwnerExists, windowCardReducers } from './dashboardLayoutWindowReducers';
+import { viewCardReducers } from './dashboardLayoutViewReducers';
+import { workflowCardReducers } from './dashboardLayoutWorkflowReducers';
+import { ledgerRekey, ledgerRemove, reconcileDashboardCardZOrder } from './dashboardLayoutCardState';
+
+export {
+  DEFAULT_BROWSER_CARD_H,
+  DEFAULT_BROWSER_CARD_W,
+  DEFAULT_CARD_H,
+  DEFAULT_CARD_W,
+  DEFAULT_MARKETPLACE_CARD_H,
+  DEFAULT_MARKETPLACE_CARD_W,
+  DEFAULT_SETTINGS_CARD_H,
+  DEFAULT_SETTINGS_CARD_W,
+  DEFAULT_VIEW_CARD_H,
+  DEFAULT_VIEW_CARD_W,
+  DEFAULT_WORKFLOW_CARD_H,
+  DEFAULT_WORKFLOW_CARD_W,
+  DEFAULT_WORKFLOWS_HUB_H,
+  DEFAULT_WORKFLOWS_HUB_W,
+  EXPANDED_CARD_MIN_H,
+  GRID_GAP,
+  MARKETPLACE_CARD_ID,
+  SETTINGS_CARD_ID,
+  WORKFLOW_CARD_GAP,
+  WORKFLOWS_HUB_ID,
+  viewCardKey,
+} from './dashboardLayoutModel';
+export type {
+  BrowserCardPosition,
+  BrowserTab,
+  CardPosition,
+  CardType,
+  ClosedCard,
+  ClosedCardKind,
+  DashboardLayoutState,
+  ViewCardPosition,
+  WorkflowCardPosition,
+  WorkflowsHubPosition,
+  WorkflowsRunContext,
+} from './dashboardLayoutModel';
+export {
+  computeSpawnPosition,
+  findOpenGridCell,
+  findOpenSpotNear,
+  placeBesideCard,
+  placeBelowCard,
+  placeBrowserBesideChat,
+  placeInParentColumn,
+} from './dashboardLayoutGeometry';
+export type { SpawnAnchor } from './dashboardLayoutGeometry';
 
 // fetchSession 404/410 strips the layout card to stop AgentChat remount-loop. Matched by string to avoid circular import.
 const fetchSessionRejectedAction = createAction<
@@ -15,230 +90,14 @@ const deleteWorkflowFulfilledAction = createAction<string>('workflows/delete/ful
 
 const DASHBOARDS_API = `${API_BASE}/dashboards`;
 
-export const DEFAULT_CARD_W = 480;
-export const DEFAULT_CARD_H = 280;
-export const DEFAULT_VIEW_CARD_W = 1280;
-export const DEFAULT_VIEW_CARD_H = 800;
-export const DEFAULT_BROWSER_CARD_W = 1280;
-export const DEFAULT_BROWSER_CARD_H = 800;
-export const DEFAULT_WORKFLOW_CARD_W = 480;
-export const DEFAULT_WORKFLOW_CARD_H = 520;
-// Open at the same default footprint as a browser/view card so it lands at a comfortable size automatically.
-export const DEFAULT_WORKFLOWS_HUB_W = DEFAULT_BROWSER_CARD_W;
-export const DEFAULT_WORKFLOWS_HUB_H = DEFAULT_BROWSER_CARD_H;
-export const DEFAULT_SETTINGS_CARD_W = DEFAULT_BROWSER_CARD_W;
-export const DEFAULT_SETTINGS_CARD_H = DEFAULT_BROWSER_CARD_H;
-// The two singleton windows have no card map to key off, so they own these fixed ids everywhere (selection, minimize, z-order).
-export const SETTINGS_CARD_ID = 'settings';
-export const MARKETPLACE_CARD_ID = 'marketplace';
-export const DEFAULT_MARKETPLACE_CARD_W = DEFAULT_BROWSER_CARD_W;
-export const DEFAULT_MARKETPLACE_CARD_H = DEFAULT_BROWSER_CARD_H;
-export const WORKFLOWS_HUB_ID = 'workflows-hub';
-export const EXPANDED_CARD_MIN_H = 620;
-export const GRID_GAP = 24;
-// Gap between the Workflows window and the cards it spawns (run monitor, that monitor's browser). Keeps the hub -> monitor -> browser row evenly spaced.
-export const WORKFLOW_CARD_GAP = 140;
-const GRID_ORIGIN = { x: 40, y: 100 };
-const GRID_COLS_FALLBACK = 4;
-
-export type CardType = 'agent' | 'view' | 'browser' | 'workflow' | 'workflows-hub' | 'workflows-monitor' | 'settings' | 'marketplace';
-
-export interface CardPosition {
-  session_id: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  zOrder: number;
+async function readJson<T>(res: Response, fallback: string): Promise<T> {
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = typeof data.detail === 'string' ? data.detail : `${fallback}: ${res.status}`;
+    throw new Error(detail);
+  }
+  return data as T;
 }
-
-export interface ViewCardPosition {
-  output_id: string;
-  // Which instance of the app this card is (1 = primary, absent on pre-instance layouts). Each instance is a fully independent runtime on its own ports.
-  instance?: number;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  zOrder: number;
-  parent_session_id?: string | null;
-  /** Chat session this app preview lives inside (renders over the chat's dock slot); null/absent = free card. */
-  docked_to?: string | null;
-  // Reveal-born apps start as a light "built for you, click to open" card so the onboarding curtain
-  // lifts INSTANTLY instead of booting a live Vite preview in-frame. Cleared on first click -> boots.
-  preview_deferred?: boolean;
-}
-
-// Record key + card identity for a view card. The primary keeps the bare output_id so persisted layouts and every existing by-output lookup stay valid; secondaries append #N.
-export function viewCardKey(outputId: string, instance?: number): string {
-  return (instance ?? 1) > 1 ? `${outputId}#${instance}` : outputId;
-}
-
-export interface BrowserTab {
-  id: string;
-  url: string;
-  title: string;
-  favicon?: string;
-}
-
-export interface BrowserCardPosition {
-  browser_id: string;
-  url: string;
-  tabs: BrowserTab[];
-  activeTabId: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  zOrder: number;
-  /** Agent session that spawned this browser; auto-removed when its owner reaches terminal state. */
-  spawned_by?: string | null;
-  keep_open?: boolean;
-  /** Dashboard this card belongs to; cards render and persist only on their owning dashboard. */
-  dashboard_id?: string;
-  /** Chat session this browser lives inside (renders over the chat's dock slot); null/absent = free card. */
-  docked_to?: string | null;
-}
-
-export interface WorkflowCardPosition {
-  workflow_id: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  zOrder: number;
-  source_session_id?: string | null;
-}
-
-/** Singleton per dashboard; only one Workflows Hub card open at a time. */
-export interface WorkflowsHubPosition {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  zOrder: number;
-}
-
-// One entry in the Ctrl/Cmd+Shift+T "reopen last closed" stack: a full snapshot for browser/view/workflow/tab, just the session id for an agent (its session is brought back via resumeSession).
-export type ClosedCard =
-  | { uid: string; kind: 'browser'; closedAt: number; card: BrowserCardPosition }
-  | { uid: string; kind: 'view'; closedAt: number; card: ViewCardPosition }
-  | { uid: string; kind: 'workflow'; closedAt: number; card: WorkflowCardPosition }
-  | { uid: string; kind: 'tab'; closedAt: number; browserId: string; index: number; tab: BrowserTab }
-  | { uid: string; kind: 'agent'; closedAt: number; sessionId: string; position: CardPosition | null };
-
-export type ClosedCardKind = ClosedCard['kind'];
-
-const RECENTLY_CLOSED_CAP = 25;
-
-export interface DashboardLayoutState {
-  cards: Record<string, CardPosition>;
-  viewCards: Record<string, ViewCardPosition>;
-  browserCards: Record<string, BrowserCardPosition>;
-  workflowCards: Record<string, WorkflowCardPosition>;
-  workflowsHub: WorkflowsHubPosition | null;
-  closedCardPositions: Record<string, CardPosition>;
-  /** Session-global LIFO undo stack for Ctrl/Cmd+Shift+T; survives dashboard switches (resetLayout leaves it alone). */
-  recentlyClosed: ClosedCard[];
-  glowingBrowserCards: Record<string, { sourceId: string; fading: boolean; label?: string }>;
-  glowingAgentCards: Record<string, { sourceId: string; fading: boolean; sourceYRatio?: number; label?: string }>;
-  /** Window controls: cards collapsed to a title pill (many at once). Keyed by any card id (session/browser/view/workflow). */
-  minimizedCards: Record<string, boolean>;
-  /** macOS-style tiling: card id -> zone ('fullscreen' | 'fill' | 'left'|'right'|'top'|'bottom' | 'tl'|'tr'|'bl'|'br' | 't3l'|'t3c'|'t3r'). A tiled card renders at that viewport region (webview stays mounted); 'fullscreen' also hides the app chrome. */
-  tiledCards: Record<string, string>;
-  persistedExpandedSessionIds: string[];
-  nextZOrder: number;
-  loading: boolean;
-  initialized: boolean;
-  /** True only after a SUCCESSFUL layout fetch for the current dashboard; saveLayout is a no-op until then (a failed boot fetch must never wipe the server layout). */
-  saveArmed: boolean;
-  /** Transient: new browser card id; Dashboard pans/zooms to it then clears via clearPendingFocusBrowserId. */
-  pendingFocusBrowserId: string | null;
-  // Set when a view card is opened from outside the canvas (sidebar app click / toolbar picker) so the dashboard fits+highlights it on arrival; holds the card key.
-  pendingFocusViewCardId: string | null;
-  /** Transient: snapshot stand-ins for off-screen webviews; never rides the layout PUT. */
-  suspendedBrowserCards: Record<string, { dataUrl: string; capturedAt: number }>;
-  /** Transient: spawned cards that are about to be removed; surfaces the fade + Keep pill. */
-  endingBrowserCards: Record<string, { status: 'completed' | 'error'; at: number }>;
-  /** Transient: id of the view card the user has clicked into; preload stops forwarding canvas gestures while set. */
-  activeViewCardId: string | null;
-  pendingFocusWorkflowId: string | null;
-  /** Transient: signals Dashboard to pan/zoom to the singleton Workflows Hub on open. */
-  pendingFocusWorkflowsHub: boolean;
-  /** Transient deep-link target: the Workflows card jumps to this workflow's detail on open, then clears it. */
-  workflowsAppTarget: string | null;
-  /** Workflow id whose live run is being watched in the Run Monitor card docked beside the window. Null = closed. */
-  workflowsMonitorId: string | null;
-  /** Specific run id to show in the monitor (e.g. clicked from history); null = follow the latest run. */
-  workflowsMonitorRunId: string | null;
-  /** Geometry of the spawned Run Monitor card (a real canvas card, tethered to the window). Ephemeral, not persisted. */
-  workflowsMonitorCard: WorkflowsHubPosition | null;
-  /** A run attached to a workflow's chat as a removable context chip; its transcript rides along each send until removed. */
-  workflowsRunContext: WorkflowsRunContext | null;
-  /** Settings as an on-canvas window (singleton). Ephemeral, not persisted: a fresh boot opens on a clean canvas. */
-  settingsCard: WorkflowsHubPosition | null;
-  /** Transient: signals Dashboard to pan/zoom to the Settings window on open. */
-  pendingFocusSettingsCard: boolean;
-  /** Transient deep-link: which settings tab to land on; SettingsBody consumes and clears it. */
-  settingsRequestedTab: string | null;
-  /** Marketplace as an on-canvas window (singleton), same lifecycle as the Settings window. */
-  marketplaceCard: WorkflowsHubPosition | null;
-  /** Transient: signals Dashboard to pan/zoom to the Marketplace window on open. */
-  pendingFocusMarketplaceCard: boolean;
-  /** Transient deep-link: which marketplace view to land on; the card consumes and clears it. */
-  marketplaceRequestedTab: string | null;
-  /** Focus-order overrides, keyed by card id (singletons use their literal ids). bringToFront writes ONLY here, so a click never churns card-object identities; effective z = zOrders[id] ?? the base stamped at creation. */
-  zOrders: Record<string, number>;
-  /** Creation-order ledger, oldest first, across all content card types; the trash's no-selection press pops the newest. Persisted with the layout (zOrder can't stand in, it re-bumps on every focus). */
-  creationOrder: string[];
-}
-
-export interface WorkflowsRunContext {
-  workflowId: string;
-  runId: string;
-  title: string;
-  metaLabel: string;
-  color: string;
-}
-
-const initialState: DashboardLayoutState = {
-  cards: {},
-  viewCards: {},
-  browserCards: {},
-  workflowCards: {},
-  workflowsHub: null,
-  closedCardPositions: {},
-  recentlyClosed: [],
-  glowingBrowserCards: {},
-  glowingAgentCards: {},
-  minimizedCards: {},
-  tiledCards: {},
-  persistedExpandedSessionIds: [],
-  nextZOrder: 1,
-  loading: false,
-  initialized: false,
-  saveArmed: false,
-  pendingFocusBrowserId: null,
-  pendingFocusViewCardId: null,
-  suspendedBrowserCards: {},
-  endingBrowserCards: {},
-  activeViewCardId: null,
-  pendingFocusWorkflowId: null,
-  pendingFocusWorkflowsHub: false,
-  workflowsAppTarget: null,
-  workflowsMonitorId: null,
-  workflowsMonitorRunId: null,
-  workflowsMonitorCard: null,
-  workflowsRunContext: null,
-  settingsCard: null,
-  pendingFocusSettingsCard: false,
-  settingsRequestedTab: null,
-  marketplaceCard: null,
-  pendingFocusMarketplaceCard: false,
-  marketplaceRequestedTab: null,
-  creationOrder: [],
-  zOrders: {},
-};
 
 interface LayoutPayload {
   cards: Record<string, CardPosition>;
@@ -250,32 +109,24 @@ interface LayoutPayload {
   creationOrder: string[];
   // Optional because savers omit it: the save thunk reads the live map from state itself.
   zOrders?: Record<string, number>;
+  unknownPersistedLayoutFields: Record<string, unknown>;
 }
 
-// Window-state entries (tiles, minimized pills) are only meaningful while some card map owns the id.
-function tileOwnerExists(s: DashboardLayoutState, id: string): boolean {
-  return id in s.cards || id in s.viewCards || id in s.browserCards || id in s.workflowCards
-    || (id === WORKFLOWS_HUB_ID && !!s.workflowsHub) || (id === SETTINGS_CARD_ID && !!s.settingsCard)
-    || (id === MARKETPLACE_CARD_ID && !!s.marketplaceCard);
-}
+const KNOWN_PERSISTED_LAYOUT_FIELDS = new Set([
+  'cards',
+  'view_cards',
+  'browser_cards',
+  'workflow_cards',
+  'workflows_hub',
+  'expanded_session_ids',
+  'creation_order',
+  'z_orders',
+]);
 
-function ledgerAdd(ledger: string[], id: string): void {
-  if (!ledger.includes(id)) ledger.push(id);
-}
-
-function ledgerRemove(ledger: string[], id: string): void {
-  const i = ledger.indexOf(id);
-  if (i !== -1) ledger.splice(i, 1);
-}
-
-function ledgerRekey(ledger: string[], oldId: string, newId: string): void {
-  const i = ledger.indexOf(oldId);
-  if (i !== -1) ledger[i] = newId;
-  else ledgerAdd(ledger, newId);
-}
-
-function generateTabId(): string {
-  return `tab-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+function unknownPersistedLayoutFields(layout: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(layout).filter(([key]) => !KNOWN_PERSISTED_LAYOUT_FIELDS.has(key)),
+  );
 }
 
 export const fetchLayout = createAsyncThunk(
@@ -283,9 +134,7 @@ export const fetchLayout = createAsyncThunk(
   // isReconnect distinguishes a socket-reconnect recovery refetch (merge, keep live positions) from a fresh mount/switch load (replace, snapshot is the user's saved layout). Passed explicitly, not inferred from state, so a stale in-flight fetch from a previous dashboard can't be misread as a merge.
   async ({ dashboardId }: { dashboardId: string; isReconnect?: boolean }) => {
     const res = await fetch(`${DASHBOARDS_API}/${dashboardId}`);
-    // A non-2xx body silently parsing to "no layout" is how a healthy dashboard gets wiped: the empty result gets marked initialized and the next debounced save persists it.
-    if (!res.ok) throw new Error(`layout fetch failed: ${res.status}`);
-    const data = await res.json();
+    const data = await readJson<{ layout?: Record<string, unknown> }>(res, 'Dashboard layout fetch failed');
     const layout = data.layout ?? {};
     const browserCards = (layout.browser_cards ?? {}) as Record<string, any>;
 
@@ -310,23 +159,25 @@ export const fetchLayout = createAsyncThunk(
       expandedSessionIds: (layout.expanded_session_ids ?? []) as string[],
       creationOrder: (layout.creation_order ?? []) as string[],
       zOrders: (layout.z_orders ?? {}) as Record<string, number>,
+      unknownPersistedLayoutFields: unknownPersistedLayoutFields(layout),
     } satisfies LayoutPayload;
   },
 );
 
-interface SaveLayoutPayload extends LayoutPayload {
+interface SaveLayoutPayload extends Omit<LayoutPayload, 'unknownPersistedLayoutFields'> {
   dashboardId: string;
+  saveAuthority: Record<string, unknown> | undefined;
 }
 
 export const saveLayout = createAsyncThunk(
   'dashboardLayout/save',
   async (payload: SaveLayoutPayload, { getState }) => {
+    const layoutState = (getState() as { dashboardLayout: DashboardLayoutState }).dashboardLayout;
     // Never persist a layout this client never successfully loaded; a failed boot fetch otherwise saves the pristine empty store over the server's real layout (the wipe class).
-    const dl = (getState() as { dashboardLayout: { saveArmed: boolean; zOrders: Record<string, number> } }).dashboardLayout;
-    if (!dl.saveArmed) return payload;
+    if (!layoutState.saveArmed) return payload;
     // Prune focus overrides to ids that still exist, so removed cards can't grow the map forever.
     const liveZ: Record<string, number> = {};
-    for (const [zid, z] of Object.entries(dl.zOrders)) {
+    for (const [zid, z] of Object.entries(layoutState.zOrders)) {
       if (payload.cards[zid] || payload.viewCards[zid] || payload.browserCards[zid] || payload.workflowCards[zid]
         || zid === 'settings' || zid === 'marketplace' || zid === 'workflows-hub' || zid === 'workflows-monitor') liveZ[zid] = z;
     }
@@ -335,6 +186,7 @@ export const saveLayout = createAsyncThunk(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         layout: {
+          ...(layoutState.unknownPersistedLayoutFieldsByDashboard[payload.dashboardId] ?? {}),
           cards: payload.cards,
           view_cards: payload.viewCards,
           browser_cards: payload.browserCards,
@@ -348,286 +200,24 @@ export const saveLayout = createAsyncThunk(
     });
     return payload;
   },
+  {
+    condition: (payload, { getState }) => {
+      const layoutState = (getState() as { dashboardLayout: DashboardLayoutState }).dashboardLayout;
+      const currentAuthority = layoutState.unknownPersistedLayoutFieldsByDashboard[payload.dashboardId];
+      // Fulfilled fetches create a new per-dashboard baseline object even when the unknown-field map is empty.
+      // Identity binds delayed/unmount saves to the exact successful fetch they were captured from.
+      const activeRefetchIsPending = (
+        layoutState.loading
+        && layoutState.activeFetchDashboardId === payload.dashboardId
+      );
+      return (
+        !activeRefetchIsPending
+        && payload.saveAuthority !== undefined
+        && payload.saveAuthority === currentAuthority
+      );
+    },
+  },
 );
-
-interface Rect {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
-
-interface CardPlacementExclusion {
-  type: CardType;
-  id: string;
-}
-
-function rectsOverlap(a: Rect, b: Rect): boolean {
-  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
-}
-
-function collectOccupiedRects(
-  state: DashboardLayoutState,
-  expandedSessionIds?: string[],
-  exclude?: CardPlacementExclusion,
-): Rect[] {
-  const expanded = new Set(expandedSessionIds);
-  const rects: Rect[] = [];
-  for (const c of Object.values(state.cards)) {
-    if (exclude?.type === 'agent' && exclude.id === c.session_id) continue;
-    const h = expanded.has(c.session_id) ? Math.max(EXPANDED_CARD_MIN_H, c.height) : c.height;
-    rects.push({ x: c.x, y: c.y, w: c.width, h });
-  }
-  for (const c of Object.values(state.viewCards)) {
-    if (exclude?.type === 'view' && exclude.id === c.output_id) continue;
-    rects.push({ x: c.x, y: c.y, w: c.width, h: c.height });
-  }
-  for (const c of Object.values(state.browserCards)) {
-    if (exclude?.type === 'browser' && exclude.id === c.browser_id) continue;
-    rects.push({ x: c.x, y: c.y, w: c.width, h: c.height });
-  }
-  for (const w of Object.values(state.workflowCards)) {
-    rects.push({ x: w.x, y: w.y, w: w.width, h: w.height });
-  }
-  if (state.workflowsHub) {
-    rects.push({ x: state.workflowsHub.x, y: state.workflowsHub.y, w: state.workflowsHub.width, h: state.workflowsHub.height });
-  }
-  if (state.settingsCard) {
-    rects.push({ x: state.settingsCard.x, y: state.settingsCard.y, w: state.settingsCard.width, h: state.settingsCard.height });
-  }
-  if (state.marketplaceCard) {
-    rects.push({ x: state.marketplaceCard.x, y: state.marketplaceCard.y, w: state.marketplaceCard.width, h: state.marketplaceCard.height });
-  }
-  return rects;
-}
-
-export function findOpenGridCell(
-  occupiedRects: Rect[],
-  newW: number,
-  newH: number,
-  colLimit?: number,
-): { x: number; y: number } {
-  const cellW = DEFAULT_CARD_W + GRID_GAP;
-  const cellH = DEFAULT_CARD_H + GRID_GAP;
-  const maxCols = colLimit ?? Math.max(
-    1,
-    Math.floor((window.innerWidth - GRID_ORIGIN.x) / cellW) || GRID_COLS_FALLBACK,
-  );
-
-  for (let row = 0; ; row++) {
-    for (let col = 0; col < maxCols; col++) {
-      const x = GRID_ORIGIN.x + col * cellW;
-      const y = GRID_ORIGIN.y + row * cellH;
-      const candidate: Rect = { x, y, w: newW, h: newH };
-      if (!occupiedRects.some((r) => rectsOverlap(candidate, r))) {
-        return { x, y };
-      }
-    }
-  }
-}
-
-// Tidy packs into the grid shape that fills the SCREEN best. The default column count is derived from
-// window.innerWidth, which is screen pixels pretending to be world units: it laid 8 cards out as a
-// 2-wide, 4-tall ribbon that the camera then had to pull back to 41% to show.
-function tidyColumnCount(itemSizes: Array<{ w: number; h: number }>): number {
-  const cellW = DEFAULT_CARD_W + GRID_GAP;
-  const cellH = DEFAULT_CARD_H + GRID_GAP;
-  let cells = 0;
-  let widest = 1;
-  for (const s of itemSizes) {
-    const cols = Math.max(1, Math.ceil(s.w / cellW));
-    cells += cols * Math.max(1, Math.ceil(s.h / cellH));
-    widest = Math.max(widest, cols);
-  }
-  const vw = window.innerWidth || 1440;
-  const vh = window.innerHeight || 900;
-  let best = widest;
-  let bestZoom = 0;
-  for (let cols = widest; cols <= Math.max(widest, cells); cols++) {
-    const rows = Math.ceil(cells / cols);
-    const zoom = Math.min(vw / (cols * cellW), vh / (rows * cellH));
-    if (zoom > bestZoom) {
-      bestZoom = zoom;
-      best = cols;
-    }
-  }
-  return best;
-}
-
-// Like findOpenGridCell but biased to stay near a proposed (x,y) anchor. Used when the backend hands us a card with a position that's already occupied (sub-agent or sub-browser spawning on top of its parent or a sibling). Spirals outward from the anchor on a grid, snapping to cell-aligned positions so the result still looks intentional, not dropped from orbit. Caps the spiral search at ~1000 cells to avoid pathological work in adversarial layouts, falls back to findOpenGridCell after that. Cost: O(rects × cells_scanned). Spawn events are rare (not per-frame), so this only runs when a new card appears. Typical scan resolves in <10 cells, well below the cap. No perf impact on steady-state UI.
-export function findOpenSpotNear(
-  anchorX: number,
-  anchorY: number,
-  occupiedRects: Rect[],
-  newW: number,
-  newH: number,
-): { x: number; y: number } {
-  const cellW = DEFAULT_CARD_W + GRID_GAP;
-  const cellH = DEFAULT_CARD_H + GRID_GAP;
-  // Snap the anchor to the nearest grid cell so cards align.
-  const baseCol = Math.round((anchorX - GRID_ORIGIN.x) / cellW);
-  const baseRow = Math.round((anchorY - GRID_ORIGIN.y) / cellH);
-
-  const cellFree = (col: number, row: number): boolean => {
-    const x = GRID_ORIGIN.x + col * cellW;
-    const y = GRID_ORIGIN.y + row * cellH;
-    const candidate: Rect = { x, y, w: newW, h: newH };
-    return !occupiedRects.some((r) => rectsOverlap(candidate, r));
-  };
-
-  if (cellFree(baseCol, baseRow)) {
-    return {
-      x: GRID_ORIGIN.x + baseCol * cellW,
-      y: GRID_ORIGIN.y + baseRow * cellH,
-    };
-  }
-
-  // Ring order approximates distance but returns the first-in-scan cell, which flings a card to a
-  // far corner when the near cells are blocked (a big browser + expanded chats). Instead pick the
-  // cell CLOSEST to the anchor by real distance: scan outward, and once a ring yields a free cell,
-  // scan ONE more ring (a ring-r corner ~r*1.41 can lose to a ring-(r+1) edge) then take the nearest.
-  const MAX_RING = 32;
-  const spotDist = (col: number, row: number): number => {
-    const x = GRID_ORIGIN.x + col * cellW;
-    const y = GRID_ORIGIN.y + row * cellH;
-    return Math.hypot(x - anchorX, y - anchorY);
-  };
-  let best: { col: number; row: number; d: number } | null = null;
-  let firstHitRing = -1;
-  for (let r = 1; r <= MAX_RING; r++) {
-    for (let dy = -r; dy <= r; dy++) {
-      for (let dx = -r; dx <= r; dx++) {
-        if (Math.abs(dx) !== r && Math.abs(dy) !== r) continue;
-        const col = baseCol + dx;
-        const row = baseRow + dy;
-        if (col < 0 || row < 0) continue;
-        if (!cellFree(col, row)) continue;
-        const d = spotDist(col, row);
-        if (!best || d < best.d) best = { col, row, d };
-      }
-    }
-    if (best && firstHitRing === -1) firstHitRing = r;
-    // Scan one ring past the first hit (a ring-r corner can lose to a ring-(r+1) edge), then commit.
-    if (firstHitRing !== -1 && r >= firstHitRing + 1) break;
-  }
-  if (best) {
-    return {
-      x: GRID_ORIGIN.x + best.col * cellW,
-      y: GRID_ORIGIN.y + best.row * cellH,
-    };
-  }
-
-  // Pathological, full canvas occupied near anchor. Fall back to the global first-empty scan so we never return an overlap.
-  return findOpenGridCell(occupiedRects, newW, newH);
-}
-
-// Dock a new card to the right of an anchor card, stacking under any cards already in that right-hand column. Anchor is any rect, so a browser can dock beside a normal agent card OR a workflow run/monitor card that has no session entry in state.cards.
-export function placeBesideCard(
-  state: DashboardLayoutState,
-  anchor: { x: number; y: number; width: number; height: number },
-  newW: number,
-  newH: number,
-  expandedSessionIds?: string[],
-  exclude?: CardPlacementExclusion,
-  gap: number = GRID_GAP * 12,
-  exact: boolean = false,
-): { x: number; y: number } {
-  const rects = collectOccupiedRects(state, expandedSessionIds, exclude);
-  const targetX = anchor.x + anchor.width + gap;
-  const columnCards = [
-    ...Object.values(state.browserCards).filter(
-      (c) => !(exclude?.type === 'browser' && exclude.id === c.browser_id),
-    ),
-    ...Object.values(state.viewCards).filter(
-      (c) => !(exclude?.type === 'view' && exclude.id === c.output_id),
-    ),
-  ].filter((c) => Math.abs(c.x - targetX) < 50);
-  const targetY = columnCards.length > 0
-    ? Math.max(...columnCards.map((c) => c.y + c.height)) + GRID_GAP
-    : anchor.y;
-
-  // exact keeps the precise gap (so the card mirrors however its anchor was placed, e.g. a run browser matching the hub->monitor gap); grid-snapping would knock that gap off. Fall back to the snapped search only if the exact spot is taken.
-  if (exact && !rects.some((r) => rectsOverlap({ x: targetX, y: targetY, w: newW, h: newH }, r))) {
-    return { x: targetX, y: targetY };
-  }
-  return findOpenSpotNear(targetX, targetY, rects, newW, newH);
-}
-
-// Dock a chat-spawned browser to the right of its chat card. Unlike placeBesideCard, this ALWAYS lands beside the chat (overlap is fine, the new card sits on top via zOrder) so an occupied spot can never fling the browser to a far grid cell or stack it under an unrelated card. Only this chat's OWN browsers (same spawned_by, still in the column) stack under each other so siblings don't fully cover one another; every other card is ignored.
-export function placeBrowserBesideChat(
-  state: DashboardLayoutState,
-  chat: { x: number; y: number; width: number; height: number },
-  parentSessionId: string,
-  newW: number,
-  newH: number,
-  excludeBrowserId?: string,
-): { x: number; y: number } {
-  const targetX = chat.x + chat.width + GRID_GAP * 12;
-  const siblings = Object.values(state.browserCards).filter(
-    (c) => c.browser_id !== excludeBrowserId && c.spawned_by === parentSessionId && Math.abs(c.x - targetX) < 50,
-  );
-  const targetY = siblings.length > 0
-    ? Math.max(...siblings.map((c) => c.y + c.height)) + GRID_GAP
-    : chat.y;
-  return { x: targetX, y: targetY };
-}
-
-// Dock a new card directly below an anchor card (left edges aligned). Used for a browser spawned by a Workflows-hub chat, which has no agent card to sit beside.
-export function placeBelowCard(
-  state: DashboardLayoutState,
-  anchor: { x: number; y: number; width: number; height: number },
-  newW: number,
-  newH: number,
-  expandedSessionIds?: string[],
-  exclude?: CardPlacementExclusion,
-): { x: number; y: number } {
-  const rects = collectOccupiedRects(state, expandedSessionIds, exclude);
-  return findOpenSpotNear(anchor.x, anchor.y + anchor.height + GRID_GAP, rects, newW, newH);
-}
-
-export function placeInParentColumn(
-  state: DashboardLayoutState,
-  parentSessionId: string | null | undefined,
-  newW: number,
-  newH: number,
-  expandedSessionIds?: string[],
-  exclude?: CardPlacementExclusion,
-): { x: number; y: number } {
-  const parentCard = parentSessionId ? state.cards[parentSessionId] : null;
-  if (!parentCard) {
-    return findOpenGridCell(collectOccupiedRects(state, expandedSessionIds, exclude), newW, newH);
-  }
-  return placeBesideCard(state, parentCard, newW, newH, expandedSessionIds, exclude);
-}
-
-// Where a user-created card (chat/app/browser) should land. Resolved in the UI layer where selection + viewport are known, then handed to the add reducers as an explicit x/y. `beside` (the currently selected card) docks the new card to its right, stacking under that column (collision-aware); `viewportCenter` (canvas-space center of what the user is looking at) drops it dead-center "in front of you", overlapping whatever's there. With neither, falls back to the legacy top-left grid scan.
-export interface SpawnAnchor {
-  beside?: { x: number; y: number; width: number; height: number };
-  viewportCenter?: { x: number; y: number };
-}
-
-export function computeSpawnPosition(
-  state: DashboardLayoutState,
-  newW: number,
-  newH: number,
-  anchor: SpawnAnchor,
-  expandedSessionIds?: string[],
-): { x: number; y: number } {
-  if (anchor.beside) {
-    return placeBesideCard(state, anchor.beside, newW, newH, expandedSessionIds);
-  }
-  if (anchor.viewportCenter) {
-    // Closest open gap to the viewport center: dead-center-with-overlap stacked spawns invisibly on top of each other (two center spawns in a row = the second fully covers the first). The spiral stays center-biased so it still reads as "in front of you".
-    return findOpenSpotNear(
-      anchor.viewportCenter.x - newW / 2,
-      anchor.viewportCenter.y - newH / 2,
-      collectOccupiedRects(state, expandedSessionIds),
-      newW,
-      newH,
-    );
-  }
-  return findOpenGridCell(collectOccupiedRects(state, expandedSessionIds), newW, newH);
-}
 
 // Reconnect-refetch merge: ADD only the cards the snapshot carries that the client is missing (e.g. a spawned browser whose broadcast was lost in a socket gap), collision-resolving each against the live layout so a recovered card can't land on a card already on canvas, and NEVER touch a card the client already has (that's exactly what preserves its live, collision-placed position). The shared `occupied` list carries placements forward so two recovered cards in the same pass also avoid each other.
 function addMissingCards<T extends { x: number; y: number; width: number; height: number }>(
@@ -644,1222 +234,41 @@ function addMissingCards<T extends { x: number; y: number; width: number; height
   }
 }
 
-// One docked surface per chat: the slot is a single rect, so docking a new browser/app releases
-// whatever was previously docked there (it falls back to its stored free position).
-function clearOtherDocks(state: { browserCards: Record<string, BrowserCardPosition>; viewCards: Record<string, ViewCardPosition> }, sessionId: string, keepBrowserId?: string): void {
-  for (const bc of Object.values(state.browserCards)) {
-    if (bc.docked_to !== sessionId) continue;
-    // The card being (re-)docked must survive its own clear: layout sync re-asserts docks.
-    if (bc.browser_id === keepBrowserId) continue;
-    // Corpse cleanup happens in WebSocketManager via removeBrowserCardCleanly, NOT here: a bare store delete gets resurrected by the backend layout sync as a free card.
-    bc.docked_to = null;
-  }
-  for (const vc of Object.values(state.viewCards)) {
-    if (vc.docked_to === sessionId) vc.docked_to = null;
-  }
-}
 
 const dashboardLayoutSlice = createSlice({
   name: 'dashboardLayout',
-  initialState,
+  initialState: initialDashboardLayoutState,
   reducers: {
-    // Window controls (traffic lights). Minimize parks a card in the right-edge rail; tiling snaps it
-    // to a macOS-style viewport zone. Rule 6 of the tiling set (see cards/useCardTiling.ts): a parked
-    // card keeps its zone and restores back into it, but never keeps 'fullscreen', which would leave
-    // an off-canvas card hiding the whole shell.
-    toggleMinimizeCard(state, action: PayloadAction<{ cardId: string }>) {
-      const id = action.payload.cardId;
-      if (state.minimizedCards[id]) {
-        delete state.minimizedCards[id];
-      } else {
-        state.minimizedCards[id] = true;
-        if (state.tiledCards[id] === 'fullscreen') delete state.tiledCards[id];
-      }
-    },
-    setTiledCard(state, action: PayloadAction<{ cardId: string; zone: string }>) {
-      const { cardId, zone } = action.payload;
-      // The rail defers its tile dispatch two frames, so the card can be gone by the time it lands; a stranded 'fullscreen' hides the whole shell.
-      if (!tileOwnerExists(state, cardId)) return;
-      // One fullscreen owner, ever: two entries would fight over who hides the chrome and who gets the Escape.
-      if (zone === 'fullscreen') {
-        for (const [id, z] of Object.entries(state.tiledCards)) {
-          if (z === 'fullscreen' && id !== cardId) delete state.tiledCards[id];
-        }
-      }
-      state.tiledCards[cardId] = zone;
-      if (state.minimizedCards[cardId]) delete state.minimizedCards[cardId];
-    },
-    clearTiledCard(state, action: PayloadAction<string>) {
-      if (state.tiledCards[action.payload]) delete state.tiledCards[action.payload];
-    },
-    clearAllTiles(state) {
-      state.tiledCards = {};
-    },
-    clearCardWindowState(state, action: PayloadAction<string>) {
-      const id = action.payload;
-      if (state.minimizedCards[id]) delete state.minimizedCards[id];
-      if (state.tiledCards[id]) delete state.tiledCards[id];
-    },
-    setCardPosition(
-      state,
-      action: PayloadAction<{ sessionId: string; x: number; y: number }>
-    ) {
-      const { sessionId, x, y } = action.payload;
-      const card = state.cards[sessionId];
-      if (card) {
-        card.x = x;
-        card.y = y;
-      }
-    },
+    ...agentCardReducers,
 
-    setCardSize(
-      state,
-      action: PayloadAction<{ sessionId: string; width: number; height: number }>
-    ) {
-      const { sessionId, width, height } = action.payload;
-      const card = state.cards[sessionId];
-      if (card) {
-        card.width = Math.max(480, width);
-        card.height = Math.max(180, height);
-      }
-    },
+    ...canvasReducers,
 
-    placeCard(
-      state,
-      action: PayloadAction<{
-        sessionId: string;
-        x: number;
-        y: number;
-        width: number;
-        height: number;
-        // Optional: which existing sessions are currently expanded (showing their full chat history). Without this, the collision check uses each card's STORED height, which is the collapsed value, even when the card is currently rendering at the expanded ~620px. Result: new sub-agent cards spawn into the collapsed footprint but overlap the visually expanded one. Caller (Dashboard.tsx) passes the current expanded set so the collision math matches what the user actually sees.
-        expandedSessionIds?: string[];
-        // Honor the given x/y verbatim (dead-center "in front of you", overlap allowed) instead of collision-dodging to a free grid cell. Set when the caller already resolved the spot (viewport center / beside a selected card) and dodging would defeat that; tidyLayout cleans up any overlap on demand.
-        exact?: boolean;
-      }>
-    ) {
-      const { sessionId, x, y, width, height, expandedSessionIds, exact } = action.payload;
-      const pos = exact ? { x, y } : findOpenSpotNear(x, y, collectOccupiedRects(state, expandedSessionIds), width, height);
-      state.cards[sessionId] = {
-        session_id: sessionId,
-        x: pos.x,
-        y: pos.y,
-        width,
-        height,
-        zOrder: state.nextZOrder++,
-      };
-      ledgerAdd(state.creationOrder, sessionId);
-    },
+    ...viewCardReducers,
 
-    bringToFront(
-      state,
-      action: PayloadAction<{ id: string; type: CardType }>,
-    ) {
-      const { id, type } = action.payload;
-      // Focus writes ONLY the override map: the old form mutated the card object, which replaced its
-      // dict, re-rendered the controller + tethers + dock + minimap, and armed a layout PUT +
-      // thumbnail capture on every press (CANVAS_LAG_NOTES item 33). The nextZOrder-1 holder is
-      // always the top card, so the already-on-top guard (workflow textarea focus-loss) is one compare.
-      let base = 0;
-      if (type === 'agent') base = state.cards[id]?.zOrder ?? 0;
-      else if (type === 'view') base = state.viewCards[id]?.zOrder ?? 0;
-      else if (type === 'workflow') base = state.workflowCards[id]?.zOrder ?? 0;
-      else if (type === 'workflows-hub') base = state.workflowsHub?.zOrder ?? 0;
-      else if (type === 'workflows-monitor') base = state.workflowsMonitorCard?.zOrder ?? 0;
-      else if (type === 'settings') base = state.settingsCard?.zOrder ?? 0;
-      else if (type === 'marketplace') base = state.marketplaceCard?.zOrder ?? 0;
-      else base = state.browserCards[id]?.zOrder ?? 0;
-      const effective = state.zOrders[id] ?? base;
-      // Zero is the legacy every-card tie (backend-synced cards arrive without z); never short-circuit on it.
-      if (effective > 0 && effective === state.nextZOrder - 1) return;
-      state.zOrders[id] = state.nextZOrder++;
-    },
+    ...browserCardReducers,
 
-    removeCard(state, action: PayloadAction<string>) {
-      delete state.cards[action.payload];
-      delete state.tiledCards[action.payload];
-      delete state.minimizedCards[action.payload];
-      ledgerRemove(state.creationOrder, action.payload);
-    },
+    ...workflowCardReducers,
 
-    reconcileSessions(
-      state,
-      action: PayloadAction<{ sessionIds: string[]; expandedSessionIds: string[] }>,
-    ) {
-      const { sessionIds, expandedSessionIds } = action.payload;
-      const liveIds = new Set(sessionIds);
+    ...closedCardReducers,
 
-      for (const id of Object.keys(state.cards)) {
-        if (!liveIds.has(id)) {
-          state.closedCardPositions[id] = { ...state.cards[id] };
-          delete state.cards[id];
-          // A dead card must never keep owning a tile: an orphaned 'fullscreen' entry hides ALL chrome until reload.
-          delete state.tiledCards[id];
-          delete state.minimizedCards[id];
-          ledgerRemove(state.creationOrder, id);
-        }
-      }
+    ...glowReducers,
 
-      const hasDraftCard = Object.keys(state.cards).some((id) => id.startsWith('draft-'));
-      const newIds = sessionIds.filter((id) => !state.cards[id]);
-      for (const id of newIds) {
-        if (hasDraftCard && !id.startsWith('draft-')) continue;
-        const savedPos = state.closedCardPositions[id];
-        if (savedPos) {
-          state.cards[id] = { ...savedPos, session_id: id, zOrder: savedPos.zOrder || state.nextZOrder++ };
-          delete state.closedCardPositions[id];
-        } else {
-          const rects = collectOccupiedRects(state, expandedSessionIds);
-          const pos = findOpenGridCell(rects, DEFAULT_CARD_W, DEFAULT_CARD_H);
-          state.cards[id] = {
-            session_id: id,
-            x: pos.x,
-            y: pos.y,
-            width: DEFAULT_CARD_W,
-            height: DEFAULT_CARD_H,
-            zOrder: state.nextZOrder++,
-          };
-        }
-        ledgerAdd(state.creationOrder, id);
-      }
-    },
-
-    tidyLayout(
-      state,
-      action: PayloadAction<{ expandedSessionIds: string[] }>,
-    ) {
-      const expanded = new Set(action.payload.expandedSessionIds);
-      const agentCards = Object.values(state.cards);
-      const viewCards = Object.values(state.viewCards);
-      const bCards = Object.values(state.browserCards);
-      const wCards = Object.values(state.workflowCards);
-      const hub = state.workflowsHub;
-      const mon = state.workflowsMonitorCard;
-      const settings = state.settingsCard;
-      const market = state.marketplaceCard;
-      const total = agentCards.length + viewCards.length + bCards.length + wCards.length + (hub ? 1 : 0) + (mon ? 1 : 0) + (settings ? 1 : 0) + (market ? 1 : 0);
-      if (total === 0) return;
-
-      const allItems = [
-        ...agentCards.map((c) => ({ kind: 'agent' as const, id: c.session_id, x: c.x, y: c.y, storedW: c.width, storedH: c.height })),
-        ...viewCards.map((c) => ({ kind: 'view' as const, id: viewCardKey(c.output_id, c.instance), x: c.x, y: c.y, storedW: c.width, storedH: c.height })),
-        ...bCards.map((c) => ({ kind: 'browser' as const, id: c.browser_id, x: c.x, y: c.y, storedW: c.width, storedH: c.height })),
-        ...wCards.map((c) => ({ kind: 'workflow' as const, id: c.workflow_id, x: c.x, y: c.y, storedW: c.width, storedH: c.height })),
-        ...(hub ? [{ kind: 'workflows-hub' as const, id: 'workflows-hub', x: hub.x, y: hub.y, storedW: hub.width, storedH: hub.height }] : []),
-        ...(mon ? [{ kind: 'workflows-monitor' as const, id: 'workflows-monitor', x: mon.x, y: mon.y, storedW: mon.width, storedH: mon.height }] : []),
-        ...(settings ? [{ kind: 'settings' as const, id: SETTINGS_CARD_ID, x: settings.x, y: settings.y, storedW: settings.width, storedH: settings.height }] : []),
-        ...(market ? [{ kind: 'marketplace' as const, id: MARKETPLACE_CARD_ID, x: market.x, y: market.y, storedW: market.width, storedH: market.height }] : []),
-      ];
-      allItems.sort((a, b) => a.y - b.y || a.x - b.x);
-
-      const sizeOf = (item: typeof allItems[number]): { w: number; h: number } => ({
-        w: item.storedW,
-        h: item.kind === 'agent' && expanded.has(item.id)
-          ? Math.max(EXPANDED_CARD_MIN_H, item.storedH)
-          : item.storedH,
-      });
-      const cols = tidyColumnCount(allItems.map(sizeOf));
-      const placedRects: Rect[] = [];
-
-      for (const item of allItems) {
-        const { w, h } = sizeOf(item);
-
-        const pos = findOpenGridCell(placedRects, w, h, cols);
-        placedRects.push({ x: pos.x, y: pos.y, w, h });
-
-        if (item.kind === 'agent') {
-          const card = state.cards[item.id];
-          if (card) { card.x = pos.x; card.y = pos.y; }
-        } else if (item.kind === 'view') {
-          const card = state.viewCards[item.id];
-          if (card) { card.x = pos.x; card.y = pos.y; }
-        } else if (item.kind === 'workflow') {
-          const card = state.workflowCards[item.id];
-          if (card) { card.x = pos.x; card.y = pos.y; }
-        } else if (item.kind === 'workflows-hub') {
-          if (state.workflowsHub) { state.workflowsHub.x = pos.x; state.workflowsHub.y = pos.y; }
-        } else if (item.kind === 'workflows-monitor') {
-          if (state.workflowsMonitorCard) { state.workflowsMonitorCard.x = pos.x; state.workflowsMonitorCard.y = pos.y; }
-        } else if (item.kind === 'settings') {
-          if (state.settingsCard) { state.settingsCard.x = pos.x; state.settingsCard.y = pos.y; }
-        } else if (item.kind === 'marketplace') {
-          if (state.marketplaceCard) { state.marketplaceCard.x = pos.x; state.marketplaceCard.y = pos.y; }
-        } else {
-          const card = state.browserCards[item.id];
-          if (card) { card.x = pos.x; card.y = pos.y; }
-        }
-      }
-    },
-
-    addViewCard(state, action: PayloadAction<{
-      outputId: string; expandedSessionIds?: string[];
-      parentSessionId?: string | null;
-      x?: number; y?: number; width?: number; height?: number;
-      // Open ANOTHER independent instance of an already-open app instead of no-op'ing.
-      newInstance?: boolean;
-      // Reveal-only: start as a light "click to open" card instead of booting the preview eagerly.
-      previewDeferred?: boolean;
-    }>) {
-      const { outputId, expandedSessionIds, parentSessionId, x, y, width, height, newInstance, previewDeferred } = action.payload;
-      let instance = 1;
-      if (state.viewCards[outputId]) {
-        if (!newInstance) return;
-        instance = 2;
-        while (state.viewCards[viewCardKey(outputId, instance)]) instance++;
-      }
-      const w = width || DEFAULT_VIEW_CARD_W;
-      const h = height || DEFAULT_VIEW_CARD_H;
-      let posX: number, posY: number;
-      if (x != null && y != null) {
-        posX = x;
-        posY = y;
-      } else {
-        const parentCard = parentSessionId ? state.cards[parentSessionId] : null;
-        if (parentCard) {
-          const pos = placeInParentColumn(state, parentSessionId, w, h, expandedSessionIds);
-          posX = pos.x;
-          posY = pos.y;
-        } else {
-          const rects = collectOccupiedRects(state, expandedSessionIds);
-          const pos = findOpenGridCell(rects, w, h);
-          posX = pos.x;
-          posY = pos.y;
-        }
-      }
-      const cardKey = viewCardKey(outputId, instance);
-      state.viewCards[cardKey] = {
-        output_id: outputId,
-        instance,
-        x: posX,
-        y: posY,
-        width: w,
-        height: h,
-        zOrder: state.nextZOrder++,
-        parent_session_id: parentSessionId || null,
-        // An agent-built app defaults to living INSIDE its chat, same as spawned browsers.
-        docked_to: (parentSessionId && (clearOtherDocks(state, parentSessionId), parentSessionId)) || null,
-        preview_deferred: previewDeferred || undefined,
-      };
-      ledgerAdd(state.creationOrder, cardKey);
-      state.pendingFocusViewCardId = cardKey;
-    },
-
-    // First click on a reveal-parked app card: drop the defer so its live preview boots.
-    activateViewCardPreview(state, action: PayloadAction<string>) {
-      const card = state.viewCards[action.payload];
-      if (card && card.preview_deferred) card.preview_deferred = undefined;
-    },
-
-    clearPendingFocusViewCardId(state) {
-      state.pendingFocusViewCardId = null;
-    },
-
-    setViewCardPosition(
-      state,
-      action: PayloadAction<{ outputId: string; x: number; y: number }>
-    ) {
-      const { outputId, x, y } = action.payload;
-      const card = state.viewCards[outputId];
-      if (card) { card.x = x; card.y = y; }
-    },
-
-    setViewCardSize(
-      state,
-      action: PayloadAction<{ outputId: string; width: number; height: number }>
-    ) {
-      const { outputId, width, height } = action.payload;
-      const card = state.viewCards[outputId];
-      if (card) {
-        card.width = Math.max(320, width);
-        card.height = Math.max(200, height);
-      }
-    },
-
-    removeViewCard(state, action: PayloadAction<string>) {
-      delete state.viewCards[action.payload];
-      delete state.tiledCards[action.payload];
-      delete state.minimizedCards[action.payload];
-      ledgerRemove(state.creationOrder, action.payload);
-      if (state.activeViewCardId === action.payload) state.activeViewCardId = null;
-    },
-
-    setActiveViewCardId(state, action: PayloadAction<string | null>) {
-      state.activeViewCardId = action.payload;
-    },
-
-    addBrowserCard(state, action: PayloadAction<{ url: string; expandedSessionIds?: string[]; x?: number; y?: number }>) {
-      const id = `browser-${Date.now().toString(36)}`;
-      const tabId = generateTabId();
-      // Caller may pre-resolve the spawn position (beside the selected card, or in front of the viewport); otherwise fall back to the top-left grid scan.
-      const pos = action.payload.x != null && action.payload.y != null
-        ? { x: action.payload.x, y: action.payload.y }
-        : findOpenGridCell(collectOccupiedRects(state, action.payload.expandedSessionIds), DEFAULT_BROWSER_CARD_W, DEFAULT_BROWSER_CARD_H);
-      state.browserCards[id] = {
-        browser_id: id,
-        url: action.payload.url,
-        tabs: [{ id: tabId, url: action.payload.url, title: '' }],
-        activeTabId: tabId,
-        x: pos.x,
-        y: pos.y,
-        width: DEFAULT_BROWSER_CARD_W,
-        height: DEFAULT_BROWSER_CARD_H,
-        zOrder: state.nextZOrder++,
-        // Born onto the current dashboard so it shows there and only there, never bleeding onto every dashboard while it waits for the first layout save to tag it.
-        dashboard_id: getLastDashboardId() ?? undefined,
-      };
-      ledgerAdd(state.creationOrder, id);
-      state.pendingFocusBrowserId = id;
-    },
-
-    clearPendingFocusBrowserId(state) {
-      state.pendingFocusBrowserId = null;
-    },
-
-    // Camera-focus an EXISTING card (the inline chat embeds' "show on canvas"); the lifecycle
-    // pendingFocus effects own the fit + highlight + clear, same as a fresh add.
-    focusBrowserCard(state, action: PayloadAction<string>) {
-      if (state.browserCards[action.payload]) state.pendingFocusBrowserId = action.payload;
-    },
-    focusViewCard(state, action: PayloadAction<string>) {
-      if (state.viewCards[action.payload]) state.pendingFocusViewCardId = action.payload;
-    },
-
-    setViewDocked(state, action: PayloadAction<{ cardKey: string; dockedTo: string | null }>) {
-      const vc = state.viewCards[action.payload.cardKey];
-      if (!vc) return;
-      if (action.payload.dockedTo) clearOtherDocks(state, action.payload.dockedTo);
-      vc.docked_to = action.payload.dockedTo;
-    },
-    setBrowserDocked(state, action: PayloadAction<{ browserId: string; dockedTo: string | null }>) {
-      const bc = state.browserCards[action.payload.browserId];
-      if (!bc) return;
-      if (action.payload.dockedTo) clearOtherDocks(state, action.payload.dockedTo, action.payload.browserId);
-      bc.docked_to = action.payload.dockedTo;
-    },
-    addBrowserCardFromBackend(state, action: PayloadAction<BrowserCardPosition>) {
-      const card = action.payload;
-      if (state.browserCards[card.browser_id]) return;
-      const w = card.width || DEFAULT_BROWSER_CARD_W;
-      const h = card.height || DEFAULT_BROWSER_CARD_H;
-      // Collision-resolve the backend-proposed position. Backend agents often spawn sub-browsers at the parent's coordinates or at a default (0,0), without this guard, the new card lands on top of an existing one and the user sees a single card with multiple titles fighting for the z-index. Bias toward the proposed position so the spawn still LOOKS related to wherever the agent intended.
-      const rects = collectOccupiedRects(state);
-      const pos = findOpenSpotNear(card.x, card.y, rects, w, h);
-      state.browserCards[card.browser_id] = {
-        ...card,
-        x: pos.x,
-        y: pos.y,
-        width: w,
-        height: h,
-        zOrder: card.zOrder || state.nextZOrder++,
-        // An agent-spawned card must carry its home dashboard or it renders on EVERY dashboard; trust the backend's tag, fall back to the current dashboard so an old/untagged payload can't bleed.
-        dashboard_id: card.dashboard_id ?? getLastDashboardId() ?? undefined,
-      };
-      ledgerAdd(state.creationOrder, card.browser_id);
-    },
-
-    setBrowserCardPosition(
-      state,
-      action: PayloadAction<{ browserId: string; x: number; y: number }>
-    ) {
-      const { browserId, x, y } = action.payload;
-      const card = state.browserCards[browserId];
-      if (card) { card.x = x; card.y = y; }
-    },
-
-    setBrowserCardSize(
-      state,
-      action: PayloadAction<{ browserId: string; width: number; height: number }>
-    ) {
-      const { browserId, width, height } = action.payload;
-      const card = state.browserCards[browserId];
-      if (card) {
-        card.width = Math.max(400, width);
-        card.height = Math.max(300, height);
-      }
-    },
-
-    removeBrowserCard(state, action: PayloadAction<string>) {
-      delete state.browserCards[action.payload];
-      delete state.suspendedBrowserCards[action.payload];
-      delete state.endingBrowserCards[action.payload];
-      delete state.tiledCards[action.payload];
-      delete state.minimizedCards[action.payload];
-      ledgerRemove(state.creationOrder, action.payload);
-    },
-
-    markBrowserCardEnding(
-      state, action: PayloadAction<{ browserId: string; status: 'completed' | 'error' }>,
-    ) {
-      if (!state.browserCards[action.payload.browserId]) return;
-      state.endingBrowserCards[action.payload.browserId] = {
-        status: action.payload.status,
-        at: Date.now(),
-      };
-    },
-
-    cancelBrowserCardEnding(state, action: PayloadAction<string>) {
-      delete state.endingBrowserCards[action.payload];
-    },
-
-    keepBrowserCardOpen(state, action: PayloadAction<string>) {
-      const card = state.browserCards[action.payload];
-      if (!card) return;
-      card.keep_open = true;
-      // Undo any in-flight ending mark in case a close path raced ahead.
-      delete state.endingBrowserCards[action.payload];
-    },
-
-    suspendBrowserCard(state, action: PayloadAction<{ browserId: string; dataUrl: string }>) {
-      if (!state.browserCards[action.payload.browserId]) return;
-      state.suspendedBrowserCards[action.payload.browserId] = {
-        dataUrl: action.payload.dataUrl,
-        capturedAt: Date.now(),
-      };
-    },
-
-    resumeBrowserCard(state, action: PayloadAction<string>) {
-      delete state.suspendedBrowserCards[action.payload];
-    },
-
-    addWorkflowCard(
-      state,
-      action: PayloadAction<{
-        workflowId: string;
-        sourceSessionId?: string | null;
-        expandedSessionIds?: string[];
-      }>,
-    ) {
-      const { workflowId, sourceSessionId, expandedSessionIds } = action.payload;
-      if (state.workflowCards[workflowId]) {
-        state.workflowCards[workflowId].zOrder = state.nextZOrder++;
-        state.pendingFocusWorkflowId = workflowId;
-        return;
-      }
-      // Fall back to persistedExpandedSessionIds when the caller didn't wire the live list through. Without it, collectOccupiedRects sees every chat at its stored (collapsed) height, and a workflow spawned from an open chat lands on top of the visibly-tall card.
-      const expanded = expandedSessionIds ?? state.persistedExpandedSessionIds;
-      const rects = collectOccupiedRects(state, expanded);
-      let posX: number, posY: number;
-      const parentCard = sourceSessionId ? state.cards[sourceSessionId] : null;
-      if (parentCard) {
-        const anchorX = parentCard.x + parentCard.width + GRID_GAP * 6;
-        const anchorY = parentCard.y;
-        const pos = findOpenSpotNear(anchorX, anchorY, rects, DEFAULT_WORKFLOW_CARD_W, DEFAULT_WORKFLOW_CARD_H);
-        posX = pos.x;
-        posY = pos.y;
-      } else {
-        const pos = findOpenGridCell(rects, DEFAULT_WORKFLOW_CARD_W, DEFAULT_WORKFLOW_CARD_H);
-        posX = pos.x;
-        posY = pos.y;
-      }
-      state.workflowCards[workflowId] = {
-        workflow_id: workflowId,
-        x: posX,
-        y: posY,
-        width: DEFAULT_WORKFLOW_CARD_W,
-        height: DEFAULT_WORKFLOW_CARD_H,
-        zOrder: state.nextZOrder++,
-        source_session_id: sourceSessionId || null,
-      };
-      ledgerAdd(state.creationOrder, workflowId);
-      state.pendingFocusWorkflowId = workflowId;
-    },
-
-    setWorkflowCardPosition(
-      state,
-      action: PayloadAction<{ workflowId: string; x: number; y: number }>,
-    ) {
-      const { workflowId, x, y } = action.payload;
-      const card = state.workflowCards[workflowId];
-      if (card) { card.x = x; card.y = y; }
-    },
-
-    setWorkflowCardSize(
-      state,
-      action: PayloadAction<{ workflowId: string; width: number; height: number }>,
-    ) {
-      const { workflowId, width, height } = action.payload;
-      const card = state.workflowCards[workflowId];
-      if (card) {
-        card.width = Math.max(360, width);
-        card.height = Math.max(280, height);
-      }
-    },
-
-    removeWorkflowCard(state, action: PayloadAction<string>) {
-      delete state.workflowCards[action.payload];
-      // Rule 7: a dead card must never keep owning a tile; a stale entry poisons every reader of it.
-      delete state.tiledCards[action.payload];
-      delete state.minimizedCards[action.payload];
-      ledgerRemove(state.creationOrder, action.payload);
-    },
-
-    // Rekey draft- id to the server-assigned id without visually hopping the card.
-    rekeyWorkflowCard(
-      state,
-      action: PayloadAction<{ oldId: string; newId: string }>,
-    ) {
-      const { oldId, newId } = action.payload;
-      const card = state.workflowCards[oldId];
-      if (!card) return;
-      delete state.workflowCards[oldId];
-      state.workflowCards[newId] = { ...card, workflow_id: newId };
-      ledgerRekey(state.creationOrder, oldId, newId);
-      if (state.pendingFocusWorkflowId === oldId) state.pendingFocusWorkflowId = newId;
-    },
-
-    clearPendingFocusWorkflowId(state) {
-      state.pendingFocusWorkflowId = null;
-    },
-
-    openWorkflowsHub(state, action: PayloadAction<{ expandedSessionIds?: string[] } | undefined>) {
-      if (state.workflowsHub) {
-        state.workflowsHub.zOrder = state.nextZOrder++;
-        delete state.minimizedCards[WORKFLOWS_HUB_ID];
-        state.pendingFocusWorkflowsHub = true;
-        return;
-      }
-      const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
-      const pos = findOpenGridCell(rects, DEFAULT_WORKFLOWS_HUB_W, DEFAULT_WORKFLOWS_HUB_H);
-      state.workflowsHub = {
-        x: pos.x,
-        y: pos.y,
-        width: DEFAULT_WORKFLOWS_HUB_W,
-        height: DEFAULT_WORKFLOWS_HUB_H,
-        zOrder: state.nextZOrder++,
-      };
-      state.pendingFocusWorkflowsHub = true;
-    },
-
-    clearPendingFocusWorkflowsHub(state) {
-      state.pendingFocusWorkflowsHub = false;
-    },
-
-    closeWorkflowsHub(state) {
-      state.workflowsHub = null;
-      delete state.minimizedCards[WORKFLOWS_HUB_ID];
-      delete state.tiledCards[WORKFLOWS_HUB_ID];
-    },
-
-    // The Workflows app is an on-canvas card (like chat/browser/view cards), backed by the singleton workflowsHub geometry. Opening it creates or raises that card and pans to it; an optional workflowId deep-links to that workflow's detail once the card mounts.
-    openWorkflowsApp(state, action: PayloadAction<{ workflowId?: string; expandedSessionIds?: string[] } | undefined>) {
-      state.workflowsAppTarget = action.payload?.workflowId ?? null;
-      if (state.workflowsHub) {
-        state.workflowsHub.zOrder = state.nextZOrder++;
-        // Opening means visible: a parked window must come back to the canvas, or the focus pan flies to empty space.
-        delete state.minimizedCards[WORKFLOWS_HUB_ID];
-        state.pendingFocusWorkflowsHub = true;
-        return;
-      }
-      const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
-      const pos = findOpenGridCell(rects, DEFAULT_WORKFLOWS_HUB_W, DEFAULT_WORKFLOWS_HUB_H);
-      state.workflowsHub = {
-        x: pos.x,
-        y: pos.y,
-        width: DEFAULT_WORKFLOWS_HUB_W,
-        height: DEFAULT_WORKFLOWS_HUB_H,
-        zOrder: state.nextZOrder++,
-      };
-      state.pendingFocusWorkflowsHub = true;
-    },
-
-    closeWorkflowsApp(state) {
-      state.workflowsHub = null;
-      delete state.tiledCards[WORKFLOWS_HUB_ID];
-      delete state.minimizedCards[WORKFLOWS_HUB_ID];
-      state.workflowsAppTarget = null;
-      state.workflowsMonitorId = null;
-      state.workflowsMonitorRunId = null;
-      state.workflowsMonitorCard = null;
-    },
-
-    clearWorkflowsAppTarget(state) {
-      state.workflowsAppTarget = null;
-    },
-
-    // Spawn the Run Monitor as a real canvas card to the right of the window, tethered back to it. Reuses the window's geometry to place + size it. runId pins a specific (e.g. history) run; omit it to follow the latest.
-    openWorkflowMonitor(state, action: PayloadAction<{ workflowId: string; runId?: string }>) {
-      state.workflowsMonitorId = action.payload.workflowId;
-      state.workflowsMonitorRunId = action.payload.runId ?? null;
-      const hub = state.workflowsHub;
-      // Keep the existing card position when just switching the run shown.
-      if (!state.workflowsMonitorCard) {
-        state.workflowsMonitorCard = {
-          x: hub ? hub.x + hub.width + WORKFLOW_CARD_GAP : 220,
-          y: hub ? hub.y : 160,
-          width: 520,
-          height: hub ? hub.height : 560,
-          zOrder: state.nextZOrder++,
-        };
-      } else {
-        state.workflowsMonitorCard.zOrder = state.nextZOrder++;
-      }
-    },
-
-    closeWorkflowMonitor(state) {
-      state.workflowsMonitorId = null;
-      state.workflowsMonitorRunId = null;
-      state.workflowsMonitorCard = null;
-    },
-
-    setWorkflowsMonitorPosition(state, action: PayloadAction<{ x: number; y: number }>) {
-      if (!state.workflowsMonitorCard) return;
-      state.workflowsMonitorCard.x = action.payload.x;
-      state.workflowsMonitorCard.y = action.payload.y;
-    },
-
-    setWorkflowsRunContext(state, action: PayloadAction<WorkflowsRunContext>) {
-      state.workflowsRunContext = action.payload;
-    },
-
-    clearWorkflowsRunContext(state) {
-      state.workflowsRunContext = null;
-    },
-
-    setWorkflowsHubPosition(state, action: PayloadAction<{ x: number; y: number }>) {
-      if (!state.workflowsHub) return;
-      state.workflowsHub.x = action.payload.x;
-      state.workflowsHub.y = action.payload.y;
-    },
-
-    setWorkflowsHubSize(state, action: PayloadAction<{ width: number; height: number }>) {
-      if (!state.workflowsHub) return;
-      state.workflowsHub.width = Math.max(720, action.payload.width);
-      state.workflowsHub.height = Math.max(420, action.payload.height);
-    },
-
-    // Settings is an on-canvas window like the Workflows app, not a modal: opening it creates or raises that card and pans to it.
-    openSettingsCard(state, action: PayloadAction<{ tab?: string; expandedSessionIds?: string[] } | undefined>) {
-      state.settingsRequestedTab = action.payload?.tab ?? null;
-      if (state.settingsCard) {
-        state.settingsCard.zOrder = state.nextZOrder++;
-        delete state.minimizedCards[SETTINGS_CARD_ID];
-        state.pendingFocusSettingsCard = true;
-        return;
-      }
-      const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
-      const pos = findOpenGridCell(rects, DEFAULT_SETTINGS_CARD_W, DEFAULT_SETTINGS_CARD_H);
-      state.settingsCard = {
-        x: pos.x,
-        y: pos.y,
-        width: DEFAULT_SETTINGS_CARD_W,
-        height: DEFAULT_SETTINGS_CARD_H,
-        zOrder: state.nextZOrder++,
-      };
-      state.pendingFocusSettingsCard = true;
-    },
-
-    closeSettingsCard(state) {
-      state.settingsCard = null;
-      state.settingsRequestedTab = null;
-      delete state.minimizedCards[SETTINGS_CARD_ID];
-      delete state.tiledCards[SETTINGS_CARD_ID];
-      state.pendingFocusSettingsCard = false;
-    },
-
-    clearPendingFocusSettingsCard(state) {
-      state.pendingFocusSettingsCard = false;
-    },
-
-    clearSettingsRequestedTab(state) {
-      state.settingsRequestedTab = null;
-    },
-
-    setSettingsCardPosition(state, action: PayloadAction<{ x: number; y: number }>) {
-      if (!state.settingsCard) return;
-      state.settingsCard.x = action.payload.x;
-      state.settingsCard.y = action.payload.y;
-    },
-
-    setSettingsCardSize(state, action: PayloadAction<{ width: number; height: number }>) {
-      if (!state.settingsCard) return;
-      state.settingsCard.width = Math.max(640, action.payload.width);
-      state.settingsCard.height = Math.max(460, action.payload.height);
-    },
-
-    // Marketplace mirrors the Settings window: an on-canvas singleton, opened or raised in place.
-    openMarketplaceCard(state, action: PayloadAction<{ tab?: string; expandedSessionIds?: string[] } | undefined>) {
-      state.marketplaceRequestedTab = action.payload?.tab ?? null;
-      if (state.marketplaceCard) {
-        state.marketplaceCard.zOrder = state.nextZOrder++;
-        delete state.minimizedCards[MARKETPLACE_CARD_ID];
-        state.pendingFocusMarketplaceCard = true;
-        return;
-      }
-      const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
-      const pos = findOpenGridCell(rects, DEFAULT_MARKETPLACE_CARD_W, DEFAULT_MARKETPLACE_CARD_H);
-      state.marketplaceCard = {
-        x: pos.x,
-        y: pos.y,
-        width: DEFAULT_MARKETPLACE_CARD_W,
-        height: DEFAULT_MARKETPLACE_CARD_H,
-        zOrder: state.nextZOrder++,
-      };
-      state.pendingFocusMarketplaceCard = true;
-    },
-
-    closeMarketplaceCard(state) {
-      state.marketplaceCard = null;
-      state.marketplaceRequestedTab = null;
-      delete state.minimizedCards[MARKETPLACE_CARD_ID];
-      delete state.tiledCards[MARKETPLACE_CARD_ID];
-      state.pendingFocusMarketplaceCard = false;
-    },
-
-    clearPendingFocusMarketplaceCard(state) {
-      state.pendingFocusMarketplaceCard = false;
-    },
-
-    clearMarketplaceRequestedTab(state) {
-      state.marketplaceRequestedTab = null;
-    },
-
-    setMarketplaceCardPosition(state, action: PayloadAction<{ x: number; y: number }>) {
-      if (!state.marketplaceCard) return;
-      state.marketplaceCard.x = action.payload.x;
-      state.marketplaceCard.y = action.payload.y;
-    },
-
-    setMarketplaceCardSize(state, action: PayloadAction<{ width: number; height: number }>) {
-      if (!state.marketplaceCard) return;
-      state.marketplaceCard.width = Math.max(760, action.payload.width);
-      state.marketplaceCard.height = Math.max(520, action.payload.height);
-    },
-
-    pasteBrowserCard(
-      state,
-      action: PayloadAction<{
-        tabs: BrowserTab[]; url: string; expandedSessionIds?: string[];
-        id?: string; x?: number; y?: number; width?: number; height?: number;
-      }>
-    ) {
-      const { x, y, width, height } = action.payload;
-      const id = action.payload.id || `browser-${Date.now().toString(36)}`;
-      const newTabs = action.payload.tabs.map((t) => ({
-        id: generateTabId(),
-        url: t.url,
-        title: '',
-        favicon: undefined,
-      }));
-      const activeTab = newTabs[0];
-      let posX: number, posY: number;
-      if (x != null && y != null) {
-        posX = x;
-        posY = y;
-      } else {
-        const rects = collectOccupiedRects(state, action.payload.expandedSessionIds);
-        const pos = findOpenGridCell(rects, DEFAULT_BROWSER_CARD_W, DEFAULT_BROWSER_CARD_H);
-        posX = pos.x;
-        posY = pos.y;
-      }
-      state.browserCards[id] = {
-        browser_id: id,
-        url: activeTab?.url || action.payload.url,
-        tabs: newTabs.length > 0 ? newTabs : [{ id: generateTabId(), url: action.payload.url, title: '' }],
-        activeTabId: activeTab?.id || generateTabId(),
-        x: posX,
-        y: posY,
-        width: width || DEFAULT_BROWSER_CARD_W,
-        height: height || DEFAULT_BROWSER_CARD_H,
-        zOrder: state.nextZOrder++,
-        // Pasted onto the dashboard the user is looking at, else it bleeds onto every dashboard.
-        dashboard_id: getLastDashboardId() ?? undefined,
-      };
-    },
-
-    updateBrowserCardUrl(
-      state,
-      action: PayloadAction<{ browserId: string; url: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (card) {
-        card.url = action.payload.url;
-        const tab = card.tabs.find((t) => t.id === card.activeTabId);
-        if (tab) tab.url = action.payload.url;
-      }
-    },
-
-    addBrowserTab(
-      state,
-      action: PayloadAction<{ browserId: string; url: string; makeActive?: boolean }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const tabId = generateTabId();
-      card.tabs.push({ id: tabId, url: action.payload.url, title: '' });
-      if (action.payload.makeActive !== false) {
-        card.activeTabId = tabId;
-        card.url = action.payload.url;
-      }
-    },
-
-    removeBrowserTab(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const idx = card.tabs.findIndex((t) => t.id === action.payload.tabId);
-      if (idx === -1) return;
-      card.tabs.splice(idx, 1);
-      if (card.tabs.length === 0) {
-        delete state.browserCards[action.payload.browserId];
-        delete state.suspendedBrowserCards[action.payload.browserId];
-        return;
-      }
-      if (card.activeTabId === action.payload.tabId) {
-        const newActive = card.tabs[Math.min(idx, card.tabs.length - 1)];
-        card.activeTabId = newActive.id;
-        card.url = newActive.url;
-      }
-    },
-
-    setActiveBrowserTab(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const tab = card.tabs.find((t) => t.id === action.payload.tabId);
-      if (tab) {
-        card.activeTabId = tab.id;
-        card.url = tab.url;
-      }
-    },
-
-    // Ctrl+Tab / Ctrl+Shift+Tab: move to the next/previous tab, wrapping around. dir 1 = forward.
-    cycleBrowserTab(
-      state,
-      action: PayloadAction<{ browserId: string; dir: 1 | -1 }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card || card.tabs.length < 2) return;
-      const idx = card.tabs.findIndex((t) => t.id === card.activeTabId);
-      if (idx === -1) return;
-      const n = card.tabs.length;
-      const next = card.tabs[(idx + action.payload.dir + n) % n];
-      card.activeTabId = next.id;
-      card.url = next.url;
-    },
-
-    updateBrowserTabUrl(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string; url: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const tab = card.tabs.find((t) => t.id === action.payload.tabId);
-      if (tab) {
-        tab.url = action.payload.url;
-        if (action.payload.tabId === card.activeTabId) {
-          card.url = action.payload.url;
-        }
-      }
-    },
-
-    updateBrowserTabTitle(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string; title: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const tab = card.tabs.find((t) => t.id === action.payload.tabId);
-      if (tab) tab.title = action.payload.title;
-    },
-
-    updateBrowserTabFavicon(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string; favicon: string }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const tab = card.tabs.find((t) => t.id === action.payload.tabId);
-      if (tab) tab.favicon = action.payload.favicon;
-    },
-
-    reorderBrowserTab(
-      state,
-      action: PayloadAction<{ browserId: string; tabId: string; toIndex: number }>
-    ) {
-      const card = state.browserCards[action.payload.browserId];
-      if (!card) return;
-      const fromIdx = card.tabs.findIndex((t) => t.id === action.payload.tabId);
-      if (fromIdx === -1) return;
-      const [tab] = card.tabs.splice(fromIdx, 1);
-      card.tabs.splice(Math.max(0, Math.min(action.payload.toIndex, card.tabs.length)), 0, tab);
-    },
-
-    // Drag a tab OUT of a browser card: into another card (absorbed, appended + activated) or onto empty canvas (spins off a new card at the drop point). Moving the last tab dissolves the source card, Chrome-style.
-    moveBrowserTab(
-      state,
-      action: PayloadAction<{ fromBrowserId: string; tabId: string; toBrowserId?: string; x?: number; y?: number }>
-    ) {
-      const { fromBrowserId, tabId, toBrowserId, x, y } = action.payload;
-      if (toBrowserId === fromBrowserId) return;
-      const source = state.browserCards[fromBrowserId];
-      if (!source) return;
-      const idx = source.tabs.findIndex((t) => t.id === tabId);
-      if (idx === -1) return;
-      const target = toBrowserId ? state.browserCards[toBrowserId] : undefined;
-      if (toBrowserId && !target) return;
-      const [moved] = source.tabs.splice(idx, 1);
-      // Fresh id: reusing the old one makes the receiving BrowserCard think the tab is already initialized, so its webview never loads the URL and sits at about:blank.
-      const tab = { ...moved, id: generateTabId() };
-      const spun = {
-        owner: source.spawned_by ?? null,
-        x: source.x, y: source.y, width: source.width, height: source.height, dashboard_id: source.dashboard_id,
-      };
-      const dissolved = source.tabs.length === 0;
-      if (dissolved) {
-        delete state.browserCards[fromBrowserId];
-        delete state.suspendedBrowserCards[fromBrowserId];
-      } else if (source.activeTabId === tabId) {
-        const nextActive = source.tabs[Math.min(idx, source.tabs.length - 1)];
-        source.activeTabId = nextActive.id;
-        source.url = nextActive.url;
-      }
-      if (target) {
-        target.tabs.push(tab);
-        target.activeTabId = tab.id;
-        target.url = tab.url;
-        target.zOrder = state.nextZOrder++;
-      } else {
-        // The last tab leaving is the card MOVING, so it keeps its id; either way it keeps its agent
-        // owner, or the agent stops recognising its own browser and spawns a second one next time it
-        // browses. keep_open because pulling it out is the user claiming it: the owner finishing must
-        // not delete it out from under them, exactly as when it had no owner at all.
-        const id = dissolved ? fromBrowserId : `browser-${Date.now().toString(36)}`;
-        state.browserCards[id] = {
-          browser_id: id,
-          url: tab.url,
-          tabs: [tab],
-          activeTabId: tab.id,
-          x: x ?? spun.x + 60,
-          y: y ?? spun.y + 60,
-          width: spun.width,
-          height: spun.height,
-          zOrder: state.nextZOrder++,
-          dashboard_id: spun.dashboard_id,
-          spawned_by: spun.owner,
-          keep_open: true,
-        };
-      }
-    },
-
-    moveCards(
-      state,
-      action: PayloadAction<{
-        items: Array<{ id: string; type: CardType }>;
-        dx: number;
-        dy: number;
-      }>,
-    ) {
-      const { items, dx, dy } = action.payload;
-      for (const item of items) {
-        if (item.type === 'agent') {
-          const card = state.cards[item.id];
-          if (card) {
-            card.x += dx;
-            card.y += dy;
-          }
-        } else if (item.type === 'view') {
-          const card = state.viewCards[item.id];
-          if (card) {
-            card.x += dx;
-            card.y += dy;
-          }
-        } else if (item.type === 'workflow') {
-          const card = state.workflowCards[item.id];
-          if (card) {
-            card.x += dx;
-            card.y += dy;
-          }
-        } else if (item.type === 'workflows-hub') {
-          if (state.workflowsHub) {
-            state.workflowsHub.x += dx;
-            state.workflowsHub.y += dy;
-          }
-        } else if (item.type === 'settings') {
-          if (state.settingsCard) {
-            state.settingsCard.x += dx;
-            state.settingsCard.y += dy;
-          }
-        } else if (item.type === 'marketplace') {
-          if (state.marketplaceCard) {
-            state.marketplaceCard.x += dx;
-            state.marketplaceCard.y += dy;
-          }
-        } else {
-          const card = state.browserCards[item.id];
-          if (card) {
-            card.x += dx;
-            card.y += dy;
-          }
-        }
-      }
-    },
-
-    // Snapshot a card onto the reopen stack RIGHT BEFORE it's closed (the data must still be in state). Dispatch only from genuine user closes, not programmatic teardown.
-    recordClosedCard(
-      state,
-      action: PayloadAction<{ kind: ClosedCardKind; id: string; browserId?: string }>
-    ) {
-      const { kind, id, browserId } = action.payload;
-      const closedAt = Date.now();
-      const uid = `${kind}-${id}-${closedAt}`;
-      let entry: ClosedCard | null = null;
-      if (kind === 'browser' && state.browserCards[id]) {
-        entry = { uid, kind, closedAt, card: { ...state.browserCards[id], tabs: state.browserCards[id].tabs.map((t) => ({ ...t })) } };
-      } else if (kind === 'view' && state.viewCards[id]) {
-        entry = { uid, kind, closedAt, card: { ...state.viewCards[id] } };
-      } else if (kind === 'workflow' && state.workflowCards[id]) {
-        entry = { uid, kind, closedAt, card: { ...state.workflowCards[id] } };
-      } else if (kind === 'agent') {
-        entry = { uid, kind, closedAt, sessionId: id, position: state.cards[id] ? { ...state.cards[id] } : null };
-      } else if (kind === 'tab' && browserId && state.browserCards[browserId]) {
-        const card = state.browserCards[browserId];
-        const index = card.tabs.findIndex((t) => t.id === id);
-        // Last tab closing tears the whole card down; that's recorded as a 'browser' close instead, so skip.
-        if (index >= 0 && card.tabs.length > 1) entry = { uid, kind, closedAt, browserId, index, tab: { ...card.tabs[index] } };
-      }
-      if (!entry) return;
-      state.recentlyClosed.push(entry);
-      if (state.recentlyClosed.length > RECENTLY_CLOSED_CAP) state.recentlyClosed.shift();
-    },
-
-    // Re-insert a non-agent closed card (agents come back via resumeSession in the reopenLastClosed thunk). Lands on the current dashboard.
-    restoreClosedCard(
-      state,
-      action: PayloadAction<{ entry: ClosedCard; dashboardId?: string }>
-    ) {
-      const { entry, dashboardId } = action.payload;
-      const zOrder = state.nextZOrder++;
-      if (entry.kind === 'browser') {
-        state.browserCards[entry.card.browser_id] = { ...entry.card, zOrder, dashboard_id: dashboardId ?? entry.card.dashboard_id };
-      } else if (entry.kind === 'view') {
-        state.viewCards[viewCardKey(entry.card.output_id, entry.card.instance)] = { ...entry.card, zOrder };
-      } else if (entry.kind === 'workflow') {
-        state.workflowCards[entry.card.workflow_id] = { ...entry.card, zOrder };
-      } else if (entry.kind === 'tab') {
-        const card = state.browserCards[entry.browserId];
-        if (card) {
-          // Fresh id: reusing the old one makes BrowserCard think the tab is already initialized, so its webview never reloads the URL and sits at about:blank.
-          const tab = { ...entry.tab, id: generateTabId() };
-          card.tabs.splice(Math.min(entry.index, card.tabs.length), 0, tab);
-          card.activeTabId = tab.id;
-          card.url = tab.url;
-        }
-      }
-    },
-
-    popClosedCard(state, action: PayloadAction<string>) {
-      state.recentlyClosed = state.recentlyClosed.filter((e) => e.uid !== action.payload);
-    },
-
-    // Pre-seed a resumed agent's old position so reconcileSessions drops its card back where it was, not in a fresh grid cell.
-    seedClosedAgentPosition(
-      state,
-      action: PayloadAction<{ sessionId: string; position: CardPosition }>
-    ) {
-      state.closedCardPositions[action.payload.sessionId] = action.payload.position;
-    },
-
-    replaceDraftId(
-      state,
-      action: PayloadAction<{ oldId: string; newId: string }>
-    ) {
-      const { oldId, newId } = action.payload;
-      const card = state.cards[oldId];
-      if (card) {
-        delete state.cards[oldId];
-        state.cards[newId] = { ...card, session_id: newId };
-      }
-    },
-
-    setGlowingBrowserCards(
-      state,
-      action: PayloadAction<{ browserIds: string[]; sessionId: string; label?: string }>
-    ) {
-      const { browserIds, sessionId, label } = action.payload;
-      for (const id of browserIds) {
-        state.glowingBrowserCards[id] = { sourceId: sessionId, fading: false, label };
-      }
-    },
-
-    fadeGlowingBrowserCards(state, action: PayloadAction<string>) {
-      const sessionId = action.payload;
-      for (const entry of Object.values(state.glowingBrowserCards)) {
-        if (entry.sourceId === sessionId) entry.fading = true;
-      }
-    },
-
-    clearGlowingBrowserCards(state, action: PayloadAction<string>) {
-      const sessionId = action.payload;
-      for (const [browserId, entry] of Object.entries(state.glowingBrowserCards)) {
-        if (entry.sourceId === sessionId) delete state.glowingBrowserCards[browserId];
-      }
-    },
-
-    clearAllGlowingBrowserCards(state) {
-      state.glowingBrowserCards = {};
-    },
-
-    setGlowingAgentCard(state, action: PayloadAction<{ sessionId: string; sourceId: string; sourceYRatio?: number; label?: string }>) {
-      const { sessionId, sourceId, sourceYRatio, label } = action.payload;
-      state.glowingAgentCards[sessionId] = { sourceId, fading: false, sourceYRatio, label };
-    },
-
-    fadeGlowingAgentCard(state, action: PayloadAction<string>) {
-      const entry = state.glowingAgentCards[action.payload];
-      if (entry) entry.fading = true;
-    },
-
-    clearGlowingAgentCard(state, action: PayloadAction<string>) {
-      delete state.glowingAgentCards[action.payload];
-    },
-
-    resetLayout(state, action: PayloadAction<{ keepBrowserIds?: string[] } | undefined>) {
-      state.tiledCards = {};
-      state.minimizedCards = {};
-      // Keep the recently-used (keep-alive) browser cards mounted across a dashboard switch so their webContents + sessionStorage survive (logged-in sites stay logged in); everything else is wiped for the fresh load. Their suspend entry rides along so a parked one isn't silently dropped.
-      const keep = new Set(action.payload?.keepBrowserIds || []);
-      const keptBrowsers: typeof state.browserCards = {};
-      const keptSuspended: typeof state.suspendedBrowserCards = {};
-      for (const id of keep) {
-        if (state.browserCards[id]) keptBrowsers[id] = state.browserCards[id];
-        if (state.suspendedBrowserCards[id]) keptSuspended[id] = state.suspendedBrowserCards[id];
-      }
-      state.cards = {};
-      state.viewCards = {};
-      state.browserCards = keptBrowsers;
-      state.workflowCards = {};
-      state.workflowsHub = null;
-      state.settingsCard = null;
-      state.pendingFocusSettingsCard = false;
-      state.settingsRequestedTab = null;
-      state.marketplaceCard = null;
-      state.pendingFocusMarketplaceCard = false;
-      state.marketplaceRequestedTab = null;
-      state.closedCardPositions = {};
-      state.glowingBrowserCards = {};
-      state.glowingAgentCards = {};
-      state.persistedExpandedSessionIds = [];
-      state.nextZOrder = 1;
-      state.initialized = false;
-      state.saveArmed = false;
-      state.suspendedBrowserCards = keptSuspended;
-      state.endingBrowserCards = {};
-      state.pendingFocusWorkflowId = null;
-      // Per-dashboard, same as the cards it tracks; fetchLayout.fulfilled rebuilds it for the new dashboard.
-      state.creationOrder = [];
-    },
+    ...resetReducers,
+    ...windowCardReducers,
 
   },
   extraReducers: (builder) => {
     builder
-      .addCase(fetchLayout.pending, (state) => {
+      .addCase(fetchLayout.pending, (state, action) => {
         state.loading = true;
+        state.activeFetchDashboardId = action.meta.arg.dashboardId;
+        state.activeFetchRequestId = action.meta.requestId;
       })
       .addCase(fetchLayout.fulfilled, (state, action) => {
+        if (
+          action.meta.arg.dashboardId !== state.activeFetchDashboardId
+          || action.meta.requestId !== state.activeFetchRequestId
+        ) return;
         state.loading = false;
         // A fresh mount/switch load replaces (the snapshot is the user's saved layout, authoritative). A reconnect refetch (useDashboardLifecycle line ~90) recovers cards lost in a socket gap and must MERGE, blind- replacing there clobbered the live, collision-placed positions of cards already on canvas (the overlap / vanish under load while many browsers spawn). The caller says which; never inferred from state.
         const isReconnectRefetch = action.meta.arg.isReconnect === true;
@@ -1914,30 +323,13 @@ const dashboardLayoutSlice = createSlice({
           addMissingCards(state.workflowCards, action.payload.workflowCards || {}, occupied);
           if (!state.workflowsHub && action.payload.workflowsHub) state.workflowsHub = action.payload.workflowsHub;
         }
+        state.unknownPersistedLayoutFieldsByDashboard[ownerDashboardId] = action.payload.unknownPersistedLayoutFields;
         state.persistedExpandedSessionIds = action.payload.expandedSessionIds;
-
-        let maxZ = 0;
-        for (const c of Object.values(state.cards)) {
-          if (!c.zOrder) c.zOrder = 0;
-          if (c.zOrder > maxZ) maxZ = c.zOrder;
-        }
-        for (const c of Object.values(state.viewCards)) {
-          if (!c.zOrder) c.zOrder = 0;
-          if (c.zOrder > maxZ) maxZ = c.zOrder;
-        }
-        for (const c of Object.values(state.browserCards)) {
-          if (!c.zOrder) c.zOrder = 0;
-          if (c.zOrder > maxZ) maxZ = c.zOrder;
-        }
-        for (const w of Object.values(state.workflowCards)) {
-          if (!w.zOrder) w.zOrder = 0;
-          if (w.zOrder > maxZ) maxZ = w.zOrder;
-        }
         state.zOrders = { ...state.zOrders, ...(action.payload.zOrders ?? {}) };
-        for (const z of Object.values(state.zOrders)) { if (z > maxZ) maxZ = z; }
-        state.nextZOrder = maxZ + 1;
 
-        // Ledger rebuild: persisted order filtered to live ids, then unledgered survivors by zOrder (legacy layouts, drift). Keep-alive browsers homed on OTHER dashboards stay out: the trash must never delete a card the user can't see.
+        reconcileDashboardCardZOrder(state);
+
+        // Ledger rebuild: persisted order filtered to live ids, then unledgered survivors by effective zOrder (legacy layouts, drift). Keep-alive browsers homed on OTHER dashboards stay off this dashboard's ledger.
         const zOf = (id: string): number =>
           state.zOrders[id] ?? state.cards[id]?.zOrder ?? state.viewCards[id]?.zOrder ?? state.browserCards[id]?.zOrder ?? state.workflowCards[id]?.zOrder ?? 0;
         const live = new Set<string>([
@@ -1953,10 +345,16 @@ const dashboardLayoutSlice = createSlice({
         const rest = [...live].filter((id) => !ledgered.has(id)).sort((a, b) => zOf(a) - zOf(b));
         state.creationOrder = [...persisted, ...rest];
       })
-      .addCase(fetchLayout.rejected, (state) => {
+      .addCase(fetchLayout.rejected, (state, action) => {
+        if (
+          action.meta.arg.dashboardId !== state.activeFetchDashboardId
+          || action.meta.requestId !== state.activeFetchRequestId
+        ) return;
         state.loading = false;
         // Fail-open for RENDERING only; saveArmed stays false so this client can never persist the empty layout it booted with over the server's real one (the wipe that hit 2026-07-20).
         state.initialized = true;
+        // Revoke only this dashboard's save authority until a later successful fetch restores its baseline.
+        delete state.unknownPersistedLayoutFieldsByDashboard[action.meta.arg.dashboardId];
       })
       // Rule 8 of the tiling set: a chat's zone belongs to its OPEN state, so every action that closes
       // chats untiles them here, in the same dispatch. See untileClosedChats.
@@ -2009,9 +407,6 @@ const dashboardLayoutSlice = createSlice({
           for (const bc of Object.values(state.browserCards)) {
             if (bc.spawned_by !== session.id) continue;
             const pos = placeBrowserBesideChat(state, parentCard, session.id, bc.width, bc.height, bc.browser_id);
-            // Default home is inside the chat, same as the non-racing spawn path.
-            clearOtherDocks(state, session.id);
-            bc.docked_to = session.id;
             bc.x = pos.x;
             bc.y = pos.y;
             state.glowingBrowserCards[bc.browser_id] = { sourceId: session.id, fading: false, label: 'Use Browser' };

--- a/frontend/src/shared/state/dashboardLayoutViewReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutViewReducers.ts
@@ -1,0 +1,115 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  DEFAULT_VIEW_CARD_H,
+  DEFAULT_VIEW_CARD_W,
+  viewCardKey,
+  type DashboardLayoutState,
+} from './dashboardLayoutModel';
+import {
+  collectOccupiedRects,
+  findOpenGridCell,
+  placeInParentColumn,
+} from './dashboardLayoutGeometry';
+import { ledgerAdd, ledgerRemove } from './dashboardLayoutCardState';
+import { clearOtherDocks } from './dashboardLayoutWindowReducers';
+
+export const viewCardReducers = {
+  addViewCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{
+      outputId: string; expandedSessionIds?: string[];
+      parentSessionId?: string | null;
+      x?: number; y?: number; width?: number; height?: number;
+      newInstance?: boolean;
+      // Reveal-only: start as a light "click to open" card instead of booting the preview eagerly.
+      previewDeferred?: boolean;
+    }>,
+  ) {
+    const { outputId, expandedSessionIds, parentSessionId, x, y, width, height, newInstance, previewDeferred } = action.payload;
+    let instance = 1;
+    if (state.viewCards[outputId]) {
+      if (!newInstance) {
+        state.viewCards[outputId].zOrder = state.nextZOrder++;
+        state.pendingFocusViewCardId = outputId;
+        return;
+      }
+      instance = 2;
+      while (state.viewCards[viewCardKey(outputId, instance)]) instance++;
+    }
+    const w = width || DEFAULT_VIEW_CARD_W;
+    const h = height || DEFAULT_VIEW_CARD_H;
+    let posX: number, posY: number;
+    if (x != null && y != null) {
+      posX = x;
+      posY = y;
+    } else {
+      const parentCard = parentSessionId ? state.cards[parentSessionId] : null;
+      if (parentCard) {
+        const pos = placeInParentColumn(state, parentSessionId, w, h, expandedSessionIds);
+        posX = pos.x;
+        posY = pos.y;
+      } else {
+        const rects = collectOccupiedRects(state, expandedSessionIds);
+        const pos = findOpenGridCell(rects, w, h);
+        posX = pos.x;
+        posY = pos.y;
+      }
+    }
+    const cardKey = viewCardKey(outputId, instance);
+    state.viewCards[cardKey] = {
+      output_id: outputId,
+      instance,
+      x: posX,
+      y: posY,
+      width: w,
+      height: h,
+      zOrder: state.nextZOrder++,
+      parent_session_id: parentSessionId || null,
+      // An agent-built app defaults to living INSIDE its chat, same as spawned browsers.
+      docked_to: (parentSessionId && (clearOtherDocks(state, parentSessionId), parentSessionId)) || null,
+      preview_deferred: previewDeferred || undefined,
+    };
+    state.pendingFocusViewCardId = cardKey;
+    ledgerAdd(state.creationOrder, cardKey);
+  },
+
+  clearPendingFocusViewCardId(state: DashboardLayoutState) {
+    state.pendingFocusViewCardId = null;
+  },
+
+  setViewCardPosition(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ outputId: string; x: number; y: number }>,
+  ) {
+    const { outputId, x, y } = action.payload;
+    const card = state.viewCards[outputId];
+    if (card) {
+      card.x = x;
+      card.y = y;
+    }
+  },
+
+  setViewCardSize(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ outputId: string; width: number; height: number }>,
+  ) {
+    const { outputId, width, height } = action.payload;
+    const card = state.viewCards[outputId];
+    if (card) {
+      card.width = Math.max(320, width);
+      card.height = Math.max(200, height);
+    }
+  },
+
+  removeViewCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.viewCards[action.payload];
+    delete state.tiledCards[action.payload];
+    delete state.minimizedCards[action.payload];
+    ledgerRemove(state.creationOrder, action.payload);
+    if (state.activeViewCardId === action.payload) state.activeViewCardId = null;
+  },
+
+  setActiveViewCardId(state: DashboardLayoutState, action: PayloadAction<string | null>) {
+    state.activeViewCardId = action.payload;
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutWindowReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutWindowReducers.ts
@@ -1,0 +1,207 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  DEFAULT_MARKETPLACE_CARD_H,
+  DEFAULT_MARKETPLACE_CARD_W,
+  DEFAULT_SETTINGS_CARD_H,
+  DEFAULT_SETTINGS_CARD_W,
+  MARKETPLACE_CARD_ID,
+  SETTINGS_CARD_ID,
+  WORKFLOWS_HUB_ID,
+  type BrowserCardPosition,
+  type DashboardLayoutState,
+  type ViewCardPosition,
+} from './dashboardLayoutModel';
+import { collectOccupiedRects, findOpenGridCell } from './dashboardLayoutGeometry';
+
+// Window-management reducers ported from upstream openswarm-ai (Settings/Marketplace app cards, docking a browser or view inside its chat, tiling to screen zones, the minimize rail, camera focus, and lazy view previews). One module so the composer stays a composer.
+
+export function tileOwnerExists(s: DashboardLayoutState, id: string): boolean {
+  return id in s.cards || id in s.viewCards || id in s.browserCards || id in s.workflowCards
+    || (id === WORKFLOWS_HUB_ID && !!s.workflowsHub) || (id === SETTINGS_CARD_ID && !!s.settingsCard)
+    || (id === MARKETPLACE_CARD_ID && !!s.marketplaceCard);
+}
+
+export function clearOtherDocks(state: { browserCards: Record<string, BrowserCardPosition>; viewCards: Record<string, ViewCardPosition> }, sessionId: string, keepBrowserId?: string): void {
+  for (const bc of Object.values(state.browserCards)) {
+    if (bc.docked_to !== sessionId) continue;
+    // The card being (re-)docked must survive its own clear: layout sync re-asserts docks.
+    if (bc.browser_id === keepBrowserId) continue;
+    // Corpse cleanup happens in WebSocketManager via removeBrowserCardCleanly, NOT here: a bare store delete gets resurrected by the backend layout sync as a free card.
+    bc.docked_to = null;
+  }
+  for (const vc of Object.values(state.viewCards)) {
+    if (vc.docked_to === sessionId) vc.docked_to = null;
+  }
+}
+
+export const windowCardReducers = {
+  // First click on a reveal-parked app card: drop the defer so its live preview boots.
+  activateViewCardPreview(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const card = state.viewCards[action.payload];
+    if (card && card.preview_deferred) card.preview_deferred = undefined;
+  },
+
+  clearAllTiles(state: DashboardLayoutState) {
+    state.tiledCards = {};
+  },
+
+  clearCardWindowState(state: DashboardLayoutState, action: PayloadAction<string>) {
+    const id = action.payload;
+    if (state.minimizedCards[id]) delete state.minimizedCards[id];
+    if (state.tiledCards[id]) delete state.tiledCards[id];
+  },
+
+  clearMarketplaceRequestedTab(state: DashboardLayoutState) {
+    state.marketplaceRequestedTab = null;
+  },
+
+  clearPendingFocusMarketplaceCard(state: DashboardLayoutState) {
+    state.pendingFocusMarketplaceCard = false;
+  },
+
+  clearPendingFocusSettingsCard(state: DashboardLayoutState) {
+    state.pendingFocusSettingsCard = false;
+  },
+
+  clearSettingsRequestedTab(state: DashboardLayoutState) {
+    state.settingsRequestedTab = null;
+  },
+
+  clearTiledCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    if (state.tiledCards[action.payload]) delete state.tiledCards[action.payload];
+  },
+
+  closeMarketplaceCard(state: DashboardLayoutState) {
+    state.marketplaceCard = null;
+    state.marketplaceRequestedTab = null;
+    delete state.minimizedCards[MARKETPLACE_CARD_ID];
+    delete state.tiledCards[MARKETPLACE_CARD_ID];
+    state.pendingFocusMarketplaceCard = false;
+  },
+
+  closeSettingsCard(state: DashboardLayoutState) {
+    state.settingsCard = null;
+    state.settingsRequestedTab = null;
+    delete state.minimizedCards[SETTINGS_CARD_ID];
+    delete state.tiledCards[SETTINGS_CARD_ID];
+    state.pendingFocusSettingsCard = false;
+  },
+
+  // Camera-focus an EXISTING card (the inline chat embeds' "show on canvas"); the lifecycle
+  // pendingFocus effects own the fit + highlight + clear, same as a fresh add.
+  focusBrowserCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    if (state.browserCards[action.payload]) state.pendingFocusBrowserId = action.payload;
+  },
+
+  focusViewCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    if (state.viewCards[action.payload]) state.pendingFocusViewCardId = action.payload;
+  },
+
+  // Marketplace mirrors the Settings window: an on-canvas singleton, opened or raised in place.
+  openMarketplaceCard(state: DashboardLayoutState, action: PayloadAction<{ tab?: string; expandedSessionIds?: string[] } | undefined>) {
+    state.marketplaceRequestedTab = action.payload?.tab ?? null;
+    if (state.marketplaceCard) {
+      state.marketplaceCard.zOrder = state.nextZOrder++;
+      delete state.minimizedCards[MARKETPLACE_CARD_ID];
+      state.pendingFocusMarketplaceCard = true;
+      return;
+    }
+    const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
+    const pos = findOpenGridCell(rects, DEFAULT_MARKETPLACE_CARD_W, DEFAULT_MARKETPLACE_CARD_H);
+    state.marketplaceCard = {
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_MARKETPLACE_CARD_W,
+      height: DEFAULT_MARKETPLACE_CARD_H,
+      zOrder: state.nextZOrder++,
+    };
+    state.pendingFocusMarketplaceCard = true;
+  },
+
+  // Settings is an on-canvas window like the Workflows app, not a modal: opening it creates or raises that card and pans to it.
+  openSettingsCard(state: DashboardLayoutState, action: PayloadAction<{ tab?: string; expandedSessionIds?: string[] } | undefined>) {
+    state.settingsRequestedTab = action.payload?.tab ?? null;
+    if (state.settingsCard) {
+      state.settingsCard.zOrder = state.nextZOrder++;
+      delete state.minimizedCards[SETTINGS_CARD_ID];
+      state.pendingFocusSettingsCard = true;
+      return;
+    }
+    const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
+    const pos = findOpenGridCell(rects, DEFAULT_SETTINGS_CARD_W, DEFAULT_SETTINGS_CARD_H);
+    state.settingsCard = {
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_SETTINGS_CARD_W,
+      height: DEFAULT_SETTINGS_CARD_H,
+      zOrder: state.nextZOrder++,
+    };
+    state.pendingFocusSettingsCard = true;
+  },
+
+  setBrowserDocked(state: DashboardLayoutState, action: PayloadAction<{ browserId: string; dockedTo: string | null }>) {
+    const bc = state.browserCards[action.payload.browserId];
+    if (!bc) return;
+    if (action.payload.dockedTo) clearOtherDocks(state, action.payload.dockedTo, action.payload.browserId);
+    bc.docked_to = action.payload.dockedTo;
+  },
+
+  setMarketplaceCardPosition(state: DashboardLayoutState, action: PayloadAction<{ x: number; y: number }>) {
+    if (!state.marketplaceCard) return;
+    state.marketplaceCard.x = action.payload.x;
+    state.marketplaceCard.y = action.payload.y;
+  },
+
+  setMarketplaceCardSize(state: DashboardLayoutState, action: PayloadAction<{ width: number; height: number }>) {
+    if (!state.marketplaceCard) return;
+    state.marketplaceCard.width = Math.max(760, action.payload.width);
+    state.marketplaceCard.height = Math.max(520, action.payload.height);
+  },
+
+  setSettingsCardPosition(state: DashboardLayoutState, action: PayloadAction<{ x: number; y: number }>) {
+    if (!state.settingsCard) return;
+    state.settingsCard.x = action.payload.x;
+    state.settingsCard.y = action.payload.y;
+  },
+
+  setSettingsCardSize(state: DashboardLayoutState, action: PayloadAction<{ width: number; height: number }>) {
+    if (!state.settingsCard) return;
+    state.settingsCard.width = Math.max(640, action.payload.width);
+    state.settingsCard.height = Math.max(460, action.payload.height);
+  },
+
+  setTiledCard(state: DashboardLayoutState, action: PayloadAction<{ cardId: string; zone: string }>) {
+    const { cardId, zone } = action.payload;
+    // The rail defers its tile dispatch two frames, so the card can be gone by the time it lands; a stranded 'fullscreen' hides the whole shell.
+    if (!tileOwnerExists(state, cardId)) return;
+    // One fullscreen owner, ever: two entries would fight over who hides the chrome and who gets the Escape.
+    if (zone === 'fullscreen') {
+      for (const [id, z] of Object.entries(state.tiledCards)) {
+        if (z === 'fullscreen' && id !== cardId) delete state.tiledCards[id];
+      }
+    }
+    state.tiledCards[cardId] = zone;
+    if (state.minimizedCards[cardId]) delete state.minimizedCards[cardId];
+  },
+
+  setViewDocked(state: DashboardLayoutState, action: PayloadAction<{ cardKey: string; dockedTo: string | null }>) {
+    const vc = state.viewCards[action.payload.cardKey];
+    if (!vc) return;
+    if (action.payload.dockedTo) clearOtherDocks(state, action.payload.dockedTo);
+    vc.docked_to = action.payload.dockedTo;
+  },
+
+  // Window controls (traffic lights). Minimize parks a card in the right-edge rail; tiling snaps it
+  // to a macOS-style viewport zone. Rule 6 of the tiling set (see cards/useCardTiling.ts): a parked
+  // card keeps its zone and restores back into it, but never keeps 'fullscreen', which would leave
+  // an off-canvas card hiding the whole shell.
+  toggleMinimizeCard(state: DashboardLayoutState, action: PayloadAction<{ cardId: string }>) {
+    const id = action.payload.cardId;
+    if (state.minimizedCards[id]) {
+      delete state.minimizedCards[id];
+    } else {
+      state.minimizedCards[id] = true;
+      if (state.tiledCards[id] === 'fullscreen') delete state.tiledCards[id];
+    }
+  },
+};

--- a/frontend/src/shared/state/dashboardLayoutWorkflowReducers.ts
+++ b/frontend/src/shared/state/dashboardLayoutWorkflowReducers.ts
@@ -1,0 +1,231 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import {
+  DEFAULT_WORKFLOW_CARD_H,
+  DEFAULT_WORKFLOW_CARD_W,
+  DEFAULT_WORKFLOWS_HUB_H,
+  DEFAULT_WORKFLOWS_HUB_W,
+  GRID_GAP,
+  WORKFLOW_CARD_GAP,
+  type DashboardLayoutState,
+  type WorkflowsRunContext,
+  WORKFLOWS_HUB_ID
+} from './dashboardLayoutModel';
+import {
+  collectOccupiedRects,
+  findOpenGridCell,
+  findOpenSpotNear,
+} from './dashboardLayoutGeometry';
+import { ledgerAdd, ledgerRekey, ledgerRemove } from './dashboardLayoutCardState';
+
+export function closeWorkflowsAppState(state: DashboardLayoutState): void {
+  state.workflowsHub = null;
+  delete state.tiledCards[WORKFLOWS_HUB_ID];
+  delete state.minimizedCards[WORKFLOWS_HUB_ID];
+  state.workflowsAppTarget = null;
+  state.workflowsMonitorId = null;
+  state.workflowsMonitorRunId = null;
+  state.workflowsMonitorCard = null;
+}
+
+export const workflowCardReducers = {
+  addWorkflowCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{
+      workflowId: string;
+      sourceSessionId?: string | null;
+      expandedSessionIds?: string[];
+    }>,
+  ) {
+    const { workflowId, sourceSessionId, expandedSessionIds } = action.payload;
+    if (state.workflowCards[workflowId]) {
+      state.workflowCards[workflowId].zOrder = state.nextZOrder++;
+      state.pendingFocusWorkflowId = workflowId;
+      return;
+    }
+    const expanded = expandedSessionIds ?? state.persistedExpandedSessionIds;
+    const rects = collectOccupiedRects(state, expanded);
+    let posX: number, posY: number;
+    const parentCard = sourceSessionId ? state.cards[sourceSessionId] : null;
+    if (parentCard) {
+      const anchorX = parentCard.x + parentCard.width + GRID_GAP * 6;
+      const anchorY = parentCard.y;
+      const pos = findOpenSpotNear(anchorX, anchorY, rects, DEFAULT_WORKFLOW_CARD_W, DEFAULT_WORKFLOW_CARD_H);
+      posX = pos.x;
+      posY = pos.y;
+    } else {
+      const pos = findOpenGridCell(rects, DEFAULT_WORKFLOW_CARD_W, DEFAULT_WORKFLOW_CARD_H);
+      posX = pos.x;
+      posY = pos.y;
+    }
+    state.workflowCards[workflowId] = {
+      workflow_id: workflowId,
+      x: posX,
+      y: posY,
+      width: DEFAULT_WORKFLOW_CARD_W,
+      height: DEFAULT_WORKFLOW_CARD_H,
+      zOrder: state.nextZOrder++,
+      source_session_id: sourceSessionId || null,
+    };
+    ledgerAdd(state.creationOrder, workflowId);
+    state.pendingFocusWorkflowId = workflowId;
+  },
+
+  setWorkflowCardPosition(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ workflowId: string; x: number; y: number }>,
+  ) {
+    const { workflowId, x, y } = action.payload;
+    const card = state.workflowCards[workflowId];
+    if (card) {
+      card.x = x;
+      card.y = y;
+    }
+  },
+
+  setWorkflowCardSize(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ workflowId: string; width: number; height: number }>,
+  ) {
+    const { workflowId, width, height } = action.payload;
+    const card = state.workflowCards[workflowId];
+    if (card) {
+      card.width = Math.max(360, width);
+      card.height = Math.max(280, height);
+    }
+  },
+
+  removeWorkflowCard(state: DashboardLayoutState, action: PayloadAction<string>) {
+    delete state.workflowCards[action.payload];
+    // Rule 7: a dead card must never keep owning a tile; a stale entry poisons every reader of it.
+    delete state.tiledCards[action.payload];
+    delete state.minimizedCards[action.payload];
+    ledgerRemove(state.creationOrder, action.payload);
+  },
+
+  rekeyWorkflowCard(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ oldId: string; newId: string }>,
+  ) {
+    const { oldId, newId } = action.payload;
+    const card = state.workflowCards[oldId];
+    if (!card) return;
+    delete state.workflowCards[oldId];
+    state.workflowCards[newId] = { ...card, workflow_id: newId };
+    ledgerRekey(state.creationOrder, oldId, newId);
+    if (state.pendingFocusWorkflowId === oldId) state.pendingFocusWorkflowId = newId;
+  },
+
+  clearPendingFocusWorkflowId(state: DashboardLayoutState) {
+    state.pendingFocusWorkflowId = null;
+  },
+
+  openWorkflowsHub(state: DashboardLayoutState, action: PayloadAction<{ expandedSessionIds?: string[] } | undefined>) {
+    if (state.workflowsHub) {
+      state.workflowsHub.zOrder = state.nextZOrder++;
+      delete state.minimizedCards[WORKFLOWS_HUB_ID];
+      state.pendingFocusWorkflowsHub = true;
+      return;
+    }
+    const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
+    const pos = findOpenGridCell(rects, DEFAULT_WORKFLOWS_HUB_W, DEFAULT_WORKFLOWS_HUB_H);
+    state.workflowsHub = {
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_WORKFLOWS_HUB_W,
+      height: DEFAULT_WORKFLOWS_HUB_H,
+      zOrder: state.nextZOrder++,
+    };
+    state.pendingFocusWorkflowsHub = true;
+  },
+
+  clearPendingFocusWorkflowsHub(state: DashboardLayoutState) {
+    state.pendingFocusWorkflowsHub = false;
+  },
+
+  closeWorkflowsHub(state: DashboardLayoutState) {
+    state.workflowsHub = null;
+    delete state.minimizedCards[WORKFLOWS_HUB_ID];
+    delete state.tiledCards[WORKFLOWS_HUB_ID];
+  },
+
+  openWorkflowsApp(
+    state: DashboardLayoutState,
+    action: PayloadAction<{ workflowId?: string; expandedSessionIds?: string[] } | undefined>,
+  ) {
+    state.workflowsAppTarget = action.payload?.workflowId ?? null;
+    if (state.workflowsHub) {
+      state.workflowsHub.zOrder = state.nextZOrder++;
+      // Opening means visible: a parked window must come back to the canvas, or the focus pan flies to empty space.
+      delete state.minimizedCards[WORKFLOWS_HUB_ID];
+      state.pendingFocusWorkflowsHub = true;
+      return;
+    }
+    const rects = collectOccupiedRects(state, action.payload?.expandedSessionIds);
+    const pos = findOpenGridCell(rects, DEFAULT_WORKFLOWS_HUB_W, DEFAULT_WORKFLOWS_HUB_H);
+    state.workflowsHub = {
+      x: pos.x,
+      y: pos.y,
+      width: DEFAULT_WORKFLOWS_HUB_W,
+      height: DEFAULT_WORKFLOWS_HUB_H,
+      zOrder: state.nextZOrder++,
+    };
+    state.pendingFocusWorkflowsHub = true;
+  },
+
+  closeWorkflowsApp(state: DashboardLayoutState) {
+    closeWorkflowsAppState(state);
+  },
+
+  clearWorkflowsAppTarget(state: DashboardLayoutState) {
+    state.workflowsAppTarget = null;
+  },
+
+  openWorkflowMonitor(state: DashboardLayoutState, action: PayloadAction<{ workflowId: string; runId?: string }>) {
+    state.workflowsMonitorId = action.payload.workflowId;
+    state.workflowsMonitorRunId = action.payload.runId ?? null;
+    const hub = state.workflowsHub;
+    if (!state.workflowsMonitorCard) {
+      state.workflowsMonitorCard = {
+        x: hub ? hub.x + hub.width + WORKFLOW_CARD_GAP : 220,
+        y: hub ? hub.y : 160,
+        width: 520,
+        height: hub ? hub.height : 560,
+        zOrder: state.nextZOrder++,
+      };
+    } else {
+      state.workflowsMonitorCard.zOrder = state.nextZOrder++;
+    }
+  },
+
+  closeWorkflowMonitor(state: DashboardLayoutState) {
+    state.workflowsMonitorId = null;
+    state.workflowsMonitorRunId = null;
+    state.workflowsMonitorCard = null;
+  },
+
+  setWorkflowsMonitorPosition(state: DashboardLayoutState, action: PayloadAction<{ x: number; y: number }>) {
+    if (!state.workflowsMonitorCard) return;
+    state.workflowsMonitorCard.x = action.payload.x;
+    state.workflowsMonitorCard.y = action.payload.y;
+  },
+
+  setWorkflowsRunContext(state: DashboardLayoutState, action: PayloadAction<WorkflowsRunContext>) {
+    state.workflowsRunContext = action.payload;
+  },
+
+  clearWorkflowsRunContext(state: DashboardLayoutState) {
+    state.workflowsRunContext = null;
+  },
+
+  setWorkflowsHubPosition(state: DashboardLayoutState, action: PayloadAction<{ x: number; y: number }>) {
+    if (!state.workflowsHub) return;
+    state.workflowsHub.x = action.payload.x;
+    state.workflowsHub.y = action.payload.y;
+  },
+
+  setWorkflowsHubSize(state: DashboardLayoutState, action: PayloadAction<{ width: number; height: number }>) {
+    if (!state.workflowsHub) return;
+    state.workflowsHub.width = Math.max(720, action.payload.width);
+    state.workflowsHub.height = Math.max(420, action.payload.height);
+  },
+};


### PR DESCRIPTION
> **Draft, stacked on #147** (its import-safe `config.ts`/`safeMode.ts` are what let the reducer tests run under node:test; the extra commits in this diff disappear once #147 merges). This is one of three god-file splits (this, #150 AgentChat, #151 electron/main.js). Because you commit to these files weekly, I'd like a short **freeze on `dashboardLayoutSlice.ts`** before this leaves draft: you stop touching that file, I rebase and mark ready within the hour, you review/merge, freeze lifts. Say which order suits you; my default is this one first, then AgentChat, then electron.

`dashboardLayoutSlice.ts` was 2,145 lines. This moves its reducers and helpers into single-purpose modules next to it and shrinks the slice to the store wiring, the fetch/save thunks and the extraReducers (568 lines). Every exported action name and the persisted layout shape are unchanged.

| Module | What moved there |
|---|---|
| `dashboardLayoutModel.ts` | types, defaults, initial state |
| `dashboardLayoutGeometry.ts` | grid/collision/placement helpers |
| `dashboardLayoutCardState.ts` | one accessor registry for every `CardType`; z-order ledger rekey/remove/reconcile |
| `dashboardLayout{Agent,View,Browser,Workflow,Window,Canvas,Closed,Glow,Reset}Reducers.ts` | the reducers, by card family |

Behaviour changes, each with tests (node:test, 24 cases in `dashboardLayout{Slice,SaveAuthority,FetchAuthority,CardState}.test.ts`):

- **Save authority.** `saveLayout` now takes the per-dashboard baseline object the last successful fetch created (`saveAuthority`) and refuses a payload whose baseline is not the current one, or while a refetch for that dashboard is pending. A delayed or unmount save captured before a rejected/superseded fetch can no longer erase the server's layout. `useLayoutSave` and the header's Share flush pass it from a selector.
- **Fetch authority.** Only the latest request generation may fulfill for the active dashboard; a late fetch cannot replace the active dashboard or be saved under its id, and a late rejection cannot revoke a newer baseline.
- **Unknown persisted layout fields** are read on fetch and written back on save instead of being dropped, so a newer build's fields survive a save from an older one.
- **z-order ledger** is reconciled after a wholesale layout replace.

Also: the geometry helpers read the viewport through `viewportSize()` (same fallbacks the callers used, 1440×900, when there is no `window`), so the reducer tests run under node:test. `AppShell`/canvas behaviour is untouched.

Proof: `tsc --noEmit` clean; `node scripts/run-tests.mjs` 167/167; packaged macOS app: upstream smoke 5/5 + the characterization suite (#146) 19/19.

Not in this PR (separate decisions): a compositions/experts card family, the dashboard header a11y refactor.