### PR TITLE
electron: move backend readiness, boot telemetry, the frontend server, port choice and runtime paths out of main.js

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,11 +48,17 @@ jobs:
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
             | tail -1 | tee collected.txt
+      # --timeout: a test that blocks forever (a bare ws.receive_json() waiting for an event that never
+      # comes, say) otherwise stalls the run at 99% until timeout-minutes with no summary and no junit.
+      # With the cap it fails by name, the rest of the suite runs, and the assertion below still holds.
       - name: Run the backend suite
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --timeout=300 \
             --junitxml "${RUNNER_TEMP}/pytest.xml"
       - name: Every collected test ran
+        # Runs after a red suite too, so a failure report also says whether the run was complete.
+        if: ${{ !cancelled() }}
         run: |
           python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
           import re, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,65 @@
+name: backend-tests
+
+# The backend pytest suite, run on every pull request and on pushes to the mainline branches. Until
+# now nothing ran it in CI, so a regression only surfaced when someone ran it by hand.
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  workflow_dispatch:
+
+# Runs checked-out project code on pull_request: the token stays read-only.
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.lock
+            backend/requirements-dev.txt
+      - name: Install backend deps (locked runtime + dev)
+        run: |
+          python -m pip install --require-hashes --only-binary=:all: -r backend/requirements.lock
+          python -m pip install -r backend/requirements-dev.txt
+      # Two numbers that must agree. A test process that dies mid-run can exit 0 with no summary
+      # (a hard-exit shutdown path did exactly that once and silently skipped ~42% of the suite), so
+      # the job also asserts that every collected test was actually run: junit testcase count ==
+      # collect-only count. Green then means green, not "green as far as it got".
+      - name: Count the suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
+            | tail -1 | tee collected.txt
+      - name: Run the backend suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --junitxml "${RUNNER_TEMP}/pytest.xml"
+      - name: Every collected test ran
+        run: |
+          python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          ran = sum(1 for _ in ET.parse(sys.argv[1]).getroot().iter('testcase'))
+          m = re.search(r'(\d+) tests? collected', open(sys.argv[2]).read())
+          collected = int(m.group(1)) if m else -1
+          print(f'collected={collected} ran={ran}')
+          if collected < 1 or ran != collected:
+              sys.exit(f'FAIL: {ran} of {collected} collected tests reached the report; the run was truncated')
+          PY

--- a/.github/workflows/edge-tests.yml
+++ b/.github/workflows/edge-tests.yml
@@ -1,0 +1,44 @@
+name: edge-tests
+
+# The openswarm-edge pytest suite, on every pull request that touches it and on pushes to the
+# mainline branches.
+on:
+  pull_request:
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edge-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (openswarm-edge)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: openswarm-edge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: openswarm-edge/requirements.txt
+      - name: Install edge deps
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+      - name: Run the edge suite
+        run: python -m pytest tests -q -p no:cacheprovider

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,43 @@
+name: frontend-tests
+
+# Typecheck plus the renderer's node:test suite, on every pull request and on pushes to the mainline
+# branches. Until now neither ran in CI; the tests were run by hand, one file at a time.
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-tests:
+    name: tsc + node:test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.json
+      - name: Unit tests (node:test via tsx)
+        run: node scripts/run-tests.mjs

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,6 +9,9 @@
 
 pytest==8.3.4
 pytest-asyncio==0.25.2
+# Per-test wall-clock cap for CI (see .github/workflows/backend-tests.yml): a test that
+# blocks forever fails by name instead of stalling the whole run until the job cap.
+pytest-timeout==2.4.0
 
 # Used by linter/lint.py (the vulture dead-code check). watchfiles, also
 # needed by lint.py, already comes in transitively via uvicorn[standard].

--- a/backend/tests/test_ws_integration.py
+++ b/backend/tests/test_ws_integration.py
@@ -6,6 +6,8 @@ extracted handlers + the broadcast, which the in-process harness (no server, no 
 The SDK and WS auth are mocked; everything else is the real running stack."""
 
 import asyncio
+import queue
+import threading
 
 import pytest
 
@@ -17,6 +19,29 @@ from fastapi.testclient import TestClient
 import backend.main as main_mod
 from backend.apps.agents.agent_manager import agent_manager
 from backend.apps.agents.core.models import AgentSession
+import backend.apps.agents.manager.run.RunOptions as run_options_mod
+
+
+def p_receive_json(ws, timeout: float = 5.0):
+    """ws.receive_json() blocks forever when the event never comes; a regression in the loop then
+    hangs the whole pytest run instead of failing this test. Bound every receive."""
+    out = queue.Queue(maxsize=1)
+
+    def p_recv():
+        try:
+            out.put((True, ws.receive_json()))
+        except BaseException as exc:
+            out.put((False, exc))
+
+    thread = threading.Thread(target=p_recv, daemon=True)
+    thread.start()
+    try:
+        ok, value = out.get(timeout=timeout)
+    except queue.Empty as exc:
+        raise AssertionError(f"timed out waiting for websocket event after {timeout}s") from exc
+    if ok:
+        return value
+    raise value
 
 
 def p_assistant():
@@ -32,6 +57,20 @@ def p_result():
 
 def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
     monkeypatch.setattr(main_mod, "p_ws_auth_ok", lambda ws: True, raising=True)
+
+    # The contract of this test is "SDK and WS auth mocked, everything else real", but two things on
+    # the turn path reach outside the process and must not decide the outcome: configure_provider_env
+    # can wander into 9Router revival (spawn/npm install, serialized on a module-level lock) whenever
+    # earlier tests left provider evidence behind, and the background turn-label aux call does the
+    # same. Pin both out; the persistent-client path is pinned off suite-wide in conftest.
+    async def p_noop_provider_env(*args, **kwargs):
+        return None
+
+    async def p_noop_turn_label(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(run_options_mod, "configure_provider_env", p_noop_provider_env, raising=True)
+    monkeypatch.setattr(agent_manager, "generate_turn_label", p_noop_turn_label, raising=True)
 
     async def fake_query(*args, **kwargs):
         yield p_assistant()
@@ -49,10 +88,15 @@ def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
             ws.send_json({"event": "agent:send_message", "data": {"prompt": "hi"}})
             seen = []
             for _ in range(40):
-                ev = ws.receive_json()
+                ev = p_receive_json(ws)
                 seen.append(ev.get("event"))
-                if ev.get("event") == "agent:message" and "hello from the loop" in str(ev.get("data", {})):
+                if (
+                    ev.get("event") == "agent:status"
+                    and ev.get("data", {}).get("status") == "completed"
+                ):
                     break
+            else:
+                raise AssertionError(f"did not receive completed status; saw events={seen}")
         # the real loop's assistant reply made it all the way back over the WS
         assert "agent:message" in seen
         assert any(m.role == "assistant" and "hello from the loop" in str(m.content)

--- a/electron/backend-readiness.js
+++ b/electron/backend-readiness.js
@@ -1,0 +1,173 @@
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+function authTokenFilePath(options) {
+  const {
+    isPackaged,
+    platform,
+    env,
+    electronDir,
+    homedir = os.homedir,
+    pathImpl = path,
+  } = options;
+  const home = homedir();
+  if (!isPackaged) {
+    return pathImpl.join(electronDir, '..', 'backend', 'data', 'auth.token');
+  }
+  if (platform === 'darwin') {
+    return pathImpl.join(home, 'Library', 'Application Support', 'OpenSwarm', 'data', 'auth.token');
+  }
+  if (platform === 'win32') {
+    return pathImpl.join(env.APPDATA || home, 'OpenSwarm', 'data', 'auth.token');
+  }
+  const dataRoot = env.XDG_DATA_HOME || pathImpl.join(home, '.local', 'share');
+  return pathImpl.join(dataRoot, 'OpenSwarm', 'data', 'auth.token');
+}
+
+function readAuthToken(tokenPath, fsImpl = fs) {
+  try {
+    return fsImpl.readFileSync(tokenPath, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function createBackendImportWarmup(options) {
+  const {
+    pythonPath,
+    projectRoot,
+    debuggerDir,
+    pythonSitePackages,
+    scratchRoot,
+    platform,
+    env = process.env,
+    pathImpl = path,
+  } = options;
+  if (!pythonPath || !projectRoot || !scratchRoot || !platform) {
+    throw new Error('backend import warmup requires pythonPath, projectRoot, scratchRoot, and platform');
+  }
+
+  const trustedPythonPath = [projectRoot, debuggerDir, pythonSitePackages]
+    .filter(Boolean)
+    .join(pathImpl.delimiter);
+  const warmupEnv = {
+    ...env,
+    ENABLE_HOSTED_DEMO: '0',
+    OPENSWARM_PACKAGED: '1',
+    OPENSWARM_BACKEND_IMPORT_ONLY: '1',
+    OPENSWARM_DISABLE_9ROUTER_AUTOSTART: '1',
+    OPENSWARM_FREE_TRIAL_ENABLED: '0',
+    PYTHONDONTWRITEBYTECODE: '1',
+    PYTHONNOUSERSITE: '1',
+    PYTHONUNBUFFERED: '1',
+    PYTHONUTF8: '1',
+    PYTHONPATH: trustedPythonPath,
+    APPDATA: scratchRoot,
+    LOCALAPPDATA: scratchRoot,
+    HOME: scratchRoot,
+    USERPROFILE: scratchRoot,
+    XDG_DATA_HOME: scratchRoot,
+  };
+  delete warmupEnv.PYTHONHOME;
+
+  return {
+    file: pythonPath,
+    args: ['-s', '-c', 'import backend.main; print("backend.main importable")'],
+    options: {
+      cwd: projectRoot,
+      env: warmupEnv,
+    },
+  };
+}
+
+async function loadAuthToken(options) {
+  const {
+    tokenPath,
+    fsImpl = fs,
+    attempts = 20,
+    retryMs = 100,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    logger = console,
+  } = options;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const token = readAuthToken(tokenPath, fsImpl);
+    if (token) {
+      logger.log(`[auth] loaded token from ${tokenPath}`);
+      return token;
+    }
+    await sleep(retryMs);
+  }
+  logger.warn(
+    `[auth] FAILED to load auth token from ${tokenPath} after 2s — WS/HTTP will be rejected`,
+  );
+  return '';
+}
+
+function waitForBackend(port, options = {}) {
+  const {
+    process: backendProcess = null,
+    httpImpl = http,
+    now = Date.now,
+    setTimeoutImpl = setTimeout,
+    onStillStarting = () => {},
+    onTakingTooLong = () => {},
+  } = options;
+  const start = now();
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stillStartingNotified = false;
+    let actionsShown = false;
+    const finish = (complete, value) => {
+      if (settled) return;
+      settled = true;
+      complete(value);
+    };
+
+    if (backendProcess) {
+      backendProcess.once('exit', (code) => {
+        if (code !== 0 && code !== null) {
+          finish(reject, new Error(`Backend process exited with code ${code} during startup`));
+        }
+      });
+      backendProcess.once('error', (error) => {
+        finish(reject, new Error(`Backend failed to spawn: ${error && error.message || error}`));
+      });
+    }
+
+    function check() {
+      if (settled) return;
+      const elapsed = now() - start;
+      if (elapsed > 60_000 && !stillStartingNotified) {
+        stillStartingNotified = true;
+        onStillStarting();
+      }
+      if (elapsed > 180_000 && !actionsShown) {
+        actionsShown = true;
+        onTakingTooLong();
+      }
+      const request = httpImpl.get(`http://127.0.0.1:${port}/api/health/check`, (response) => {
+        if (response.statusCode === 200) {
+          finish(resolve);
+        } else {
+          setTimeoutImpl(check, 500);
+        }
+      });
+      request.on('error', () => setTimeoutImpl(check, 500));
+      request.setTimeout(2000, () => {
+        request.destroy();
+        setTimeoutImpl(check, 500);
+      });
+    }
+    check();
+  });
+}
+
+module.exports = {
+  authTokenFilePath,
+  createBackendImportWarmup,
+  readAuthToken,
+  loadAuthToken,
+  waitForBackend,
+};

--- a/electron/backend-readiness.test.js
+++ b/electron/backend-readiness.test.js
@@ -1,0 +1,265 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+const {
+  authTokenFilePath,
+  createBackendImportWarmup,
+  loadAuthToken,
+  readAuthToken,
+  waitForBackend,
+} = require('./backend-readiness');
+
+test('backend import warmup is isolated from user data and inherited Python paths', () => {
+  const spec = createBackendImportWarmup({
+    pythonPath: 'C:\\app\\resources\\python-env\\python.exe',
+    projectRoot: 'C:\\app\\resources',
+    debuggerDir: 'C:\\app\\resources\\debugger',
+    pythonSitePackages: 'C:\\app\\resources\\python-env\\Lib\\site-packages',
+    scratchRoot: 'C:\\temp\\openswarm-warmup',
+    platform: 'win32',
+    env: {
+      APPDATA: 'C:\\Users\\Ada\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\Ada\\AppData\\Local',
+      ENABLE_HOSTED_DEMO: '1',
+      PYTHONHOME: 'C:\\host\\python',
+      PYTHONPATH: 'C:\\host\\untrusted',
+    },
+    pathImpl: path.win32,
+  });
+
+  assert.equal(spec.file, 'C:\\app\\resources\\python-env\\python.exe');
+  assert.deepEqual(spec.args, ['-s', '-c', 'import backend.main; print("backend.main importable")']);
+  assert.equal(spec.options.cwd, 'C:\\app\\resources');
+  assert.equal(spec.options.env.APPDATA, 'C:\\temp\\openswarm-warmup');
+  assert.equal(spec.options.env.LOCALAPPDATA, 'C:\\temp\\openswarm-warmup');
+  assert.equal(spec.options.env.HOME, 'C:\\temp\\openswarm-warmup');
+  assert.equal(spec.options.env.USERPROFILE, 'C:\\temp\\openswarm-warmup');
+  assert.equal(spec.options.env.XDG_DATA_HOME, 'C:\\temp\\openswarm-warmup');
+  assert.equal(spec.options.env.OPENSWARM_PACKAGED, '1');
+  assert.equal(spec.options.env.OPENSWARM_BACKEND_IMPORT_ONLY, '1');
+  assert.equal(spec.options.env.ENABLE_HOSTED_DEMO, '0');
+  assert.equal(spec.options.env.OPENSWARM_DISABLE_9ROUTER_AUTOSTART, '1');
+  assert.equal(spec.options.env.PYTHONDONTWRITEBYTECODE, '1');
+  assert.equal(spec.options.env.PYTHONNOUSERSITE, '1');
+  assert.equal(
+    spec.options.env.PYTHONPATH,
+    [
+      'C:\\app\\resources',
+      'C:\\app\\resources\\debugger',
+      'C:\\app\\resources\\python-env\\Lib\\site-packages',
+    ].join(path.win32.delimiter),
+  );
+  assert.ok(!spec.options.env.PYTHONPATH.includes('untrusted'));
+  assert.equal('PYTHONHOME' in spec.options.env, false);
+});
+
+test('backend import warmup redirects macOS and Linux data roots', () => {
+  const common = {
+    pythonPath: '/app/resources/python-env/bin/python3',
+    projectRoot: '/app/resources',
+    scratchRoot: '/tmp/openswarm-warmup',
+    env: { HOME: '/Users/ada', XDG_DATA_HOME: '/home/ada/.local/share' },
+    pathImpl: path.posix,
+  };
+  const mac = createBackendImportWarmup({ ...common, platform: 'darwin' });
+  const linux = createBackendImportWarmup({ ...common, platform: 'linux' });
+  assert.equal(mac.options.env.HOME, '/tmp/openswarm-warmup');
+  assert.equal(linux.options.env.XDG_DATA_HOME, '/tmp/openswarm-warmup');
+  assert.equal(mac.options.env.APPDATA, '/tmp/openswarm-warmup');
+  assert.equal(linux.options.env.USERPROFILE, '/tmp/openswarm-warmup');
+});
+
+test('backend import warmup rejects incomplete path contracts', () => {
+  assert.throws(
+    () => createBackendImportWarmup({ pythonPath: 'python', projectRoot: '/app' }),
+    /requires pythonPath, projectRoot, scratchRoot, and platform/,
+  );
+});
+
+function tokenPath(overrides = {}) {
+  return authTokenFilePath({
+    isPackaged: true,
+    platform: 'linux',
+    env: {},
+    homedir: () => '/home/ada',
+    electronDir: '/repo/electron',
+    pathImpl: path.posix,
+    ...overrides,
+  });
+}
+
+test('resolves auth.token for dev and every packaged data-root policy', () => {
+  assert.equal(tokenPath({ isPackaged: false }), '/repo/backend/data/auth.token');
+  assert.equal(
+    tokenPath({ platform: 'darwin', homedir: () => '/Users/ada' }),
+    '/Users/ada/Library/Application Support/OpenSwarm/data/auth.token',
+  );
+  assert.equal(
+    tokenPath({ platform: 'win32', env: { APPDATA: '/profiles/ada/roaming' } }),
+    '/profiles/ada/roaming/OpenSwarm/data/auth.token',
+  );
+  assert.equal(
+    tokenPath({ platform: 'win32', homedir: () => '/Users/ada' }),
+    '/Users/ada/OpenSwarm/data/auth.token',
+  );
+  assert.equal(
+    tokenPath({ env: { XDG_DATA_HOME: '/data/ada' } }),
+    '/data/ada/OpenSwarm/data/auth.token',
+  );
+  assert.equal(tokenPath(), '/home/ada/.local/share/OpenSwarm/data/auth.token');
+});
+
+test('reads and trims a token, returning empty on blank or failed reads', () => {
+  assert.equal(readAuthToken('/token', { readFileSync: () => '  secret\n' }), 'secret');
+  assert.equal(readAuthToken('/token', { readFileSync: () => '  \n' }), '');
+  assert.equal(readAuthToken('/token', { readFileSync: () => { throw new Error('missing'); } }), '');
+});
+
+test('token loading preserves retry cadence and success logging', async () => {
+  let reads = 0;
+  const sleeps = [];
+  const logs = [];
+  const warnings = [];
+  const token = await loadAuthToken({
+    tokenPath: '/data/auth.token',
+    fsImpl: { readFileSync: () => (++reads === 3 ? ' live-token ' : '') },
+    sleep: async (ms) => { sleeps.push(ms); },
+    logger: {
+      log: (message) => logs.push(message),
+      warn: (message) => warnings.push(message),
+    },
+  });
+
+  assert.equal(token, 'live-token');
+  assert.equal(reads, 3);
+  assert.deepEqual(sleeps, [100, 100]);
+  assert.deepEqual(logs, ['[auth] loaded token from /data/auth.token']);
+  assert.deepEqual(warnings, []);
+});
+
+test('token loading performs all 20 reads and final sleeps before warning', async () => {
+  let reads = 0;
+  const sleeps = [];
+  const warnings = [];
+  const token = await loadAuthToken({
+    tokenPath: '/data/auth.token',
+    fsImpl: { readFileSync: () => { reads += 1; throw new Error('not ready'); } },
+    sleep: async (ms) => { sleeps.push(ms); },
+    logger: { log() {}, warn: (message) => warnings.push(message) },
+  });
+
+  assert.equal(token, '');
+  assert.equal(reads, 20);
+  assert.equal(sleeps.length, 20);
+  assert.equal(sleeps.every((ms) => ms === 100), true);
+  assert.deepEqual(warnings, [
+    '[auth] FAILED to load auth token from /data/auth.token after 2s — WS/HTTP will be rejected',
+  ]);
+});
+
+function requestDouble(onGet) {
+  return {
+    get(url, callback) {
+      const request = new EventEmitter();
+      request.destroyed = false;
+      request.setTimeout = (ms, handler) => {
+        request.timeoutMs = ms;
+        request.timeoutHandler = handler;
+      };
+      request.destroy = () => { request.destroyed = true; };
+      onGet({ url, callback, request });
+      return request;
+    },
+  };
+}
+
+test('health polling resolves only on HTTP 200 and retries other statuses after 500ms', async () => {
+  const statuses = [503, 200];
+  const delays = [];
+  const urls = [];
+  const result = waitForBackend(8330, {
+    httpImpl: requestDouble(({ url, callback }) => {
+      urls.push(url);
+      queueMicrotask(() => callback({ statusCode: statuses.shift() }));
+    }),
+    setTimeoutImpl(handler, ms) {
+      delays.push(ms);
+      queueMicrotask(handler);
+    },
+  });
+
+  await result;
+  assert.deepEqual(urls, [
+    'http://127.0.0.1:8330/api/health/check',
+    'http://127.0.0.1:8330/api/health/check',
+  ]);
+  assert.deepEqual(delays, [500]);
+});
+
+test('health polling rejects nonzero exits and spawn errors but ignores clean exits', async () => {
+  const stalledHttp = requestDouble(() => {});
+  const failed = new EventEmitter();
+  const failedWait = waitForBackend(8330, { process: failed, httpImpl: stalledHttp });
+  failed.emit('exit', 7);
+  await assert.rejects(failedWait, /Backend process exited with code 7 during startup/);
+
+  const spawnFailed = new EventEmitter();
+  const spawnWait = waitForBackend(8330, { process: spawnFailed, httpImpl: stalledHttp });
+  spawnFailed.emit('error', new Error('blocked'));
+  await assert.rejects(spawnWait, /Backend failed to spawn: blocked/);
+
+  const clean = new EventEmitter();
+  const cleanWait = waitForBackend(8330, {
+    process: clean,
+    httpImpl: requestDouble(({ callback }) => queueMicrotask(() => callback({ statusCode: 200 }))),
+  });
+  clean.emit('exit', 0);
+  await cleanWait;
+});
+
+test('health polling preserves warning thresholds and request timeout behavior', async () => {
+  const nowValues = [0, 60_001, 180_001, 180_500];
+  const statuses = [503, 503, 200];
+  const stillStarting = [];
+  const takingTooLong = [];
+  const delays = [];
+  const requests = [];
+  const waiting = waitForBackend(8330, {
+    now: () => nowValues.shift(),
+    onStillStarting: () => stillStarting.push('shown'),
+    onTakingTooLong: () => takingTooLong.push('shown'),
+    httpImpl: requestDouble(({ callback, request }) => {
+      requests.push(request);
+      queueMicrotask(() => callback({ statusCode: statuses.shift() }));
+    }),
+    setTimeoutImpl(handler, ms) {
+      delays.push(ms);
+      queueMicrotask(handler);
+    },
+  });
+
+  await waiting;
+  assert.deepEqual(stillStarting, ['shown']);
+  assert.deepEqual(takingTooLong, ['shown']);
+  assert.deepEqual(delays, [500, 500]);
+  assert.equal(requests.every((request) => request.timeoutMs === 2000), true);
+
+  const timeoutDelays = [];
+  let timedRequest;
+  const timeoutWait = waitForBackend(8331, {
+    httpImpl: requestDouble(({ callback, request }) => {
+      timedRequest = request;
+      request.afterTimeout = () => callback({ statusCode: 200 });
+    }),
+    setTimeoutImpl(handler, ms) {
+      timeoutDelays.push(ms);
+      if (ms === 500) queueMicrotask(() => timedRequest.afterTimeout());
+    },
+  });
+  timedRequest.timeoutHandler();
+  await timeoutWait;
+  assert.equal(timedRequest.destroyed, true);
+  assert.equal(timedRequest.timeoutMs, 2000);
+  assert.deepEqual(timeoutDelays, [500]);
+});

--- a/electron/boot-telemetry.js
+++ b/electron/boot-telemetry.js
@@ -1,0 +1,100 @@
+function createBootTelemetry(options = {}) {
+  const {
+    launchTime = Date.now(),
+    now = Date.now,
+    logger = console,
+    schedule = setTimeout,
+    onBeaconReady = () => {},
+    beaconDelayMs = 1500,
+    stderrLimit = 60,
+  } = options;
+
+  const perfSeen = new Set();
+  const perfValues = {};
+  const backendStderr = [];
+  let preflightInfo = {};
+  let preflightVerdict = null;
+  let preflightPendingCache = null;
+  let beaconScheduled = false;
+
+  function markPerformance(name) {
+    if (perfSeen.has(name)) return false;
+    perfSeen.add(name);
+    const elapsed = now() - launchTime;
+    perfValues[name] = elapsed;
+    try { logger.log(`[perf] ${name} t=${elapsed}`); } catch (_) {}
+    return true;
+  }
+
+  function appendBackendStderr(text) {
+    backendStderr.push(text);
+    while (backendStderr.length > stderrLimit) backendStderr.shift();
+  }
+
+  function recentBackendStderr(count) {
+    return backendStderr.slice(-count).join('');
+  }
+
+  function setPreflightInfo(info) {
+    preflightInfo = info;
+  }
+
+  function setPreflightVerdict(verdict) {
+    preflightVerdict = verdict;
+  }
+
+  function commitPreflightCacheIfReady() {
+    if (!preflightPendingCache) return false;
+    if (perfValues['backend-http-ready'] == null) return false;
+    const { pf, dataDir, version, result } = preflightPendingCache;
+    preflightPendingCache = null;
+    try {
+      pf.writeCache(pf.defaultEnv(), dataDir, version, result);
+      logger.log(`[preflight2] cache committed for v${version}`);
+    } catch (error) {
+      logger.log(`[preflight2] cache write failed: ${error && error.message}`);
+    }
+    return true;
+  }
+
+  function stagePreflightCache(pendingCache) {
+    preflightPendingCache = pendingCache;
+    commitPreflightCacheIfReady();
+  }
+
+  function scheduleBeaconIfReady() {
+    if (beaconScheduled) return false;
+    if (perfValues['first-paint'] == null || perfValues['backend-http-ready'] == null) {
+      return false;
+    }
+    beaconScheduled = true;
+    schedule(onBeaconReady, beaconDelayMs);
+    return true;
+  }
+
+  function beaconSnapshot() {
+    return {
+      perf: { ...perfValues },
+      preflight: { ...preflightInfo },
+      preflight2: preflightVerdict ? {
+        verdict: preflightVerdict.verdict,
+        totalMs: preflightVerdict.totalMs,
+        names: (preflightVerdict.results || []).map((result) => `${result.name}:${result.status}`),
+      } : null,
+    };
+  }
+
+  return {
+    markPerformance,
+    appendBackendStderr,
+    recentBackendStderr,
+    setPreflightInfo,
+    setPreflightVerdict,
+    stagePreflightCache,
+    commitPreflightCacheIfReady,
+    scheduleBeaconIfReady,
+    beaconSnapshot,
+  };
+}
+
+module.exports = { createBootTelemetry };

--- a/electron/boot-telemetry.test.js
+++ b/electron/boot-telemetry.test.js
@@ -1,0 +1,140 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createBootTelemetry } = require('./boot-telemetry');
+
+function harness(overrides = {}) {
+  const logs = [];
+  const scheduled = [];
+  const beacons = [];
+  const telemetry = createBootTelemetry({
+    launchTime: 1_000,
+    now: () => 1_125,
+    logger: { log: (message) => logs.push(message) },
+    schedule: (callback, delay) => scheduled.push({ callback, delay }),
+    onBeaconReady: () => beacons.push('ready'),
+    ...overrides,
+  });
+  return { telemetry, logs, scheduled, beacons };
+}
+
+test('records each performance milestone once from process launch', () => {
+  let now = 1_125;
+  const fixture = harness({ now: () => now });
+
+  assert.equal(fixture.telemetry.markPerformance('first-paint'), true);
+  now = 1_900;
+  assert.equal(fixture.telemetry.markPerformance('first-paint'), false);
+  fixture.telemetry.markPerformance('first-agent-response');
+
+  assert.deepEqual(fixture.telemetry.beaconSnapshot().perf, {
+    'first-paint': 125,
+    'first-agent-response': 900,
+  });
+  assert.deepEqual(fixture.logs, [
+    '[perf] first-paint t=125',
+    '[perf] first-agent-response t=900',
+  ]);
+});
+
+test('keeps only the newest bounded backend diagnostics for splash callbacks', () => {
+  const fixture = harness({ stderrLimit: 3 });
+  fixture.telemetry.appendBackendStderr('one');
+  fixture.telemetry.appendBackendStderr('two');
+  fixture.telemetry.appendBackendStderr('three');
+  fixture.telemetry.appendBackendStderr('four');
+
+  assert.equal(fixture.telemetry.recentBackendStderr(2), 'threefour');
+  assert.equal(fixture.telemetry.recentBackendStderr(30), 'two three four'.replaceAll(' ', ''));
+});
+
+test('projects preflight state into the existing compact beacon shape', () => {
+  const fixture = harness();
+  fixture.telemetry.setPreflightInfo({ userDataWritable: true, freeDiskMB: 2048 });
+  fixture.telemetry.setPreflightVerdict({
+    verdict: 'warn',
+    totalMs: 44,
+    results: [
+      { name: 'disk', status: 'ok', reason: '' },
+      { name: 'gpu', status: 'warn', reason: 'slow' },
+    ],
+  });
+
+  assert.deepEqual(fixture.telemetry.beaconSnapshot(), {
+    perf: {},
+    preflight: { userDataWritable: true, freeDiskMB: 2048 },
+    preflight2: {
+      verdict: 'warn',
+      totalMs: 44,
+      names: ['disk:ok', 'gpu:warn'],
+    },
+  });
+});
+
+test('commits a staged preflight cache only after backend readiness and only once', () => {
+  const fixture = harness();
+  const writes = [];
+  const pf = {
+    defaultEnv: () => ({ platform: 'win32' }),
+    writeCache: (...args) => writes.push(args),
+  };
+  const result = { verdict: 'ok', totalMs: 25, results: [] };
+
+  fixture.telemetry.stagePreflightCache({ pf, dataDir: 'C:/data', version: '1.2.3', result });
+  assert.deepEqual(writes, []);
+  fixture.telemetry.markPerformance('backend-http-ready');
+  fixture.telemetry.commitPreflightCacheIfReady();
+  fixture.telemetry.commitPreflightCacheIfReady();
+
+  assert.deepEqual(writes, [[{ platform: 'win32' }, 'C:/data', '1.2.3', result]]);
+  assert.equal(fixture.logs.at(-1), '[preflight2] cache committed for v1.2.3');
+});
+
+test('a cache staged after readiness commits immediately and consumes failures', () => {
+  const fixture = harness();
+  fixture.telemetry.markPerformance('backend-http-ready');
+  let attempts = 0;
+  const pf = {
+    defaultEnv: () => ({}),
+    writeCache: () => { attempts += 1; throw new Error('denied'); },
+  };
+
+  fixture.telemetry.stagePreflightCache({
+    pf,
+    dataDir: '/data',
+    version: '2.0.0',
+    result: { verdict: 'ok' },
+  });
+  fixture.telemetry.commitPreflightCacheIfReady();
+
+  assert.equal(attempts, 1);
+  assert.equal(fixture.logs.at(-1), '[preflight2] cache write failed: denied');
+});
+
+test('schedules one delayed beacon only after paint and backend are both ready', () => {
+  const fixture = harness();
+  fixture.telemetry.markPerformance('first-paint');
+  assert.equal(fixture.telemetry.scheduleBeaconIfReady(), false);
+  fixture.telemetry.markPerformance('backend-http-ready');
+  assert.equal(fixture.telemetry.scheduleBeaconIfReady(), true);
+  assert.equal(fixture.telemetry.scheduleBeaconIfReady(), false);
+
+  assert.equal(fixture.scheduled.length, 1);
+  assert.equal(fixture.scheduled[0].delay, 1500);
+  assert.deepEqual(fixture.beacons, []);
+  fixture.scheduled[0].callback();
+  assert.deepEqual(fixture.beacons, ['ready']);
+});
+
+test('beacon callback reads telemetry at send time rather than schedule time', () => {
+  const snapshots = [];
+  let telemetry;
+  const fixture = harness({ onBeaconReady: () => snapshots.push(telemetry.beaconSnapshot()) });
+  telemetry = fixture.telemetry;
+  telemetry.markPerformance('first-paint');
+  telemetry.markPerformance('backend-http-ready');
+  telemetry.scheduleBeaconIfReady();
+  telemetry.markPerformance('first-agent-response');
+  fixture.scheduled[0].callback();
+
+  assert.equal(snapshots[0].perf['first-agent-response'], 125);
+});

--- a/electron/frontend-server.js
+++ b/electron/frontend-server.js
@@ -1,0 +1,207 @@
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const FRONTEND_HOST = '127.0.0.1';
+const PREFERRED_FRONTEND_PORT = 4173;
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.wasm': 'application/wasm',
+};
+
+function createRequestHandler(options) {
+  const {
+    frontendDir,
+    fsImpl = fs,
+    pathImpl = path,
+    logger = console,
+  } = options;
+  const root = pathImpl.resolve(frontendDir);
+  const indexPath = pathImpl.join(root, 'index.html');
+
+  return (req, res) => {
+    try {
+      let pathname = decodeURIComponent((req.url || '/').split('?')[0]);
+      if (pathname === '/' || pathname === '') pathname = '/index.html';
+      const resolved = pathImpl.normalize(pathImpl.join(root, pathname));
+      if (!resolved.startsWith(root + pathImpl.sep) && resolved !== indexPath) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
+      fsImpl.readFile(resolved, (error, data) => {
+        if (error) {
+          fsImpl.readFile(indexPath, (indexError, indexData) => {
+            if (indexError) {
+              res.writeHead(404);
+              res.end();
+              return;
+            }
+            res.writeHead(200, { 'Content-Type': MIME_TYPES['.html'] });
+            res.end(indexData);
+          });
+          return;
+        }
+        const extension = pathImpl.extname(resolved).toLowerCase();
+        res.writeHead(200, { 'Content-Type': MIME_TYPES[extension] || 'application/octet-stream' });
+        res.end(data);
+      });
+    } catch (error) {
+      logger.error('[frontend-server] request handler threw:', error && error.message);
+      try {
+        res.writeHead(500);
+        res.end();
+      } catch {}
+    }
+  };
+}
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.removeListener('error', onError);
+      server.removeListener('listening', onListening);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onListening = () => {
+      cleanup();
+      const address = server.address();
+      resolve(typeof address === 'object' && address ? address.port : null);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    try {
+      server.listen(port, host);
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    try {
+      server.close(() => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function logRuntimeErrors(server, logger) {
+  server.on('error', (error) => {
+    logger.error('[frontend-server] listener failed:', error && error.message);
+  });
+}
+
+function createFrontendServer(options) {
+  const {
+    frontendDir,
+    httpImpl = http,
+    host = FRONTEND_HOST,
+    preferredPort = PREFERRED_FRONTEND_PORT,
+    logger = console,
+  } = options;
+  const handler = createRequestHandler({ ...options, frontendDir, logger });
+  let activeServer = null;
+  let activePort = null;
+  let startPromise = null;
+  let closePromise = null;
+
+  async function startFresh() {
+    const preferred = httpImpl.createServer(handler);
+    try {
+      activePort = await listen(preferred, preferredPort, host);
+      activeServer = preferred;
+      logRuntimeErrors(preferred, logger);
+      logger.log(`[frontend-server] listening on ${host}:${activePort}`);
+      return activePort;
+    } catch {
+      await closeServer(preferred);
+    }
+
+    const fallback = httpImpl.createServer(handler);
+    try {
+      activePort = await listen(fallback, 0, host);
+      activeServer = fallback;
+      logRuntimeErrors(fallback, logger);
+      logger.log(`[frontend-server] listening (fallback) on ${host}:${activePort}`);
+      return activePort;
+    } catch (error) {
+      logger.error('[frontend-server] fallback also failed:', error && error.message);
+      await closeServer(fallback);
+      activePort = null;
+      throw error;
+    }
+  }
+
+  return {
+    get port() { return activePort; },
+    async start() {
+      if (closePromise) await closePromise;
+      if (activeServer) return activePort;
+      if (!startPromise) startPromise = startFresh();
+      try {
+        return await startPromise;
+      } finally {
+        if (!activeServer) startPromise = null;
+      }
+    },
+    async close() {
+      if (!closePromise) {
+        closePromise = (async () => {
+          const pendingStart = startPromise;
+          if (pendingStart) {
+            try {
+              await pendingStart;
+            } catch {}
+          }
+          const server = activeServer;
+          activeServer = null;
+          activePort = null;
+          startPromise = null;
+          await closeServer(server);
+        })();
+      }
+      try {
+        await closePromise;
+      } finally {
+        closePromise = null;
+      }
+    },
+  };
+}
+
+module.exports = {
+  FRONTEND_HOST,
+  PREFERRED_FRONTEND_PORT,
+  MIME_TYPES,
+  createRequestHandler,
+  createFrontendServer,
+};

--- a/electron/frontend-server.test.js
+++ b/electron/frontend-server.test.js
@@ -1,0 +1,172 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { createFrontendServer } = require('./frontend-server');
+
+function request(port, pathname) {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ host: '127.0.0.1', port, path: pathname }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        type: res.headers['content-type'],
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    req.on('error', reject);
+  });
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-frontend-server-'));
+  const frontendDir = path.join(root, 'frontend');
+  fs.mkdirSync(frontendDir);
+  fs.writeFileSync(path.join(frontendDir, 'index.html'), '<main>OpenSwarm</main>');
+  fs.writeFileSync(path.join(frontendDir, 'bundle.js'), 'window.ready = true;');
+  fs.writeFileSync(path.join(frontendDir, 'module.wasm'), 'wasm');
+  fs.writeFileSync(path.join(root, 'secret.txt'), 'not public');
+  return { root, frontendDir };
+}
+
+test('serves packaged assets, MIME types, query strings, and SPA fallback', async (t) => {
+  const files = fixture();
+  t.after(() => fs.rmSync(files.root, { recursive: true, force: true }));
+  const server = createFrontendServer({ frontendDir: files.frontendDir, preferredPort: 0 });
+  t.after(() => server.close());
+  const port = await server.start();
+
+  assert.deepEqual(await request(port, '/'), {
+    status: 200,
+    type: 'text/html; charset=utf-8',
+    body: '<main>OpenSwarm</main>',
+  });
+  assert.deepEqual(await request(port, '/bundle.js?v=one'), {
+    status: 200,
+    type: 'application/javascript; charset=utf-8',
+    body: 'window.ready = true;',
+  });
+  assert.equal((await request(port, '/module.wasm')).type, 'application/wasm');
+  assert.equal((await request(port, '/dashboard/client-route')).body, '<main>OpenSwarm</main>');
+});
+
+test('denies decoded traversal outside the packaged frontend directory', async (t) => {
+  const files = fixture();
+  t.after(() => fs.rmSync(files.root, { recursive: true, force: true }));
+  const server = createFrontendServer({ frontendDir: files.frontendDir, preferredPort: 0 });
+  t.after(() => server.close());
+  const port = await server.start();
+
+  const response = await request(port, '/%2e%2e/secret.txt');
+  assert.equal(response.status, 403);
+  assert.equal(response.body, '');
+});
+
+test('falls back to an ephemeral loopback port and closes idempotently', async (t) => {
+  const files = fixture();
+  t.after(() => fs.rmSync(files.root, { recursive: true, force: true }));
+  const blocker = http.createServer((_req, res) => res.end());
+  await new Promise((resolve) => blocker.listen(0, '127.0.0.1', resolve));
+  t.after(() => new Promise((resolve) => blocker.close(resolve)));
+  const occupiedPort = blocker.address().port;
+  const server = createFrontendServer({ frontendDir: files.frontendDir, preferredPort: occupiedPort });
+
+  const port = await server.start();
+  assert.notEqual(port, occupiedPort);
+  assert.equal(server.port, port);
+  await server.close();
+  await server.close();
+  assert.equal(server.port, null);
+  await assert.rejects(request(port, '/'), /ECONNREFUSED/);
+});
+
+test('rejects and cleans up when preferred and fallback listeners both fail', async () => {
+  const servers = [];
+  const httpImpl = {
+    createServer(handler) {
+      const server = new EventEmitter();
+      server.handler = handler;
+      server.closed = 0;
+      server.listen = () => queueMicrotask(() => server.emit('error', new Error('bind denied')));
+      server.close = (callback) => { server.closed += 1; callback?.(); };
+      server.address = () => null;
+      servers.push(server);
+      return server;
+    },
+  };
+  const controller = createFrontendServer({
+    frontendDir: path.join(os.tmpdir(), 'unused'),
+    httpImpl,
+  });
+
+  await assert.rejects(controller.start(), /bind denied/);
+  assert.equal(servers.length, 2);
+  assert.equal(servers.every((server) => server.closed >= 1), true);
+  assert.equal(controller.port, null);
+});
+
+test('close waits for an in-flight listener and then releases it', async () => {
+  let server;
+  const httpImpl = {
+    createServer(handler) {
+      server = new EventEmitter();
+      server.handler = handler;
+      server.closed = 0;
+      server.listen = () => {};
+      server.close = (callback) => { server.closed += 1; callback?.(); };
+      server.address = () => ({ port: 4173 });
+      return server;
+    },
+  };
+  const controller = createFrontendServer({
+    frontendDir: path.join(os.tmpdir(), 'unused'),
+    httpImpl,
+  });
+
+  const starting = controller.start();
+  const closing = controller.close();
+  assert.equal(server.closed, 0);
+
+  server.emit('listening');
+  assert.equal(await starting, 4173);
+  await closing;
+
+  assert.equal(server.closed, 1);
+  assert.equal(controller.port, null);
+});
+
+test('start waits for an overlapping close and creates a fresh listener', async () => {
+  const servers = [];
+  const httpImpl = {
+    createServer(handler) {
+      const port = 4173 + servers.length;
+      const server = new EventEmitter();
+      server.handler = handler;
+      server.closed = 0;
+      server.listen = () => queueMicrotask(() => server.emit('listening'));
+      server.close = (callback) => { server.closed += 1; callback?.(); };
+      server.address = () => ({ port });
+      servers.push(server);
+      return server;
+    },
+  };
+  const controller = createFrontendServer({
+    frontendDir: path.join(os.tmpdir(), 'unused'),
+    httpImpl,
+  });
+
+  assert.equal(await controller.start(), 4173);
+  const closing = controller.close();
+  const restarting = controller.start();
+
+  await closing;
+  assert.equal(await restarting, 4174);
+  assert.equal(servers[0].closed, 1);
+  assert.equal(servers[1].closed, 0);
+  assert.equal(controller.port, 4174);
+  await controller.close();
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -144,10 +144,13 @@ const fs = require('fs');
 const hiddenBrowser = require('./hiddenBrowser');
 const usageHarvest = require('./usageHarvest');
 const { installVoiceHotkey } = require('./voiceHotkey');
-const getPort = require('get-port');
 const http = require('http');
 const affiliateTracking = require('./affiliateTracking');
+const backendReadiness = require('./backend-readiness');
 const cdpRoutes = require('./cdp-routes');
+const { createFrontendServer } = require('./frontend-server');
+const { pickBackendPort } = require('./port-manager');
+const { createRuntimePaths } = require('./runtime-paths');
 const workflowsLifecycle = require('./workflowsLifecycle');
 
 // Squirrel makes the APP create its own shortcuts: on --squirrel-install it must
@@ -211,24 +214,17 @@ if (process.platform === 'win32' && process.argv.includes('--squirrel-firstrun')
 // Format is load-bearing: `[perf] <name> t=<ms-since-launch>` one per line.
 // APP_LAUNCH_T is captured at module load so t=0 is genuinely process start.
 const APP_LAUNCH_T = Date.now();
-const _perfSeen = new Set();
-const _perfValues = {};   // name -> ms; read by the boot beacon below.
+const { createBootTelemetry } = require('./boot-telemetry');
+const bootTelemetry = createBootTelemetry({
+  launchTime: APP_LAUNCH_T,
+  onBeaconReady: () => sendBootBeacon(),
+});
 function perfMark(name) {
-  // One-shot per milestone: first-paint etc. can re-fire on crash-recovery
-  // window recreation, but the baseline we care about is the cold boot.
-  if (_perfSeen.has(name)) return;
-  _perfSeen.add(name);
-  const t = Date.now() - APP_LAUNCH_T;
-  _perfValues[name] = t;
-  try { console.log(`[perf] ${name} t=${t}`); } catch (_) {}
+  bootTelemetry.markPerformance(name);
 }
 
 // Preflight: log the usual "works on mine, not theirs" causes (python is already covered by the exists-log + spawn handler; this adds the rest). Log-only, guarded, no PII (lengths/flags, never paths).
-let _preflightInfo = {};
-let _preflightVerdict = null;
-
 // Comprehensive preflight (electron/preflight.js): fans out checks under hard per-check timeouts, emits a [preflight2] verdict line, defers cache write until BOTH preflight finished AND backend-http-ready so a mid-boot kill cannot poison the next launch's cached verdict. Kill switch via OPENSWARM_DISABLE_PREFLIGHT=1.
-let _preflightPendingCache = null;
 // Cheap deterministic hash of installation_id into [0,99]; used by the cohort gate so the same install always falls in the same bucket regardless of when it boots.
 function installIdBucket(id) {
   if (!id) return 0;
@@ -258,14 +254,13 @@ function runComprehensivePreflight() {
   const version = (() => { try { return app.getVersion(); } catch { return '0.0.0'; } })();
   if (dataDir) { try { pf.pruneOldCaches(pf.defaultEnv(), dataDir, version); } catch {} }
   const cached = dataDir ? pf.readCache(pf.defaultEnv(), dataDir, version) : null;
-  if (cached) { console.log(`[preflight2] cached verdict=${cached.verdict} (skipping fresh probes)`); _preflightVerdict = cached; return; }
+  if (cached) { console.log(`[preflight2] cached verdict=${cached.verdict} (skipping fresh probes)`); bootTelemetry.setPreflightVerdict(cached); return; }
   pf.run(pf.defaultEnv(), { dataDir, gpu: { app } }).then((result) => {
-    _preflightVerdict = result;
+    bootTelemetry.setPreflightVerdict(result);
     const reasons = result.results.filter((r) => r.status !== 'ok').map((r) => `${r.name}:${r.status}(${r.reason})`).join('; ');
     console.log(`[preflight2] verdict=${result.verdict} totalMs=${result.totalMs} ${reasons || 'all-checks-ok'}`);
     if (dataDir && result.verdict === 'ok') {
-      _preflightPendingCache = { pf, dataDir, version, result };
-      maybeCommitPreflightCache();
+      bootTelemetry.stagePreflightCache({ pf, dataDir, version, result });
     }
   }).catch((e) => { console.log(`[preflight2] threw: ${e && e.message}`); });
 }
@@ -274,12 +269,7 @@ function runComprehensivePreflight() {
 // window between preflight-finish and backend-actually-serving cannot leave a
 // "verdict=ok" token that masks a real boot break on the next launch.
 function maybeCommitPreflightCache() {
-  if (!_preflightPendingCache) return;
-  if (_perfValues['backend-http-ready'] == null) return;
-  const { pf, dataDir, version, result } = _preflightPendingCache;
-  _preflightPendingCache = null;
-  try { pf.writeCache(pf.defaultEnv(), dataDir, version, result); console.log(`[preflight2] cache committed for v${version}`); }
-  catch (e) { console.log(`[preflight2] cache write failed: ${e && e.message}`); }
+  bootTelemetry.commitPreflightCacheIfReady();
 }
 
 function logPreflight(backendPort) {
@@ -293,8 +283,8 @@ function logPreflight(backendPort) {
     probe('oneDriveProfile', () => /onedrive/i.test(userData));
     probe('portInPreferredRange', () => backendPort >= 8324 && backendPort <= 8424);
     probe('freeDiskMB', () => Math.round((fs.statfsSync(userData).bavail * fs.statfsSync(userData).bsize) / 1048576));
-    if (isPackaged) for (const bit of ['router', 'node', 'app.asar', 'frontend', 'backend', 'python-env']) probe(bit, () => fs.existsSync(getResourcePath(bit)));
-    _preflightInfo = info;
+    if (isPackaged) for (const bit of ['router', 'node', 'app.asar', 'frontend', 'backend', 'python-env']) probe(bit, () => fs.existsSync(runtimePaths.resourcePath(bit)));
+    bootTelemetry.setPreflightInfo(info);
     console.log(`[preflight] ${Object.entries(info).map(([k, v]) => `${k}=${v}`).join(' | ')}`);
   } catch (_) { /* never break boot */ }
 }
@@ -338,13 +328,14 @@ function sendBootBeacon() {
   try {
     if (!isPackaged || !backendPort) return;
     const bi = getBuildInfo();
+    const telemetry = bootTelemetry.beaconSnapshot();
     const body = JSON.stringify({
       surface: 'boot',
       action: 'ready',
       props: {
         sha: bi.shortSha, channel: bi.channel, version: app.getVersion(),
         os: process.platform, arch: process.arch,
-        perf: _perfValues, preflight: _preflightInfo, preflight2: _preflightVerdict ? { verdict: _preflightVerdict.verdict, totalMs: _preflightVerdict.totalMs, names: (_preflightVerdict.results || []).map((r) => `${r.name}:${r.status}`) } : null, crash_dumps: countCrashDumps(), new_crashes: newCrashDumps(),
+        perf: telemetry.perf, preflight: telemetry.preflight, preflight2: telemetry.preflight2, crash_dumps: countCrashDumps(),
       },
     });
     const req = http.request({
@@ -364,15 +355,14 @@ function sendBootBeacon() {
 }
 
 // Fire the beacon once first-paint AND backend-http-ready have both landed (the POST needs the backend listening); a touch later so it stays off the critical path.
-let _beaconScheduled = false;
 function maybeSendBootBeacon() {
-  if (_beaconScheduled) return;
-  if (_perfValues['first-paint'] == null || _perfValues['backend-http-ready'] == null) return;
-  _beaconScheduled = true;
-  setTimeout(() => sendBootBeacon(), 1500);
+  bootTelemetry.scheduleBeaconIfReady();
 }
 
-// Defender warmup: NSIS runs us with --prewarm right after install so Windows scans the bundled binaries while the user is already watching the installer instead of staring at a slow first launch.
+// Defender warmup: NSIS runs us with --prewarm right after install so Windows
+// scans both the bundled binaries and the real backend import graph while the
+// user is already watching the installer instead of staring at a slow first
+// launch. Best-effort: a failure only moves this work back to first launch.
 if (process.argv.includes('--prewarm') && process.platform === 'win32') {
   const touchExe = (rel) => {
     const full = path.join(process.resourcesPath, rel);
@@ -385,6 +375,38 @@ if (process.argv.includes('--prewarm') && process.platform === 'win32') {
   touchExe(path.join('python-env', 'python.exe'));
   touchExe(path.join('node', 'x64', 'node.exe'));
   touchExe(path.join('node', 'arm64', 'node.exe'));
+  let scratchRoot = null;
+  try {
+    scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-backend-warmup-'));
+    const pythonPath = path.join(process.resourcesPath, 'python-env', 'python.exe');
+    const warmup = backendReadiness.createBackendImportWarmup({
+      pythonPath,
+      projectRoot: process.resourcesPath,
+      debuggerDir: path.join(process.resourcesPath, 'debugger'),
+      pythonSitePackages: path.join(process.resourcesPath, 'python-env', 'Lib', 'site-packages'),
+      scratchRoot,
+      platform: process.platform,
+      env: process.env,
+    });
+    execFileSync(warmup.file, warmup.args, {
+      ...warmup.options,
+      timeout: 300000,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+  } catch (_) {
+  } finally {
+    if (scratchRoot) {
+      try {
+        fs.rmSync(scratchRoot, {
+          recursive: true,
+          force: true,
+          maxRetries: 10,
+          retryDelay: 200,
+        });
+      } catch (_) {}
+    }
+  }
   process.exit(0);
 }
 
@@ -523,92 +545,13 @@ let splashWindow = null;
 let mainWindowReady = false;
 let isQuittingFromSplash = false;  // guards against double-quit during error shutdown
 let rendererCrashTimes = [];       // timestamps of recent render-process-gone events; caps the auto-reload retry storm
-const recentBackendStderr = [];   // ring buffer (last ~60 lines) for splash error UI
 let splashDataUrlCache = null;
 // Set to true around `new BrowserWindow()` for the top-level main window so the popup-UA spoofer in app.on('web-contents-created') doesn't accidentally rewrite the main window's UA. The web-contents-created event fires synchronously inside the BrowserWindow constructor, before mainWindow assignment returns; without this flag, the previous identity check (contents !== mainWindow.webContents) is racy across recreateMainWindow() because mainWindow still points to the OLD window during construction of the NEW one.
 let isCreatingMainWindow = false;
 
 // Embedded HTTP server that serves the packaged frontend bundle. The previous loadFile(...) path used file:// which on Windows Electron 40 CastLabs triggered a STATUS_ACCESS_VIOLATION (0xC0000005) renderer crash on every chat / dashboard mount; dev mode using http://localhost:3000 never crashed. Serving over http://127.0.0.1:<random> from the same in-process Node http server keeps the same packaged asset layout, costs no measurable perf (in-process loopback), and avoids the file:// quirk that Chromium 144 segfaults on.
 let frontendServerPort = null;
-async function startFrontendServer() {
-  const frontendDir = path.join(process.resourcesPath, 'frontend');
-  const mimeTypes = {
-    '.html': 'text/html; charset=utf-8',
-    '.js': 'application/javascript; charset=utf-8',
-    '.mjs': 'application/javascript; charset=utf-8',
-    '.css': 'text/css; charset=utf-8',
-    '.json': 'application/json; charset=utf-8',
-    '.map': 'application/json; charset=utf-8',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.gif': 'image/gif',
-    '.webp': 'image/webp',
-    '.svg': 'image/svg+xml',
-    '.ico': 'image/x-icon',
-    '.woff': 'font/woff',
-    '.woff2': 'font/woff2',
-    '.ttf': 'font/ttf',
-    '.otf': 'font/otf',
-    '.mp4': 'video/mp4',
-    '.webm': 'video/webm',
-    '.wasm': 'application/wasm',
-  };
-  const server = http.createServer((req, res) => {
-    try {
-      let pathname = decodeURIComponent((req.url || '/').split('?')[0]);
-      if (pathname === '/' || pathname === '') pathname = '/index.html';
-      const resolved = path.normalize(path.join(frontendDir, pathname));
-      // Defense-in-depth path-traversal guard; loopback-only listener already prevents external access but a misparsed URL must not escape the frontend dir.
-      if (!resolved.startsWith(frontendDir + path.sep) && resolved !== path.join(frontendDir, 'index.html')) {
-        res.writeHead(403); res.end(); return;
-      }
-      fs.readFile(resolved, (err, data) => {
-        if (err) {
-          // SPA fallback: unknown paths return index.html so client-side routing works even if some code uses BrowserRouter instead of HashRouter.
-          fs.readFile(path.join(frontendDir, 'index.html'), (err2, indexData) => {
-            if (err2) { res.writeHead(404); res.end(); return; }
-            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-            res.end(indexData);
-          });
-          return;
-        }
-        const ext = path.extname(resolved).toLowerCase();
-        res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
-        res.end(data);
-      });
-    } catch (err) {
-      console.error('[frontend-server] request handler threw:', err && err.message);
-      try { res.writeHead(500); res.end(); } catch (_) {}
-    }
-  });
-  // Try a deterministic port first so the renderer's origin stays stable across launches.
-  // localStorage is keyed by origin (incl. port), and the old listen(0) handed out a random
-  // port every launch, which wiped onboarding state on every restart and re-triggered the
-  // tour. Try a preferred port; if held, fall back to OS-assigned.
-  const PREFERRED_PORT = 4173;
-  return new Promise((resolve) => {
-    server.once('error', () => {
-      // Preferred port held; fall back. localStorage may rotate this run but stabilizes once 4173 frees up.
-      const fallback = http.createServer(server.listeners('request')[0]);
-      fallback.on('error', (err) => {
-        console.error('[frontend-server] fallback also failed:', err && err.message);
-      });
-      fallback.listen(0, '127.0.0.1', () => {
-        const addr = fallback.address();
-        frontendServerPort = typeof addr === 'object' && addr ? addr.port : null;
-        console.log(`[frontend-server] listening (fallback) on 127.0.0.1:${frontendServerPort}`);
-        resolve(frontendServerPort);
-      });
-    });
-    server.listen(PREFERRED_PORT, '127.0.0.1', () => {
-      const addr = server.address();
-      frontendServerPort = typeof addr === 'object' && addr ? addr.port : null;
-      console.log(`[frontend-server] listening on 127.0.0.1:${frontendServerPort}`);
-      resolve(frontendServerPort);
-    });
-  });
-}
+let frontendServer = null;
 
 const GPU_FALLBACK_MARKER = path.join(os.homedir(), 'Library', 'Application Support', 'openswarm', 'gpu-fallback.marker');
 let reducedGraphicsThisBoot = false;
@@ -624,6 +567,23 @@ try {
 
 const isPackaged = app.isPackaged;
 const isDev = process.env.ELECTRON_DEV === '1';
+const runtimePaths = createRuntimePaths({
+  isPackaged,
+  isDev,
+  platform: process.platform,
+  arch: process.arch,
+  resourcesPath: process.resourcesPath,
+  electronDir: __dirname,
+  env: process.env,
+});
+function getAuthTokenPath() {
+  return backendReadiness.authTokenFilePath({
+    isPackaged,
+    platform: process.platform,
+    env: process.env,
+    electronDir: __dirname,
+  });
+}
 
 // Mac-only crash watchdog. Targets the macOS 26.5 + Electron 42 NSEvent
 // null-deref users have reported (wake-from-sleep mostly). When the parent
@@ -840,140 +800,21 @@ function osTakingTooLongText() {
   return 'Backend is taking longer than usual. You can wait, view logs, or restart.';
 }
 
-/**
- * macOS GUI apps launched from Finder/Dock inherit a minimal PATH from launchd
- * (/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin) — none of the user's shell
- * additions (nvm, volta, homebrew, bun, etc.) are present. Resolve the real
- * PATH by asking the user's default shell, then fall back to well-known dirs.
- */
-function getShellPath() {
-  if (process.platform !== 'darwin' || isDev) return process.env.PATH || '';
-
-  // Strategy 1: ask the user's login shell for its PATH
-  try {
-    const userShell = process.env.SHELL || '/bin/zsh';
-    const result = execFileSync(userShell, ['-ilc', 'echo $PATH'], {
-      encoding: 'utf8',
-      timeout: 5000,
-      env: { ...process.env, HOME: os.homedir() },
-    });
-    const resolved = result.trim();
-    if (resolved) return resolved;
-  } catch (_) { /* fall through */ }
-
-  // Strategy 2: read macOS system PATH config (/etc/paths + /etc/paths.d/*)
-  const systemPaths = [];
-  try {
-    const base = fs.readFileSync('/etc/paths', 'utf8');
-    for (const line of base.split('\n')) {
-      const p = line.trim();
-      if (p) systemPaths.push(p);
-    }
-  } catch (_) { /* ignore */ }
-  try {
-    const pathsD = '/etc/paths.d';
-    if (fs.existsSync(pathsD)) {
-      for (const file of fs.readdirSync(pathsD).sort()) {
-        const content = fs.readFileSync(path.join(pathsD, file), 'utf8');
-        for (const line of content.split('\n')) {
-          const p = line.trim();
-          if (p) systemPaths.push(p);
-        }
-      }
-    }
-  } catch (_) { /* ignore */ }
-
-  // Strategy 3: well-known user-local bin directories
-  const home = os.homedir();
-  const fallbackDirs = [
-    path.join(home, '.local/bin'),
-    path.join(home, '.volta/bin'),
-    path.join(home, '.fnm/aliases/default/bin'),
-    path.join(home, '.bun/bin'),
-    path.join(home, '.cargo/bin'),
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-  ];
-
-  const nvmDir = path.join(home, '.nvm/versions/node');
-  try {
-    if (fs.existsSync(nvmDir)) {
-      const versions = fs.readdirSync(nvmDir).sort().reverse();
-      if (versions.length) {
-        fallbackDirs.unshift(path.join(nvmDir, versions[0], 'bin'));
-      }
-    }
-  } catch (_) { /* ignore */ }
-
-  const seen = new Set();
-  const dirs = [];
-  for (const d of [...fallbackDirs, ...systemPaths, ...(process.env.PATH || '').split(':')]) {
-    if (!d || seen.has(d)) continue;
-    seen.add(d);
-    try { if (fs.statSync(d).isDirectory()) dirs.push(d); } catch { /* skip */ }
-  }
-  return dirs.join(':');
-}
-
-function getResourcePath(...segments) {
-  if (isPackaged) {
-    return path.join(process.resourcesPath, ...segments);
-  }
-  return path.join(__dirname, '..', ...segments);
-}
-
-function getPythonPath() {
-  // python-build-standalone layout differs by OS:
-  //   macOS / Linux: <env>/bin/python3
-  //   Windows:       <env>\python.exe   (no bin/, no python3)
-  //
-  // macOS extra: invoke via Python.app/Contents/MacOS/python3 instead of
-  // bin/python3 so LaunchServices reads LSUIElement=1 from the wrapper
-  // bundle's Info.plist and skips the Dock entry. Without this, the
-  // bundleless python3.13 binary appears as a generic "exec" placeholder
-  // in the Dock on fresh user Macs, bouncing for the entire boot window.
-  // sys.prefix / sys.executable still resolve via realpath so all stdlib
-  // and site-packages discovery is unchanged. See scripts/build-python-env.sh
-  // for the wrapper layout invariants.
-  if (isPackaged) {
-    const envPath = path.join(process.resourcesPath, 'python-env');
-    if (process.platform === 'win32') {
-      return path.join(envPath, 'python.exe');
-    }
-    if (process.platform === 'darwin') {
-      const wrapped = path.join(envPath, 'Python.app', 'Contents', 'MacOS', 'python3');
-      // Defensive fallback: if the wrapper is missing for any reason
-      // (e.g. older build cache), fall back to the bare binary so boot
-      // still succeeds — only the Dock-icon suppression is lost.
-      if (fs.existsSync(wrapped)) return wrapped;
-    }
-    return path.join(envPath, 'bin', 'python3');
-  }
-  if (process.platform === 'win32') {
-    return path.join(__dirname, '..', 'backend', '.venv', 'Scripts', 'python.exe');
-  }
-  return path.join(__dirname, '..', 'backend', '.venv', 'bin', 'python3');
-}
-
 // Read the user's provider session cookies via a one-shot bundled-python invocation, so the
 // offscreen harvest can inject them and pass provider Cloudflare with a real Chrome TLS
 // handshake. Spawned, NEVER an HTTP endpoint, so a token-holding agent can't reach it: only
 // the app shell invokes it. Always resolves (to [] on any failure) so the harvest just falls
-// back to the opportunistic path. mirrors startBackend's python env (projectRoot + site-packages).
+// back to the opportunistic path. Mirrors startBackend's python env (projectRoot + site-packages).
 function p_readProviderCookies(domain) {
   return new Promise((resolve) => {
     let done = false;
     const finish = (v) => { if (!done) { done = true; resolve(v); } };
     try {
-      const root = isPackaged ? process.resourcesPath : path.join(__dirname, '..');
+      // Same resolver startBackend uses (runtime-paths.js): bundled interpreter + the packaged site-packages for the shipped Python.
+      const root = runtimePaths.projectRoot();
       const env = { ...process.env, PYTHONUTF8: '1', PYTHONDONTWRITEBYTECODE: '1' };
-      if (isPackaged) {
-        const sitePackages = process.platform === 'win32'
-          ? path.join(process.resourcesPath, 'python-env', 'Lib', 'site-packages')
-          : path.join(process.resourcesPath, 'python-env', 'lib', 'python3.13', 'site-packages');
-        env.PYTHONPATH = [root, sitePackages].join(path.delimiter);
-      }
-      const proc = spawn(getPythonPath(), ['-m', 'backend.apps.onboarding.usage.dump_cookies', String(domain)], { cwd: root, env });
+      if (isPackaged) env.PYTHONPATH = [root, runtimePaths.pythonSitePackages()].join(path.delimiter);
+      const proc = spawn(runtimePaths.pythonExecutable(), ['-m', 'backend.apps.onboarding.usage.dump_cookies', String(domain)], { cwd: root, env });
       let out = '';
       proc.stdout.on('data', (d) => { out += d.toString(); });
       proc.on('error', () => finish([]));
@@ -984,32 +825,6 @@ function p_readProviderCookies(domain) {
 }
 usageHarvest.configure({ readCookies: p_readProviderCookies });
 
-// Path to a real Node.js binary bundled in extraResources, or null if not
-// shipped (dev mode, or build that skipped the node-fetch step). Backend
-// reads OPENSWARM_NODE_PATH env var to prefer this over both system `node`
-// (which fresh user Macs lack) and the ELECTRON_RUN_AS_NODE fallback
-// (which has flaky Dock behavior + slow cold-start). Used by 9Router and
-// MCP bundle spawning.
-//
-// Layout shipped by scripts/build-app.sh:
-//   <resources>/node/arm64/bin/node
-//   <resources>/node/x64/bin/node
-// Both arches are staged so a single extraResources entry covers
-// publish-mode dual-arch builds without per-arch staging hooks; the
-// runtime picks the matching one by process.arch. Wasted ~25 MB per
-// DMG of cross-arch payload is the cost of avoiding electron-builder's
-// per-arch beforePack complexity. Windows uses node.exe at the root of
-// the per-arch subdir.
-function getBundledNodePath() {
-  if (!isPackaged) return null;
-  const arch = process.arch === 'x64' ? 'x64' : (process.arch === 'arm64' ? 'arm64' : null);
-  if (!arch) return null;
-  const candidate = process.platform === 'win32'
-    ? path.join(process.resourcesPath, 'node', arch, 'node.exe')
-    : path.join(process.resourcesPath, 'node', arch, 'bin', 'node');
-  return fs.existsSync(candidate) ? candidate : null;
-}
-
 // Polls /api/health/check until the backend answers 200, or the spawned
 // python process exits non-zero (real failure). Never times out by wall
 // clock — on a cold-Defender Windows install this can take several
@@ -1017,100 +832,29 @@ function getBundledNodePath() {
 // users staring at a vanished icon. Instead we surface progressive
 // warnings on the splash so the wait feels intentional.
 function waitForBackend(port, opts = {}) {
-  const proc = opts.process || null;
-  const start = Date.now();
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    let stillStartingNotified = false;
-    let actionsShown = false;
-    const finish = (fn, val) => { if (settled) return; settled = true; fn(val); };
-
-    if (proc) {
-      proc.once('exit', (code) => {
-        // exit with code === null means we killed it ourselves (normal shutdown).
-        if (code !== 0 && code !== null) {
-          finish(reject, new Error(`Backend process exited with code ${code} during startup`));
-        }
+  return backendReadiness.waitForBackend(port, {
+    process: opts.process || null,
+    onStillStarting: () => {
+      emitSplashStatus({ text: osStillStartingText(), level: 'warning' });
+    },
+    onTakingTooLong: () => {
+      emitSplashStatus({
+        text: osTakingTooLongText(),
+        level: 'warning',
+        showActions: true,
+        logs: bootTelemetry.recentBackendStderr(20),
       });
-      // spawn 'error' (missing/quarantined/wrong-arch python.exe) never fires
-      // 'exit', so without this the health poll loops forever and the splash
-      // hangs. Reject so the caller surfaces the failure UI instead.
-      proc.once('error', (err) => {
-        finish(reject, new Error(`Backend failed to spawn: ${err && err.message || err}`));
-      });
-    }
-
-    function check() {
-      if (settled) return;
-      const elapsed = Date.now() - start;
-      if (elapsed > 60_000 && !stillStartingNotified) {
-        stillStartingNotified = true;
-        emitSplashStatus({ text: osStillStartingText(), level: 'warning' });
-      }
-      if (elapsed > 180_000 && !actionsShown) {
-        actionsShown = true;
-        emitSplashStatus({
-          text: osTakingTooLongText(),
-          level: 'warning',
-          showActions: true,
-          logs: recentBackendStderr.slice(-20).join(''),
-        });
-      }
-      const req = http.get(`http://127.0.0.1:${port}/api/health/check`, (res) => {
-        if (res.statusCode === 200) {
-          finish(resolve);
-        } else {
-          setTimeout(check, 500);
-        }
-      });
-      req.on('error', () => setTimeout(check, 500));
-      req.setTimeout(2000, () => {
-        req.destroy();
-        setTimeout(check, 500);
-      });
-    }
-    check();
+    },
   });
-}
-
-// Race a port-range search against a 3-second wall clock. On most machines
-// `getPort.makeRange(8324, 8424)` returns within milliseconds, but Windows
-// EDR / corp-firewall stacks can intercept the bind() probes and stall each
-// attempt for seconds — 100 attempts × multi-second stalls = "OpenSwarm is
-// hung at startup." The fallback `getPort({ port: 0 })` lets the OS pick
-// any free ephemeral port; we don't actually care about staying inside the
-// 8324-range — the renderer reads the port via IPC, no hardcoded assumption.
-async function pickBackendPort() {
-  const PREFERRED_TIMEOUT_MS = 3000;
-  // host:'127.0.0.1' is load-bearing. The backend binds uvicorn --host
-  // 127.0.0.1, but get-port defaults to probing 0.0.0.0, and on Windows a
-  // 0.0.0.0:PORT probe SUCCEEDS even when another process already holds
-  // 127.0.0.1:PORT (loopback). So without this, get-port hands back e.g.
-  // 8324 as "free" while something else owns 127.0.0.1:8324, the backend
-  // then fails its 127.0.0.1 bind with WinError 10048 and exits, and the
-  // app shows "backend crashed". Probing the same interface uvicorn binds
-  // makes get-port skip the occupied port. (POSIX already rejects the
-  // mismatched 0.0.0.0 probe, so this is a no-op correctness win on Mac.)
-  const preferred = getPort({ port: getPort.makeRange(8324, 8424), host: '127.0.0.1' });
-  let timeoutHandle;
-  const timeout = new Promise((resolve) => {
-    timeoutHandle = setTimeout(() => resolve(null), PREFERRED_TIMEOUT_MS);
-  });
-  const winner = await Promise.race([preferred, timeout]);
-  clearTimeout(timeoutHandle);
-  if (winner !== null) return winner;
-  console.warn(`[boot] getPort.makeRange(8324,8424) stalled past ${PREFERRED_TIMEOUT_MS}ms — falling back to OS-assigned port`);
-  return await getPort({ port: 0, host: '127.0.0.1' });
 }
 
 async function startBackend() {
   if (!backendPort) backendPort = await pickBackendPort();
 
-  const pythonPath = getPythonPath();
-  const backendDir = getResourcePath('backend');
-  const projectRoot = isPackaged ? process.resourcesPath : path.join(__dirname, '..');
-
-  const shellPath = getShellPath();
+  const pythonPath = runtimePaths.pythonExecutable();
+  const backendDir = runtimePaths.resourcePath('backend');
+  const projectRoot = runtimePaths.projectRoot();
+  const shellPath = runtimePaths.shellPath();
 
   // Identifies how this build was packaged. Read by the backend service
   // client so the cloud can split installer-using customers from
@@ -1160,6 +904,10 @@ async function startBackend() {
     OPENSWARM_LOCALE: app.getLocale(),
     OPENSWARM_TIMEZONE: Intl.DateTimeFormat().resolvedOptions().timeZone || '',
     PYTHONDONTWRITEBYTECODE: '1',
+    // The embedded runtime must never import packages from the host user's
+    // roaming Python directory; only the shipped site-packages are trusted.
+    PYTHONNOUSERSITE: '1',
+    PYTHONUNBUFFERED: '1',
     // PEP 540 UTF-8 mode: makes open() default to UTF-8 on Windows where
     // the locale is otherwise cp1252. Many backend modules read UTF-8
     // .md / .json files without an explicit encoding= argument.
@@ -1183,17 +931,15 @@ async function startBackend() {
   // that Electron-as-Node adds vs. native node (~1-2s). Falls back to the
   // existing system-node / Electron-as-Node chain in nine_router._find_node()
   // if the env var is unset (dev mode, or build without node fetch).
-  const bundledNode = getBundledNodePath();
+  const bundledNode = runtimePaths.bundledNodeExecutable();
   if (bundledNode) {
     env.OPENSWARM_NODE_PATH = bundledNode;
   }
 
   if (isPackaged) {
-    // site-packages location differs by OS — Windows has no lib/python3.13/.
-    const pythonEnvSitePackages = process.platform === 'win32'
-      ? path.join(process.resourcesPath, 'python-env', 'Lib', 'site-packages')
-      : path.join(process.resourcesPath, 'python-env', 'lib', 'python3.13', 'site-packages');
-    const debuggerDir = getResourcePath('debugger');
+    // site-packages location differs by OS — Windows has no lib/python<minor>/.
+    const pythonEnvSitePackages = runtimePaths.pythonSitePackages();
+    const debuggerDir = runtimePaths.resourcePath('debugger');
     env.PYTHONPATH = [projectRoot, debuggerDir, pythonEnvSitePackages].join(path.delimiter);
   }
 
@@ -1246,8 +992,7 @@ async function startBackend() {
     // Buffer the most recent stderr lines for the splash error UI so
     // when boot fails we can show actionable context inline instead of
     // making the user dig through a log file.
-    recentBackendStderr.push(text);
-    while (recentBackendStderr.length > 60) recentBackendStderr.shift();
+    bootTelemetry.appendBackendStderr(text);
   });
 
   // spawn() fires 'error' (not 'exit', not stdout/stderr) when the binary is
@@ -1260,8 +1005,7 @@ async function startBackend() {
       `  python path: ${pythonPath} (exists=${pythonExists})\n` +
       `  arch: ${process.arch}, platform: ${process.platform}\n`;
     console.error(msg);
-    recentBackendStderr.push(msg);
-    while (recentBackendStderr.length > 60) recentBackendStderr.shift();
+    bootTelemetry.appendBackendStderr(msg);
   });
 
   backendProcess.on('exit', (code) => {
@@ -1328,26 +1072,6 @@ function markBackendReady() {
   try { connectMainBridge(); } catch (_) {}
 }
 
-function getAuthTokenFilePath() {
-  // Mirrors backend/config/paths.py. On macOS the file lives at
-  // ~/Library/Application Support/OpenSwarm/data/auth.token; on
-  // Windows under %APPDATA%/OpenSwarm/data/; on Linux under
-  // ~/.local/share/OpenSwarm/data/. In dev the backend writes it to
-  // backend/data/auth.token instead.
-  if (isPackaged) {
-    if (process.platform === 'darwin') {
-      return path.join(os.homedir(), 'Library', 'Application Support', 'OpenSwarm', 'data', 'auth.token');
-    } else if (process.platform === 'win32') {
-      return path.join(process.env.APPDATA || os.homedir(), 'OpenSwarm', 'data', 'auth.token');
-    } else {
-      const xdg = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
-      return path.join(xdg, 'OpenSwarm', 'data', 'auth.token');
-    }
-  }
-  // Dev: backend/data/auth.token relative to repo root.
-  return path.join(__dirname, '..', 'backend', 'data', 'auth.token');
-}
-
 // Persistent backend log on disk. Until now the bundled-Python stdout/stderr
 // only went to the Electron process streams, which a packaged Windows app
 // has no console for, so a user whose backend failed on their machine had
@@ -1355,7 +1079,7 @@ function getAuthTokenFilePath() {
 // cause (UnicodeDecodeError, EADDRINUSE, missing DLL, AV quarantine) of the
 // "works on my laptop, not theirs" failures. Lives next to auth.token.
 function getBackendLogPath() {
-  return path.join(path.dirname(getAuthTokenFilePath()), 'backend.log');
+  return path.join(path.dirname(getAuthTokenPath()), 'backend.log');
 }
 
 let backendLogStream = null;
@@ -1397,22 +1121,8 @@ function installConsoleTee() {
 }
 
 async function loadAuthToken() {
-  const tokenPath = getAuthTokenFilePath();
-  // Retry up to 20 × 100ms = 2s in case backend is still writing the
-  // file. Backend writes BEFORE binding HTTP port though, so this
-  // usually returns on the first attempt.
-  for (let attempt = 0; attempt < 20; attempt++) {
-    try {
-      const contents = fs.readFileSync(tokenPath, 'utf8').trim();
-      if (contents) {
-        authToken = contents;
-        console.log(`[auth] loaded token from ${tokenPath}`);
-        return;
-      }
-    } catch (_) {}
-    await new Promise(r => setTimeout(r, 100));
-  }
-  console.warn(`[auth] FAILED to load auth token from ${tokenPath} after 2s — WS/HTTP will be rejected`);
+  const loaded = await backendReadiness.loadAuthToken({ tokenPath: getAuthTokenPath() });
+  if (loaded) authToken = loaded;
 }
 
 function createWindow() {
@@ -1456,7 +1166,7 @@ function createWindow() {
     mainWindow.loadURL(`http://127.0.0.1:${frontendServerPort}/index.html`);
   } else {
     // Fallback only if the embedded server failed to start; the file:// path is known to segfault on Windows CastLabs Electron 40 but it is better than a white screen.
-    const frontendPath = getResourcePath('frontend', 'index.html');
+    const frontendPath = runtimePaths.resourcePath('frontend', 'index.html');
     mainWindow.loadFile(frontendPath);
   }
 
@@ -1794,7 +1504,7 @@ function getBuildInfo() {
   if (_buildInfoCache) return _buildInfoCache;
   let info = { sha: 'unknown', shortSha: 'unknown', builtAt: null, channel: 'unknown' };
   try {
-    const raw = fs.readFileSync(path.join(__dirname, 'build-info.json'), 'utf8');
+    const raw = fs.readFileSync(path.join(__dirname, 'build-info.json'), 'utf8').replace(/^\uFEFF/, '');
     const parsed = JSON.parse(raw);
     if (parsed && parsed.sha) info = parsed;
   } catch (_) {
@@ -2312,14 +2022,20 @@ app.whenReady().then(async () => {
       backendPort = await pickBackendPort();
       const _backendBoot = startBackend().catch((err) => {
         console.error('[boot] backend startup failed:', err && err.message);
-        emitSplashStatus({ text: 'Backend failed to start', level: 'error', logs: recentBackendStderr.slice(-20).join('') });
+        emitSplashStatus({ text: 'Backend failed to start', level: 'error', logs: bootTelemetry.recentBackendStderr(20) });
       });
     }
     // Start the embedded frontend HTTP server before createWindow so loadURL has a real port. Only relevant in packaged mode; in dev, frontend lives on webpack-dev-server :3000.
     if (!isDev) {
       try {
-        await startFrontendServer();
+        frontendServer = createFrontendServer({
+          frontendDir: path.join(process.resourcesPath, 'frontend'),
+        });
+        frontendServerPort = await frontendServer.start();
       } catch (err) {
+        await frontendServer?.close().catch(() => {});
+        frontendServer = null;
+        frontendServerPort = null;
         console.error('[boot] frontend server failed to start, falling back to file://:', err && err.message);
       }
     }
@@ -2427,7 +2143,7 @@ app.whenReady().then(async () => {
       text: "OpenSwarm couldn't start: " + (err && err.message ? err.message : String(err)),
       level: 'error',
       showActions: true,
-      logs: recentBackendStderr.slice(-30).join(''),
+      logs: bootTelemetry.recentBackendStderr(30),
     });
     // Do NOT call app.quit() here — the user controls the next step
     // through the splash action buttons.
@@ -3260,6 +2976,14 @@ app.on('before-quit', async (event) => {
 
 app.on('will-quit', () => {
   if (!isDev) killBackend();
+  if (frontendServer) {
+    const stoppingServer = frontendServer;
+    frontendServer = null;
+    frontendServerPort = null;
+    void stoppingServer.close().catch((err) => {
+      console.warn('[frontend-server] close failed:', err && err.message);
+    });
+  }
   try { globalShortcut.unregisterAll(); } catch (_) {}
   try { whisperService.stopServer(); } catch (_) {}
 });
@@ -3321,7 +3045,7 @@ ipcMain.on('splash:action', (_event, action) => {
       if (fs.existsSync(logPath)) {
         shell.showItemInFolder(logPath);
       } else {
-        shell.openPath(path.dirname(getAuthTokenFilePath())).catch(() => {});
+        shell.openPath(path.dirname(getAuthTokenPath())).catch(() => {});
       }
     } catch (_) {}
   }
@@ -3349,7 +3073,7 @@ ipcMain.handle('get-backend-port', () => backendPort);
 
 // ---- Voice dictation (local whisper.cpp) ----
 function voiceResourceDir() {
-  return getResourcePath('whisper');
+  return runtimePaths.resourcePath('whisper');
 }
 function voiceUserDataDir() {
   try { return app.getPath('userData'); } catch (_) { return __dirname; }
@@ -3425,11 +3149,8 @@ ipcMain.handle('get-auth-token', async () => {
   // start, and during dev hot-reload the cached value could go stale
   // while the renderer stays alive. Re-reading is cheap (small file,
   // OS caches it) and guarantees the renderer never holds a dead token.
-  try {
-    const p = getAuthTokenFilePath();
-    const current = fs.readFileSync(p, 'utf8').trim();
-    if (current) authToken = current;
-  } catch (_) {}
+  const current = backendReadiness.readAuthToken(getAuthTokenPath());
+  if (current) authToken = current;
   return authToken;
 });
 // Phase 0: renderer fires this once, when it renders the first streamed token

--- a/electron/package.json
+++ b/electron/package.json
@@ -15,7 +15,7 @@
     "dist:win": "electron-builder --win --x64 --publish never",
     "dist:win:publish": "electron-builder --win --x64 --publish always",
     "dist:all": "electron-builder --mac --win --linux",
-    "test": "node --test affiliateTracking.test.js updateErrorMessage.test.js selectWebauthnAccount.test.js voice/streamingVoice.test.js",
+    "test": "node --test affiliateTracking.test.js backend-readiness.test.js boot-telemetry.test.js frontend-server.test.js port-manager.test.js runtime-paths.test.js updateErrorMessage.test.js selectWebauthnAccount.test.js voice/streamingVoice.test.js",
     "test:mouseclamp": "bash native/mouseclamp/run-tests.sh"
   },
   "dependencies": {

--- a/electron/port-manager.js
+++ b/electron/port-manager.js
@@ -1,0 +1,26 @@
+// Prefer the conventional port, then let get-port fall back to an OS-assigned
+// port. Passing one preferred number is important: get-port already appends
+// port 0, while a 101-port range can turn endpoint-security bind inspection
+// into a long serial startup delay. The renderer reads the selected port via
+// IPC, so no fallback range is required.
+async function pickBackendPort(options = {}) {
+  const getPortImpl = options.getPortImpl || require('get-port');
+
+  // host:'127.0.0.1' is load-bearing. The backend binds uvicorn --host
+  // 127.0.0.1, but get-port defaults to probing 0.0.0.0, and on Windows a
+  // 0.0.0.0:PORT probe SUCCEEDS even when another process already holds
+  // 127.0.0.1:PORT (loopback). So without this, get-port hands back e.g.
+  // 8324 as "free" while something else owns 127.0.0.1:8324, the backend
+  // then fails its 127.0.0.1 bind with WinError 10048 and exits, and the
+  // app shows "backend crashed". Probing the same interface uvicorn binds
+  // makes get-port skip the occupied port. (POSIX already rejects the
+  // mismatched 0.0.0.0 probe, so this is a no-op correctness win on Mac.)
+  return getPortImpl({
+    port: 8324,
+    host: '127.0.0.1',
+  });
+}
+
+module.exports = {
+  pickBackendPort,
+};

--- a/electron/port-manager.test.js
+++ b/electron/port-manager.test.js
@@ -1,0 +1,51 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { pickBackendPort } = require('./port-manager');
+
+function fakePortFinder(implementation, makeRange = () => {
+  throw new Error('makeRange must not be called');
+}) {
+  const calls = [];
+  const finder = async (options) => {
+    calls.push(options);
+    return implementation(options, calls.length);
+  };
+  finder.makeRange = makeRange;
+  return { finder, calls };
+}
+
+test('asks get-port once for the preferred port on the backend loopback host', async () => {
+  const { finder, calls } = fakePortFinder(async () => 8324);
+  const port = await pickBackendPort({ getPortImpl: finder });
+
+  assert.equal(port, 8324);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { port: 8324, host: '127.0.0.1' });
+});
+
+test('lets get-port resolve its own fallback without making a second call', async () => {
+  const { finder, calls } = fakePortFinder(() => new Promise((resolve) => {
+    setTimeout(() => resolve(49152), 10);
+  }), () => 8324);
+
+  const port = await pickBackendPort({
+    getPortImpl: finder,
+    timeoutMs: 1,
+  });
+
+  assert.equal(port, 49152);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { port: 8324, host: '127.0.0.1' });
+});
+
+test('always probes the loopback host used by the backend', async () => {
+  const { finder, calls } = fakePortFinder(async () => 8324, () => 8324);
+  const port = await pickBackendPort({
+    getPortImpl: finder,
+    host: '0.0.0.0',
+  });
+
+  assert.equal(port, 8324);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { port: 8324, host: '127.0.0.1' });
+});

--- a/electron/runtime-paths.js
+++ b/electron/runtime-paths.js
@@ -1,0 +1,150 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function createRuntimePaths(options) {
+  const {
+    isPackaged,
+    isDev,
+    platform,
+    arch,
+    resourcesPath,
+    electronDir,
+    env,
+    homedir = os.homedir,
+    fsImpl = fs,
+    pathImpl = path,
+    execFileSyncImpl = execFileSync,
+  } = options;
+  const projectDir = pathImpl.resolve(electronDir, '..');
+
+  function resourcePath(...segments) {
+    return isPackaged
+      ? pathImpl.join(resourcesPath, ...segments)
+      : pathImpl.join(projectDir, ...segments);
+  }
+
+  function pythonExecutable() {
+    // python-build-standalone layout differs by OS:
+    //   macOS / Linux: <env>/bin/python3
+    //   Windows:       <env>\python.exe   (no bin/, no python3)
+    // macOS extra: prefer Python.app/Contents/MacOS/python3 so LaunchServices reads LSUIElement=1
+    // from the wrapper bundle and skips the Dock entry (the bare binary bounces in the Dock for the
+    // whole boot on fresh Macs). Falls back to the bare binary if the wrapper is missing, so boot
+    // still succeeds and only the Dock suppression is lost. See scripts/build-python-env.sh.
+    if (isPackaged) {
+      const environment = pathImpl.join(resourcesPath, 'python-env');
+      if (platform === 'win32') return pathImpl.join(environment, 'python.exe');
+      if (platform === 'darwin') {
+        const wrapped = pathImpl.join(environment, 'Python.app', 'Contents', 'MacOS', 'python3');
+        if (fsImpl.existsSync(wrapped)) return wrapped;
+      }
+      return pathImpl.join(environment, 'bin', 'python3');
+    }
+    return platform === 'win32'
+      ? pathImpl.join(projectDir, 'backend', '.venv', 'Scripts', 'python.exe')
+      : pathImpl.join(projectDir, 'backend', '.venv', 'bin', 'python3');
+  }
+
+  function bundledNodeExecutable() {
+    if (!isPackaged || !['x64', 'arm64'].includes(arch)) return null;
+    const candidate = platform === 'win32'
+      ? pathImpl.join(resourcesPath, 'node', arch, 'node.exe')
+      : pathImpl.join(resourcesPath, 'node', arch, 'bin', 'node');
+    return fsImpl.existsSync(candidate) ? candidate : null;
+  }
+
+  function pythonSitePackages() {
+    if (!isPackaged) return null;
+    if (platform === 'win32') {
+      return pathImpl.join(resourcesPath, 'python-env', 'Lib', 'site-packages');
+    }
+
+    // The bundled interpreter's minor version is a build input, not something main.js should
+    // pin: discover the one lib/python3.N dir the env ships with, and fail loud on none/several.
+    const libDir = pathImpl.join(resourcesPath, 'python-env', 'lib');
+    let candidates = [];
+    try {
+      candidates = fsImpl.readdirSync(libDir).filter((name) => /^python3\.\d+$/.test(name));
+    } catch {}
+    if (candidates.length !== 1) {
+      throw new Error(`Expected exactly one bundled python3.N lib dir under ${libDir}, found: ${candidates.join(', ') || 'none'}`);
+    }
+    return pathImpl.join(libDir, candidates[0], 'site-packages');
+  }
+
+  function shellPath() {
+    if (platform !== 'darwin' || isDev) return env.PATH || '';
+    const home = homedir();
+    try {
+      const userShell = env.SHELL || '/bin/zsh';
+      const result = execFileSyncImpl(userShell, ['-ilc', 'echo $PATH'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        env: { ...env, HOME: home },
+      });
+      const resolved = result.trim();
+      if (resolved) return resolved;
+    } catch {}
+
+    const systemPaths = [];
+    try {
+      appendLines(systemPaths, fsImpl.readFileSync('/etc/paths', 'utf8'));
+    } catch {}
+    try {
+      const directory = '/etc/paths.d';
+      if (fsImpl.existsSync(directory)) {
+        for (const file of fsImpl.readdirSync(directory).sort()) {
+          appendLines(systemPaths, fsImpl.readFileSync(pathImpl.join(directory, file), 'utf8'));
+        }
+      }
+    } catch {}
+
+    const fallback = [
+      pathImpl.join(home, '.local/bin'),
+      pathImpl.join(home, '.volta/bin'),
+      pathImpl.join(home, '.fnm/aliases/default/bin'),
+      pathImpl.join(home, '.bun/bin'),
+      pathImpl.join(home, '.cargo/bin'),
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+    ];
+    const nvmDir = pathImpl.join(home, '.nvm/versions/node');
+    try {
+      if (fsImpl.existsSync(nvmDir)) {
+        const versions = fsImpl.readdirSync(nvmDir).sort().reverse();
+        if (versions.length) fallback.unshift(pathImpl.join(nvmDir, versions[0], 'bin'));
+      }
+    } catch {}
+
+    const seen = new Set();
+    const resolved = [];
+    for (const directory of [...fallback, ...systemPaths, ...(env.PATH || '').split(':')]) {
+      if (!directory || seen.has(directory)) continue;
+      seen.add(directory);
+      try {
+        if (fsImpl.statSync(directory).isDirectory()) resolved.push(directory);
+      } catch {}
+    }
+    return resolved.join(':');
+  }
+
+  return {
+    resourcePath,
+    projectRoot: () => isPackaged ? resourcesPath : projectDir,
+    pythonExecutable,
+    bundledNodeExecutable,
+    pythonSitePackages,
+    shellPath,
+  };
+}
+
+function appendLines(target, contents) {
+  for (const line of contents.split('\n')) {
+    const entry = line.trim();
+    if (entry) target.push(entry);
+  }
+}
+
+module.exports = { createRuntimePaths };

--- a/electron/runtime-paths.test.js
+++ b/electron/runtime-paths.test.js
@@ -1,0 +1,186 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { createRuntimePaths } = require('./runtime-paths');
+
+function fakeFs({ files = {}, directories = [], listings = {} } = {}) {
+  const dirs = new Set(directories);
+  return {
+    existsSync(target) {
+      return dirs.has(target) || Object.hasOwn(files, target) || Object.hasOwn(listings, target);
+    },
+    readFileSync(target) {
+      if (!Object.hasOwn(files, target)) throw new Error(`missing file: ${target}`);
+      return files[target];
+    },
+    readdirSync(target) {
+      if (!Object.hasOwn(listings, target)) throw new Error(`missing directory: ${target}`);
+      return listings[target];
+    },
+    statSync(target) {
+      if (!dirs.has(target)) throw new Error(`not a directory: ${target}`);
+      return { isDirectory: () => true };
+    },
+  };
+}
+
+function resolver(overrides = {}) {
+  return createRuntimePaths({
+    isPackaged: false,
+    isDev: true,
+    platform: 'linux',
+    arch: 'x64',
+    resourcesPath: '/app/resources',
+    electronDir: '/repo/electron',
+    env: { PATH: '/usr/bin' },
+    homedir: () => '/home/ada',
+    fsImpl: fakeFs(),
+    pathImpl: path.posix,
+    execFileSyncImpl: () => { throw new Error('unexpected shell invocation'); },
+    ...overrides,
+  });
+}
+
+test('resolves development resources, project root, Python, and inherited PATH', () => {
+  const paths = resolver();
+  assert.equal(paths.resourcePath('backend'), '/repo/backend');
+  assert.equal(paths.projectRoot(), '/repo');
+  assert.equal(paths.pythonExecutable(), '/repo/backend/.venv/bin/python3');
+  assert.equal(paths.pythonSitePackages(), null);
+  assert.equal(paths.shellPath(), '/usr/bin');
+});
+
+test('resolves packaged Windows runtime paths', () => {
+  const node = '/app/resources/node/x64/node.exe';
+  const paths = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'win32',
+    fsImpl: fakeFs({ files: { [node]: '' } }),
+  });
+  assert.equal(paths.resourcePath('backend'), '/app/resources/backend');
+  assert.equal(paths.projectRoot(), '/app/resources');
+  assert.equal(paths.pythonExecutable(), '/app/resources/python-env/python.exe');
+  assert.equal(paths.pythonSitePackages(), '/app/resources/python-env/Lib/site-packages');
+  assert.equal(paths.bundledNodeExecutable(), node);
+});
+
+test('resolves the packaged macOS runtime through the Python.app wrapper when it is shipped', () => {
+  const wrapper = '/app/resources/python-env/Python.app/Contents/MacOS/python3';
+  const paths = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'darwin',
+    arch: 'arm64',
+    fsImpl: fakeFs({ files: { [wrapper]: '' }, listings: { '/app/resources/python-env/lib': ['python3.13', 'site.py'] } }),
+  });
+  assert.equal(paths.pythonExecutable(), wrapper);
+  assert.equal(paths.pythonSitePackages(), '/app/resources/python-env/lib/python3.13/site-packages');
+});
+
+test('falls back to the bare python3 binary when the macOS wrapper is missing', () => {
+  const paths = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'darwin',
+    arch: 'arm64',
+    fsImpl: fakeFs({ listings: { '/app/resources/python-env/lib': ['python3.14'] } }),
+  });
+  assert.equal(paths.pythonExecutable(), '/app/resources/python-env/bin/python3');
+  assert.equal(paths.pythonSitePackages(), '/app/resources/python-env/lib/python3.14/site-packages');
+});
+
+test('site-packages follows whichever python3.N the bundled env ships, and fails loud on none or several', () => {
+  const missing = resolver({ isPackaged: true, platform: 'linux', fsImpl: fakeFs() });
+  assert.throws(() => missing.pythonSitePackages(), /Expected exactly one bundled python3\.N lib dir .* found: none/);
+
+  const several = resolver({
+    isPackaged: true,
+    platform: 'linux',
+    fsImpl: fakeFs({ listings: { '/app/resources/python-env/lib': ['python3.13', 'python3.14'] } }),
+  });
+  assert.throws(() => several.pythonSitePackages(), /found: python3\.13, python3\.14/);
+});
+
+test('returns a bundled Node executable only for a shipped supported architecture', () => {
+  const armNode = '/app/resources/node/arm64/bin/node';
+  const packaged = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'darwin',
+    arch: 'arm64',
+    fsImpl: fakeFs({ files: { [armNode]: '' } }),
+  });
+  assert.equal(packaged.bundledNodeExecutable(), armNode);
+  assert.equal(resolver({ arch: 'arm64' }).bundledNodeExecutable(), null);
+  assert.equal(resolver({ isPackaged: true, isDev: false, arch: 'ia32' }).bundledNodeExecutable(), null);
+  assert.equal(resolver({ isPackaged: true, isDev: false, arch: 'x64' }).bundledNodeExecutable(), null);
+});
+
+test('uses the packaged macOS login shell PATH with the expected environment', () => {
+  const calls = [];
+  const paths = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'darwin',
+    env: { PATH: '/usr/bin', SHELL: '/bin/fish', TOKEN: 'kept' },
+    homedir: () => '/Users/ada',
+    execFileSyncImpl(command, args, options) {
+      calls.push({ command, args, options });
+      return ' /opt/homebrew/bin:/usr/bin\n';
+    },
+  });
+
+  assert.equal(paths.shellPath(), '/opt/homebrew/bin:/usr/bin');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, '/bin/fish');
+  assert.deepEqual(calls[0].args, ['-ilc', 'echo $PATH']);
+  assert.equal(calls[0].options.timeout, 5000);
+  assert.equal(calls[0].options.env.HOME, '/Users/ada');
+  assert.equal(calls[0].options.env.TOKEN, 'kept');
+});
+
+test('builds a stable, existing-only macOS fallback PATH when the login shell fails', () => {
+  const files = {
+    '/etc/paths': '/usr/bin\n/bin\n',
+    '/etc/paths.d/a-first': '/opt/tool-a/bin\n',
+    '/etc/paths.d/z-last': '/opt/tool-z/bin\n/usr/bin\n',
+  };
+  const directories = [
+    '/Users/ada/.nvm/versions/node/v22/bin',
+    '/Users/ada/.local/bin',
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/opt/tool-a/bin',
+    '/opt/tool-z/bin',
+    '/usr/bin',
+    '/bin',
+  ];
+  const paths = resolver({
+    isPackaged: true,
+    isDev: false,
+    platform: 'darwin',
+    env: { PATH: '/usr/bin:/bin:/missing' },
+    homedir: () => '/Users/ada',
+    fsImpl: fakeFs({
+      files,
+      directories,
+      listings: {
+        '/etc/paths.d': ['z-last', 'a-first'],
+        '/Users/ada/.nvm/versions/node': ['v20', 'v22'],
+      },
+    }),
+    execFileSyncImpl: () => { throw new Error('shell unavailable'); },
+  });
+
+  assert.equal(paths.shellPath(), [
+    '/Users/ada/.nvm/versions/node/v22/bin',
+    '/Users/ada/.local/bin',
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+    '/opt/tool-a/bin',
+    '/opt/tool-z/bin',
+  ].join(':'));
+});

--- a/frontend/scripts/run-tests.mjs
+++ b/frontend/scripts/run-tests.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Runs every renderer unit test (src/**/*.test.ts, *.test.tsx) under node:test, with tsx doing the
+// TypeScript. One command for CI and for a dev machine: `node scripts/run-tests.mjs`, optionally
+// followed by file paths to run a subset. Exits non-zero if any test fails or nothing was found.
+import { spawnSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const testFile = (p) => /\.test\.tsx?$/.test(p);
+
+function walk(dir, out) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (testFile(p)) out.push(p);
+  }
+  return out;
+}
+
+const files = process.argv.length > 2 ? process.argv.slice(2) : walk(join(root, 'src'), []).sort();
+if (files.length === 0) {
+  console.error('run-tests: no test files found under src/');
+  process.exit(1);
+}
+const result = spawnSync(process.execPath, ['--import', 'tsx', '--test', ...files], { cwd: root, stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/frontend/src/shared/backendConnection.ts
+++ b/frontend/src/shared/backendConnection.ts
@@ -80,4 +80,7 @@ export function noteRequestStalled(): void {
 }
 
 // Harness/debug handle: lets a live session (CDP, support) read the signal without a store import.
-(window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+// Guarded: reducers that import this module also run under node:test, where there is no window.
+if (typeof window !== 'undefined') {
+  (window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+}

--- a/frontend/src/shared/config.ts
+++ b/frontend/src/shared/config.ts
@@ -1,6 +1,9 @@
 import { noteBackendFailure, noteBackendSuccess, noteRequestStalled, setBackendProber } from '@/shared/backendConnection';
 
-const _w = window as any;
+// Import-safe outside a renderer: reducers that import API_BASE also run under node:test, where there
+// is no window. The module then answers with the defaults and installs nothing.
+const hasWindow = typeof window !== 'undefined';
+const _w = (hasWindow ? window : {}) as any;
 // Prefer the preload-injected port; if it's missing (preload raced the backend port being picked), re-query the live value before falling back to 8324. The bare 8324 guess is wrong on any machine where the backend landed on a fallback port (e.g. 8324 was held by a leftover backend); see the self-heal below.
 const port =
   _w.__OPENSWARM_PORT__ ||
@@ -8,7 +11,7 @@ const port =
     ? _w.openswarm.getBackendPortLive()
     : 0) ||
   8324;
-const host = window.location.hostname || 'localhost';
+const host = (hasWindow && window.location.hostname) || 'localhost';
 
 export const API_BASE = `http://${host}:${port}/api`;
 export const WS_BASE = `ws://${host}:${port}`;
@@ -217,5 +220,7 @@ function _installAuthFetchInterceptor() {
   };
 }
 
-_installAuthFetchInterceptor();
-ensureAuthToken();
+if (hasWindow) {
+  _installAuthFetchInterceptor();
+  ensureAuthToken();
+}

--- a/frontend/src/shared/safeMode.ts
+++ b/frontend/src/shared/safeMode.ts
@@ -11,7 +11,10 @@ export interface SafeModeInfo {
 
 let cached: SafeModeInfo = { safeMode: false, dirtyCount: 0, fingerprint: null };
 
-const api = (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
+// Import-safe outside a renderer: the layout slice imports this, and its reducer tests run under node:test.
+const api = typeof window === 'undefined'
+  ? undefined
+  : (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
 if (api?.getSafeMode) {
   void api.getSafeMode().then((info) => {
     if (info && typeof info.safeMode === 'boolean') cached = info;


### PR DESCRIPTION
> **Draft.** Third of three god-file splits (#149 layout slice, #150 AgentChat). Branch sits on #147's tip only for consistency; the change itself touches `electron/` alone, so it does not depend on #147 (the extra commits in the diff disappear once #147 merges). Same ask: a short **freeze on `electron/main.js`** before this leaves draft — you stop touching the file, I rebase and mark ready within the hour, you review/merge, freeze lifts.

`main.js` was 4,259 lines. Five concerns that had grown inside it are now modules with node:test files, and `main.js` keeps the wiring (3,980 lines):

| Module | What it owns |
|---|---|
| `backend-readiness.js` | auth-token path/read, the backend import warm-up, `waitForBackend` (the boot health poll) |
| `boot-telemetry.js` | boot beacon assembly and the phase timings it carries |
| `frontend-server.js` | the loopback http server that serves the packaged renderer bundle |
| `port-manager.js` | backend/frontend port choice (preferred port, then `get-port`'s OS-assigned fallback) |
| `runtime-paths.js` | bundled-node / data / auth-token / python paths that `main.js` previously derived inline |

`runtime-paths.pythonExecutable()` follows `getPythonPath()` exactly (Windows `python.exe`; macOS `Python.app/Contents/MacOS/python3` wrapper when shipped, else `bin/python3`); `pythonSitePackages()` discovers the one `lib/python3.N` the bundled env ships instead of pinning a minor version, and fails loud on none/several.

Two small hardening changes ride along in `startBackend`: `PYTHONNOUSERSITE=1` (the embedded runtime must never import from the host user's roaming Python site-packages) and `PYTHONUNBUFFERED=1`; `getBuildInfo` tolerates a BOM on `build-info.json`.

Proof: `npm test` in `electron/` 77/77; packaged macOS app: upstream smoke 5/5 (paint, preload bridge, backend health, provenance, version) + the characterization suite (#146) 19/19 including the resilience specs (backend crash → respawn → reload).

Not in this PR: a live-shell PTY bridge (native dep, product decision) and the preload additions for it.