### PR TITLE
renderer: split WebSocketManager into per-family event modules; idempotent prompts over the socket

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -48,11 +48,17 @@ jobs:
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
             | tail -1 | tee collected.txt
+      # --timeout: a test that blocks forever (a bare ws.receive_json() waiting for an event that never
+      # comes, say) otherwise stalls the run at 99% until timeout-minutes with no summary and no junit.
+      # With the cap it fails by name, the rest of the suite runs, and the assertion below still holds.
       - name: Run the backend suite
         run: |
           python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --timeout=300 \
             --junitxml "${RUNNER_TEMP}/pytest.xml"
       - name: Every collected test ran
+        # Runs after a red suite too, so a failure report also says whether the run was complete.
+        if: ${{ !cancelled() }}
         run: |
           python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
           import re, sys, xml.etree.ElementTree as ET

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,65 @@
+name: backend-tests
+
+# The backend pytest suite, run on every pull request and on pushes to the mainline branches. Until
+# now nothing ran it in CI, so a regression only surfaced when someone ran it by hand.
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  workflow_dispatch:
+
+# Runs checked-out project code on pull_request: the token stays read-only.
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.lock
+            backend/requirements-dev.txt
+      - name: Install backend deps (locked runtime + dev)
+        run: |
+          python -m pip install --require-hashes --only-binary=:all: -r backend/requirements.lock
+          python -m pip install -r backend/requirements-dev.txt
+      # Two numbers that must agree. A test process that dies mid-run can exit 0 with no summary
+      # (a hard-exit shutdown path did exactly that once and silently skipped ~42% of the suite), so
+      # the job also asserts that every collected test was actually run: junit testcase count ==
+      # collect-only count. Green then means green, not "green as far as it got".
+      - name: Count the suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal --collect-only -q -p no:cacheprovider \
+            | tail -1 | tee collected.txt
+      - name: Run the backend suite
+        run: |
+          python -m pytest backend/tests --ignore=backend/tests/formal -q -p no:cacheprovider \
+            --junitxml "${RUNNER_TEMP}/pytest.xml"
+      - name: Every collected test ran
+        run: |
+          python - "${RUNNER_TEMP}/pytest.xml" collected.txt <<'PY'
+          import re, sys, xml.etree.ElementTree as ET
+          ran = sum(1 for _ in ET.parse(sys.argv[1]).getroot().iter('testcase'))
+          m = re.search(r'(\d+) tests? collected', open(sys.argv[2]).read())
+          collected = int(m.group(1)) if m else -1
+          print(f'collected={collected} ran={ran}')
+          if collected < 1 or ran != collected:
+              sys.exit(f'FAIL: {ran} of {collected} collected tests reached the report; the run was truncated')
+          PY

--- a/.github/workflows/edge-tests.yml
+++ b/.github/workflows/edge-tests.yml
@@ -1,0 +1,44 @@
+name: edge-tests
+
+# The openswarm-edge pytest suite, on every pull request that touches it and on pushes to the
+# mainline branches.
+on:
+  pull_request:
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'openswarm-edge/**'
+      - '.github/workflows/edge-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: edge-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (openswarm-edge)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: openswarm-edge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: openswarm-edge/requirements.txt
+      - name: Install edge deps
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest pytest-asyncio
+      - name: Run the edge suite
+        run: python -m pytest tests -q -p no:cacheprovider

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,43 @@
+name: frontend-tests
+
+# Typecheck plus the renderer's node:test suite, on every pull request and on pushes to the mainline
+# branches. Until now neither ran in CI; the tests were run by hand, one file at a time.
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-and-tests:
+    name: tsc + node:test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.json
+      - name: Unit tests (node:test via tsx)
+        run: node scripts/run-tests.mjs

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,6 +9,9 @@
 
 pytest==8.3.4
 pytest-asyncio==0.25.2
+# Per-test wall-clock cap for CI (see .github/workflows/backend-tests.yml): a test that
+# blocks forever fails by name instead of stalling the whole run until the job cap.
+pytest-timeout==2.4.0
 
 # Used by linter/lint.py (the vulture dead-code check). watchfiles, also
 # needed by lint.py, already comes in transitively via uvicorn[standard].

--- a/backend/tests/test_ws_integration.py
+++ b/backend/tests/test_ws_integration.py
@@ -6,6 +6,8 @@ extracted handlers + the broadcast, which the in-process harness (no server, no 
 The SDK and WS auth are mocked; everything else is the real running stack."""
 
 import asyncio
+import queue
+import threading
 
 import pytest
 
@@ -17,6 +19,29 @@ from fastapi.testclient import TestClient
 import backend.main as main_mod
 from backend.apps.agents.agent_manager import agent_manager
 from backend.apps.agents.core.models import AgentSession
+import backend.apps.agents.manager.run.RunOptions as run_options_mod
+
+
+def p_receive_json(ws, timeout: float = 5.0):
+    """ws.receive_json() blocks forever when the event never comes; a regression in the loop then
+    hangs the whole pytest run instead of failing this test. Bound every receive."""
+    out = queue.Queue(maxsize=1)
+
+    def p_recv():
+        try:
+            out.put((True, ws.receive_json()))
+        except BaseException as exc:
+            out.put((False, exc))
+
+    thread = threading.Thread(target=p_recv, daemon=True)
+    thread.start()
+    try:
+        ok, value = out.get(timeout=timeout)
+    except queue.Empty as exc:
+        raise AssertionError(f"timed out waiting for websocket event after {timeout}s") from exc
+    if ok:
+        return value
+    raise value
 
 
 def p_assistant():
@@ -32,6 +57,20 @@ def p_result():
 
 def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
     monkeypatch.setattr(main_mod, "p_ws_auth_ok", lambda ws: True, raising=True)
+
+    # The contract of this test is "SDK and WS auth mocked, everything else real", but two things on
+    # the turn path reach outside the process and must not decide the outcome: configure_provider_env
+    # can wander into 9Router revival (spawn/npm install, serialized on a module-level lock) whenever
+    # earlier tests left provider evidence behind, and the background turn-label aux call does the
+    # same. Pin both out; the persistent-client path is pinned off suite-wide in conftest.
+    async def p_noop_provider_env(*args, **kwargs):
+        return None
+
+    async def p_noop_turn_label(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(run_options_mod, "configure_provider_env", p_noop_provider_env, raising=True)
+    monkeypatch.setattr(agent_manager, "generate_turn_label", p_noop_turn_label, raising=True)
 
     async def fake_query(*args, **kwargs):
         yield p_assistant()
@@ -49,10 +88,15 @@ def test_ws_endpoint_streams_a_full_turn_end_to_end(monkeypatch):
             ws.send_json({"event": "agent:send_message", "data": {"prompt": "hi"}})
             seen = []
             for _ in range(40):
-                ev = ws.receive_json()
+                ev = p_receive_json(ws)
                 seen.append(ev.get("event"))
-                if ev.get("event") == "agent:message" and "hello from the loop" in str(ev.get("data", {})):
+                if (
+                    ev.get("event") == "agent:status"
+                    and ev.get("data", {}).get("status") == "completed"
+                ):
                     break
+            else:
+                raise AssertionError(f"did not receive completed status; saw events={seen}")
         # the real loop's assistant reply made it all the way back over the WS
         assert "agent:message" in seen
         assert any(m.role == "assistant" and "hello from the loop" in str(m.content)

--- a/frontend/scripts/run-tests.mjs
+++ b/frontend/scripts/run-tests.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Runs every renderer unit test (src/**/*.test.ts, *.test.tsx) under node:test, with tsx doing the
+// TypeScript. One command for CI and for a dev machine: `node scripts/run-tests.mjs`, optionally
+// followed by file paths to run a subset. Exits non-zero if any test fails or nothing was found.
+import { spawnSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const testFile = (p) => /\.test\.tsx?$/.test(p);
+
+function walk(dir, out) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist') continue;
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (testFile(p)) out.push(p);
+  }
+  return out;
+}
+
+const files = process.argv.length > 2 ? process.argv.slice(2) : walk(join(root, 'src'), []).sort();
+if (files.length === 0) {
+  console.error('run-tests: no test files found under src/');
+  process.exit(1);
+}
+const result = spawnSync(process.execPath, ['--import', 'tsx', '--test', ...files], { cwd: root, stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/frontend/src/shared/backendConnection.ts
+++ b/frontend/src/shared/backendConnection.ts
@@ -80,4 +80,7 @@ export function noteRequestStalled(): void {
 }
 
 // Harness/debug handle: lets a live session (CDP, support) read the signal without a store import.
-(window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+// Guarded: reducers that import this module also run under node:test, where there is no window.
+if (typeof window !== 'undefined') {
+  (window as unknown as { __OSW_CONN?: object }).__OSW_CONN = { backendReachable, onBackendReachability };
+}

--- a/frontend/src/shared/config.ts
+++ b/frontend/src/shared/config.ts
@@ -1,6 +1,9 @@
 import { noteBackendFailure, noteBackendSuccess, noteRequestStalled, setBackendProber } from '@/shared/backendConnection';
 
-const _w = window as any;
+// Import-safe outside a renderer: reducers that import API_BASE also run under node:test, where there
+// is no window. The module then answers with the defaults and installs nothing.
+const hasWindow = typeof window !== 'undefined';
+const _w = (hasWindow ? window : {}) as any;
 // Prefer the preload-injected port; if it's missing (preload raced the backend port being picked), re-query the live value before falling back to 8324. The bare 8324 guess is wrong on any machine where the backend landed on a fallback port (e.g. 8324 was held by a leftover backend); see the self-heal below.
 const port =
   _w.__OPENSWARM_PORT__ ||
@@ -8,7 +11,7 @@ const port =
     ? _w.openswarm.getBackendPortLive()
     : 0) ||
   8324;
-const host = window.location.hostname || 'localhost';
+const host = (hasWindow && window.location.hostname) || 'localhost';
 
 export const API_BASE = `http://${host}:${port}/api`;
 export const WS_BASE = `ws://${host}:${port}`;
@@ -217,5 +220,7 @@ function _installAuthFetchInterceptor() {
   };
 }
 
-_installAuthFetchInterceptor();
-ensureAuthToken();
+if (hasWindow) {
+  _installAuthFetchInterceptor();
+  ensureAuthToken();
+}

--- a/frontend/src/shared/safeMode.ts
+++ b/frontend/src/shared/safeMode.ts
@@ -11,7 +11,10 @@ export interface SafeModeInfo {
 
 let cached: SafeModeInfo = { safeMode: false, dirtyCount: 0, fingerprint: null };
 
-const api = (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
+// Import-safe outside a renderer: the layout slice imports this, and its reducer tests run under node:test.
+const api = typeof window === 'undefined'
+  ? undefined
+  : (window as unknown as { openswarm?: { getSafeMode?: () => Promise<SafeModeInfo> } }).openswarm;
 if (api?.getSafeMode) {
   void api.getSafeMode().then((info) => {
     if (info && typeof info.safeMode === 'boolean') cached = info;

--- a/frontend/src/shared/ws/WebSocketManager.test.ts
+++ b/frontend/src/shared/ws/WebSocketManager.test.ts
@@ -1,0 +1,261 @@
+// Run: node --test (via scripts/run-tests.mjs)
+import assert from 'node:assert/strict';
+import { afterEach, before, beforeEach, mock, test } from 'node:test';
+import WebSocketManager from './WebSocketManager';
+import { refreshAuthToken } from '../config';
+import { store } from '../state/store';
+import { updateSession } from '../state/agentsSlice';
+
+// The manager reads the auth token from shared/config; under node there is no preload, so seed the
+// token the way the preload would (window.openswarm.getAuthToken) and let config cache it.
+const realGlobals = {
+  WebSocket: (globalThis as any).WebSocket,
+  fetch: globalThis.fetch,
+  requestAnimationFrame: (globalThis as any).requestAnimationFrame,
+};
+before(async () => {
+  (globalThis as any).window = { openswarm: { getAuthToken: async () => 'unit-token' }, dispatchEvent: () => true };
+  // The incoming-message flush checks for a live card drag on document.body; there is none here.
+  (globalThis as any).document = { body: { classList: { contains: () => false } } };
+  await refreshAuthToken();
+});
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code: 1000 });
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(payload: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+function sentEvents(socket: FakeWebSocket): Array<{ event: string; data: Record<string, unknown> }> {
+  return socket.sent.map((payload) => JSON.parse(payload));
+}
+
+let fetchSpy = mock.fn(async () => new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  (globalThis as any).WebSocket = FakeWebSocket;
+  fetchSpy = mock.fn(async () => new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  (globalThis as any).requestAnimationFrame = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  };
+});
+
+afterEach(() => {
+  (globalThis as any).WebSocket = realGlobals.WebSocket;
+  globalThis.fetch = realGlobals.fetch;
+  (globalThis as any).requestAnimationFrame = realGlobals.requestAnimationFrame;
+  mock.restoreAll();
+});
+
+test('session socket sends tokenized hello and flushes queued frames after server hello', () => {
+  const manager = new WebSocketManager('ws://unit/ws/agents/session-one', { sessionId: 'session-one' });
+  manager.send('agent:stop', { session_id: 'session-one' });
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  assert.equal(socket.url, 'ws://unit/ws/agents/session-one?token=unit-token');
+  assert.deepEqual(socket.sent, []);
+
+  socket.open();
+  assert.equal(fetchSpy.mock.calls.length, 0);
+  let events = sentEvents(socket);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].event, 'client:hello');
+  assert.equal(events[0].data.session_id, 'session-one');
+  assert.equal(events[0].data.last_seq, 0);
+  assert.equal(typeof events[0].data.connection_uuid, 'string');
+
+  socket.receive({ event: 'server:hello', session_id: 'session-one', data: {} });
+  events = sentEvents(socket);
+  assert.equal(events.length, 2);
+  assert.deepEqual(events[1], {
+    event: 'agent:stop',
+    data: { session_id: 'session-one' },
+  });
+
+  manager.disconnect();
+});
+
+test('dashboard socket skips resume and emits reconnect notification after first open', () => {
+  const manager = new WebSocketManager('ws://unit/ws/dashboard', { skipStreamEvents: true });
+  let reconnects = 0;
+  manager.on('dashboard:reconnected', () => { reconnects += 1; });
+  manager.send('dashboard:refresh', { reason: 'test' });
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+  assert.equal(fetchSpy.mock.calls.length, 0);
+
+  let events = sentEvents(socket);
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0], {
+    event: 'dashboard:refresh',
+    data: { reason: 'test' },
+  });
+
+  socket.open();
+  assert.equal(fetchSpy.mock.calls.length, 0);
+  events = sentEvents(socket);
+  assert.equal(events.length, 1);
+  assert.equal(reconnects, 1);
+
+  manager.disconnect();
+});
+
+test('dashboard socket suppresses skipped stream events before custom listeners', () => {
+  const manager = new WebSocketManager('ws://unit/ws/dashboard', { skipStreamEvents: true });
+  const seen: unknown[] = [];
+  manager.on('agent:stream_delta', (payload) => seen.push(payload));
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+  socket.receive({
+    event: 'agent:stream_delta',
+    session_id: 'session-hidden',
+    data: { message_id: 'message-hidden', delta: 'ignored' },
+  });
+
+  assert.deepEqual(seen, []);
+
+  manager.disconnect();
+});
+
+test('custom listeners receive event payloads after built-ins and can unsubscribe', () => {
+  const manager = new WebSocketManager('ws://unit/ws/agents/session-two', { sessionId: 'session-two' });
+  const seen: unknown[] = [];
+  const unsubscribe = manager.on('custom:event', (payload) => seen.push(payload));
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+  socket.receive({ event: 'server:hello', session_id: 'session-two', data: {} });
+  socket.receive({ event: 'custom:event', session_id: 'session-two', data: { value: 42 } });
+
+  assert.deepEqual(seen, [{ session_id: 'session-two', value: 42 }]);
+
+  unsubscribe();
+  socket.receive({ event: 'custom:event', session_id: 'session-two', data: { value: 99 } });
+  assert.deepEqual(seen, [{ session_id: 'session-two', value: 42 }]);
+
+  manager.disconnect();
+});
+
+test('session socket drops replayed stream events until resume ack', () => {
+  const sessionId = 'session-stream-guard';
+  const manager = new WebSocketManager(`ws://unit/ws/agents/${sessionId}`, { sessionId });
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+
+  socket.receive({
+    event: 'agent:stream_start',
+    session_id: sessionId,
+    data: { message_id: 'replayed-message', role: 'assistant' },
+  });
+  assert.equal(store.getState().streaming.bySession[sessionId], undefined);
+
+  socket.receive({ event: 'server:hello', session_id: sessionId, data: {} });
+  socket.receive({
+    event: 'agent:stream_start',
+    session_id: sessionId,
+    data: { message_id: 'live-message', role: 'assistant' },
+  });
+  socket.receive({
+    event: 'agent:stream_delta',
+    session_id: sessionId,
+    data: { message_id: 'live-message', delta: 'hello' },
+  });
+  assert.equal(store.getState().streaming.bySession[sessionId]?.content, 'hello');
+
+  socket.receive({
+    event: 'agent:stream_end',
+    session_id: sessionId,
+    data: { message_id: 'live-message' },
+  });
+  assert.equal(store.getState().streaming.bySession[sessionId], undefined);
+
+  manager.disconnect();
+});
+
+test('agent message events append to an existing session', () => {
+  const sessionId = 'session-message-event';
+  store.dispatch(updateSession({
+    id: sessionId,
+    name: 'Unit Session',
+    status: 'running',
+    provider: 'anthropic',
+    model: 'sonnet',
+    mode: 'agent',
+    created_at: '2026-07-10T00:00:00.000Z',
+    cost_usd: 0,
+    tokens: { input: 0, output: 0 },
+    messages: [],
+    pending_approvals: [],
+    branches: { main: { id: 'main', parent_branch_id: null, fork_point_message_id: null, created_at: '2026-07-10T00:00:00.000Z' } },
+    active_branch_id: 'main',
+    allowed_tools: [],
+    tool_group_meta: {},
+  } as any));
+  const manager = new WebSocketManager(`ws://unit/ws/agents/${sessionId}`, { sessionId });
+
+  manager.connect();
+  const socket = FakeWebSocket.instances[0];
+  socket.open();
+  socket.receive({ event: 'server:hello', session_id: sessionId, data: {} });
+  socket.receive({
+    event: 'agent:message',
+    session_id: sessionId,
+    data: {
+      message: {
+        id: 'message-one',
+        role: 'assistant',
+        content: 'done',
+        timestamp: '2026-07-10T00:00:01.000Z',
+        branch_id: 'main',
+        parent_id: null,
+      },
+    },
+  });
+
+  const session = store.getState().agents.sessions[sessionId];
+  assert.equal(session.messages.length, 1);
+  assert.equal(session.messages[0].content, 'done');
+
+  manager.disconnect();
+});

--- a/frontend/src/shared/ws/WebSocketManager.ts
+++ b/frontend/src/shared/ws/WebSocketManager.ts
@@ -1,43 +1,20 @@
 import { store } from '../state/store';
 import { unstable_batchedUpdates } from 'react-dom';
-import {
-  updateSession,
-  updateSessionName,
-  updateGroupMeta,
-  addMessage,
-  addApprovalRequest,
-  removeApprovalRequest,
-  updateSessionStatus,
-  setSessionTestState,
-  updateSessionCost,
-  updateSessionContext,
-  setContextOverflow,
-  setRateLimited,
-  setProviderRetrying,
-  setContextRecovered,
-  setAppDepsChanged,
-  setMcpSuggestions,
-  addBranch,
-  setActiveBranch,
-  closeSessionFromWs,
-  trackAgentNotification,
-  setSessionConnState,
-  fetchSession,
-  recordCompaction,
-  setTurnLabel,
-  setQueued,
-  clearTurnLabel,
-} from '../state/agentsSlice';
-import { streamStart, streamDelta, streamEnd, clearStreamingForSession } from '../state/streamingSlice';
-import { addBrowserCardFromBackend, setBrowserDocked, markBrowserCardEnding, keepBrowserCardOpen, placeBesideCard, placeBelowCard, placeBrowserBesideChat, setBrowserCardPosition, setGlowingBrowserCards, fadeGlowingBrowserCards, clearGlowingBrowserCards, removeBrowserCard, GRID_GAP, WORKFLOW_CARD_GAP, openWorkflowsApp, openWorkflowMonitor } from '../state/dashboardLayoutSlice';
-import { upsertOutput } from '../state/outputsSlice';
-import { setCardPosition } from '../state/dashboardLayoutSlice';
-import { fetchSettings } from '../state/settingsSlice';
-import { displaySessionName } from '../state/sessionDisplay';
-import { upsertRun, ackRun, runWorkflowNow, openWorkflowCard, upsertWorkflow, removeWorkflow } from '../state/workflowsSlice';
+import { setSessionConnState, fetchSession } from '../state/agentsSlice';
+import { streamDelta } from '../state/streamingSlice';
+import { openWorkflowsApp } from '../state/dashboardLayoutSlice';
+import { ackRun, runWorkflowNow } from '../state/workflowsSlice';
 import { stepsSignature } from '@/app/pages/Workflows/scheduleUtils';
 import { getAuthToken } from '../config';
-import { notifyAgentCompletion, notifyWorkflowRun } from '../notifications';
+import { handleWsEvent } from './eventHandlers';
+import { genUuid } from './ids';
+import { clearSessionLastSeq, getSessionLastSeq, seedSessionSeq, setSessionLastSeq } from './resumeState';
+export { seedSessionSeq };
+import type { QueuedFrame, WSEvent, WSManagerOptions } from './types';
+
+// (session_id:seq) -> arrival time; entries older than the window are prunable. Bounded by event rate x window, not session count.
+const FRAME_DEDUPE_WINDOW_MS = 5_000;
+const _recentFrameTimes: Map<string, number> = new Map();
 
 // Phase 0 boot instrumentation: one-shot flag so we report the first streamed agent token to Electron main exactly once per app launch. Module scope (not instance) because multiple WebSocketManagers exist (one per session WS).
 let firstAgentResponseMarked = false;
@@ -47,41 +24,9 @@ const _getAuthTokenSafe = (): string => {
   try { return getAuthToken() || ''; } catch { return ''; }
 };
 
-
-const _genUuid = (): string => {
-  // Avoid pulling in `crypto.randomUUID` for compat, this is a disambiguator, not a security boundary, so a 96-bit hex string is plenty.
-  const a = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
-  const b = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
-  const c = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
-  return `${a}${b}${c}`;
-};
-
-type WSEvent = {
-  event: string;
-  session_id?: string;
-  data: Record<string, any>;
-  seq?: number;
-};
-
-interface WSManagerOptions {
-  skipStreamEvents?: boolean;
-  // Session-scoped WSes opt into resume + connection-state dispatches by passing this. Dashboard WS doesn't.
-  sessionId?: string;
-}
-
 // Heartbeat tuning. 25s is below typical aggressive NAT idle timeouts (some enterprise firewalls drop after 30s of silence), and well below browser-tab background throttling thresholds. 10s pong timeout is a balance: long enough to tolerate flaky cellular RTT spikes, short enough that a real dead socket reconnects fast.
 const HEARTBEAT_INTERVAL_MS = 25_000;
 const HEARTBEAT_TIMEOUT_MS = 10_000;
-
-// Manual runs whose monitor card we've already popped open, so the repeated "workflow:run" updates that stream during a run don't re-pin or re-stack the card.
-const autoOpenedRunIds = new Set<string>();
-
-interface QueuedFrame {
-  event: string;
-  data: Record<string, any>;
-  // Lets the future server-side dedup index match retries to originals. Today the server treats most events idempotently anyway (stop on stopped is a no-op), but the client sends this forward-compatibly so a future server upgrade is safe without a protocol bump.
-  client_msg_id: string;
-}
 
 class WebSocketManager {
   private ws: WebSocket | null = null;
@@ -164,10 +109,10 @@ class WebSocketManager {
     this.url = url;
     this.skipStreamEvents = options?.skipStreamEvents ?? false;
     this.sessionId = options?.sessionId ?? null;
-    this.connectionUuid = _genUuid();
+    this.connectionUuid = genUuid();
     // Seed lastSeq from the cross-mount persistent map so a fresh manager (created on every AgentChat remount via key={session.id}) doesn't ask the server to replay events the previous manager already saw. This is the architectural fix for "completed chats re-type themselves on reopen": the server's resume protocol now sees a real high-water mark and has nothing to replay.
     if (this.sessionId) {
-      this.lastSeq = _sessionLastSeq.get(this.sessionId) ?? 0;
+      this.lastSeq = getSessionLastSeq(this.sessionId);
     }
   }
 
@@ -294,7 +239,7 @@ class WebSocketManager {
 
   private sendPing() {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
-    const nonce = _genUuid();
+    const nonce = genUuid();
     try {
       this.ws.send(JSON.stringify({ event: 'client:ping', data: { nonce } }));
     } catch {
@@ -345,7 +290,7 @@ class WebSocketManager {
       this.lastSeq = msg.seq;
       // Mirror to the module-scope persistent map so the next fresh manager (next AgentChat remount) starts here, not at zero.
       if (this.sessionId) {
-        _sessionLastSeq.set(this.sessionId, this.lastSeq);
+        setSessionLastSeq(this.sessionId, this.lastSeq);
       }
     }
 
@@ -389,7 +334,7 @@ class WebSocketManager {
         store.dispatch(fetchSession(session_id));
         // Reset lastSeq, the REST refetch is the new authoritative baseline; subsequent server events with seq numbers will re-establish the high-water mark. Also wipe the cross-mount persistent map so a remount during this gap window doesn't resurrect the stale value.
         this.lastSeq = 0;
-        _sessionLastSeq.delete(session_id);
+        clearSessionLastSeq(session_id);
         // The recovery replay re-delivers seqs possibly seen moments ago; drop them from the dedupe window so it's never starved.
         for (const k of _recentFrameTimes.keys()) {
           if (k.startsWith(`${session_id}:`)) _recentFrameTimes.delete(k);
@@ -398,526 +343,12 @@ class WebSocketManager {
       return;
     }
 
-    if (this.skipStreamEvents) {
-      if (event === 'agent:stream_start' || event === 'agent:stream_delta' || event === 'agent:stream_end') {
-        return;
-      }
-    }
-
-    switch (event) {
-      case 'agent:test_state':
-        // broadcast_global puts everything under data (no top-level session_id).
-        if (data.session_id && data.state) {
-          store.dispatch(setSessionTestState({ sessionId: data.session_id, state: data.state }));
-        }
-        break;
-
-      case 'agent:status':
-        // Capture pre-transition status so we only fire a system notification on a real running→terminal transition. Otherwise a session that was already 'completed' on disk and got refetched would re-toast.
-        {
-          const prevSession = session_id ? store.getState().agents.sessions[session_id] : undefined;
-          const prevStatus = prevSession?.status;
-
-          if (data.session) {
-            store.dispatch(updateSession(data.session));
-          } else if (session_id) {
-            store.dispatch(updateSessionStatus({ sessionId: session_id, status: data.status }));
-          }
-          if (data.status === 'running' && session_id) {
-            store.dispatch(trackAgentNotification(session_id));
-          }
-          // Native OS notification when an agent finishes while the user is elsewhere: workflows already had this; long chat tasks deserve the same "it's done" tap on both platforms. Sub-agents stay silent (their parent's finish is the story).
-          if (data.status === 'completed' && session_id && document.hidden) {
-            const p_sess2 = data.session ?? store.getState().agents.sessions[session_id];
-            if (p_sess2 && !p_sess2.parent_session_id && p_sess2.mode !== 'browser-agent') {
-              void (window as any).openswarm?.notify?.({
-                title: 'Agent finished',
-                body: (p_sess2.name && p_sess2.name !== 'Untitled' ? p_sess2.name : 'Your task is done.').slice(0, 200),
-                deepLink: `openswarm://session/${session_id}`,
-              });
-            }
-          }
-
-          // An AppAgent driving an app card announces itself only via this status event (no card_added like browsers), so light the app card here. Keyed by the parent chat like browser glows, so the same terminal fade below clears it.
-          const p_sess = data.session;
-          if (p_sess && p_sess.mode === 'browser-agent' && typeof p_sess.browser_id === 'string' && p_sess.browser_id.startsWith('app:')
-              && (p_sess.status === 'running' || p_sess.status === 'waiting_approval')) {
-            store.dispatch(setGlowingBrowserCards({
-              browserIds: [p_sess.browser_id],
-              sessionId: p_sess.parent_session_id || p_sess.id,
-              label: 'Use App',
-            }));
-          }
-
-          // Fade this session's browser glows on the terminal transition HERE, not only in AgentChat's effect: a collapsed chat is unmounted at finish, and a never-faded glow pins the browser's renderer (exempt from suspend + the webview cap) forever.
-          const newStatus = data.status ?? data.session?.status;
-          const wasWorking = prevStatus === 'running' || prevStatus === 'waiting_approval';
-          if (session_id && wasWorking && (newStatus === 'completed' || newStatus === 'stopped' || newStatus === 'error')) {
-            store.dispatch(fadeGlowingBrowserCards(session_id));
-            setTimeout(() => store.dispatch(clearGlowingBrowserCards(session_id)), 600);
-          }
-
-          // Fire a native notification when an agent terminates while the window is hidden. Skips sub-agents and browser-agents (the parent's own completion is what the user cares about) and only fires on a real transition from a non-terminal state.
-          const TERMINAL = new Set(['completed', 'error']);
-          const NON_TERMINAL = new Set(['running', 'waiting_approval', undefined, null, '']);
-          if (
-            session_id &&
-            TERMINAL.has(data.status) &&
-            NON_TERMINAL.has(prevStatus as any) &&
-            data.session?.mode !== 'browser-agent' &&
-            data.session?.mode !== 'sub-agent' &&
-            data.session?.mode !== 'invoked-agent'
-          ) {
-            const sess = data.session ?? prevSession;
-            if (sess) {
-              const lastAssistant = [...(sess.messages || [])]
-                .reverse()
-                .find((m: any) => m.role === 'assistant' && typeof m.content === 'string');
-              notifyAgentCompletion({
-                sessionId: session_id,
-                sessionName: displaySessionName(sess.name),
-                dashboardId: sess.dashboard_id,
-                status: data.status as 'completed' | 'error',
-                bodyExcerpt: lastAssistant ? String(lastAssistant.content) : undefined,
-              });
-            }
-          }
-
-          // Clear any leftover turn label when the agent reaches a terminal state so the next turn doesn't show a stale label before its own aux call lands.
-          if (session_id && (data.status === 'completed' || data.status === 'error' || data.status === 'stopped')) {
-            store.dispatch(clearTurnLabel(session_id));
-            // Mid-stream stop: the backend keeps the partial reply, but cancelling the SDK can lag several seconds, so its authoritative agent:message lands late. Promote the in-flight assistant text to a real message NOW so it doesn't blink out the instant we clear the overlay; the late agent:message (same id) just refreshes it.
-            if (data.status === 'stopped') {
-              const entry = store.getState().streaming.bySession[session_id];
-              if (entry && entry.role === 'assistant' && entry.content) {
-                const sess = store.getState().agents.sessions[session_id];
-                if (!sess?.messages?.some((m) => m.id === entry.id)) {
-                  store.dispatch(addMessage({
-                    sessionId: session_id,
-                    message: {
-                      id: entry.id,
-                      role: 'assistant',
-                      content: entry.content,
-                      timestamp: new Date().toISOString(),
-                      branch_id: sess?.active_branch_id ?? 'main',
-                      parent_id: null,
-                    },
-                  }));
-                }
-              }
-            }
-            store.dispatch(clearStreamingForSession(session_id));
-          }
-        }
-        // Clean spawned browser cards when the PARENT finishes, never per sub-agent: the parent reuses the same browser_id for its next step, so deleting on sub-agent completion strands BrowserAgent(browser_id) on a dead card. 'stopped' skipped to allow inspect-after-manual-stop. Mark the card as ending instead of removing immediately so the card shows a fade + Keep pill; BrowserCard owns the 3s timer to remove.
-        if (
-          session_id &&
-          (data.status === 'completed' || data.status === 'error') &&
-          data.session?.mode !== 'browser-agent'
-        ) {
-          const browserCards = store.getState().dashboardLayout.browserCards;
-          for (const card of Object.values(browserCards)) {
-            if (card.spawned_by === session_id && !card.keep_open) {
-              store.dispatch(markBrowserCardEnding({
-                browserId: card.browser_id, status: data.status,
-              }));
-            }
-          }
-        }
-        break;
-
-      case 'agent:message':
-        if (session_id && data.message) {
-          store.dispatch(addMessage({ sessionId: session_id, message: data.message }));
-        }
-        break;
-
-      case 'agent:output_upserted':
-        // Emitted by the backend when an Output row is created (canvas-launched App Builder seed) or updated (post-session meta.json sync). The upsert reducer merges over an existing row so a UI that already loaded the row doesn't lose locally-applied fields.
-        if (data.output && data.output.id) {
-          store.dispatch(upsertOutput(data.output));
-        }
-        break;
-
-      case 'apps_sdk:tool_grant_request':
-        // An app asked to use a connected MCP tool; AppToolGrantHost (global mount) owns the dialog.
-        window.dispatchEvent(new CustomEvent('openswarm:app-tool-grant', { detail: data }));
-        break;
-
-      case 'apps_sdk:place_agent_card': {
-        // An app asked for its spawned agent at a specific canvas spot; the card is created async
-        // by the session lifecycle, so nudge it into place with a short bounded retry.
-        const sid = data.session_id as string;
-        const px = Number(data.x);
-        const py = Number(data.y);
-        if (!sid || !Number.isFinite(px) || !Number.isFinite(py)) break;
-        let tries = 0;
-        const place = () => {
-          const exists = !!store.getState().dashboardLayout.cards[sid];
-          if (exists) {
-            store.dispatch(setCardPosition({ sessionId: sid, x: px, y: py }));
-            return;
-          }
-          if (++tries < 20) setTimeout(place, 300);
-        };
-        place();
-        break;
-      }
-
-      case 'agent:stream_start':
-      case 'agent:stream_delta':
-      case 'agent:stream_end':
-        // Replay-skip guard. The WS resume protocol replays buffered events from the ring buffer with seq > last_seq. When this manager is freshly constructed (every AgentChat mount, because of `key={session.id}`), last_seq is 0, so the server replays EVERY buffered stream_* event for the session. Without this guard, opening any chat with prior streaming turns would replay every buffered delta as a live stream event, re-triggering the streaming UI on every reopen. The discriminator is `resumeAcked`: it flips to true when server:hello arrives, which the server sends AFTER the replay completes. Any stream_* event arriving while !resumeAcked is replay-from-buffer (historical) and can be dropped, the REST snapshot we awaited before connect is authoritative for any already-finalized message, and any genuinely live turn the server is pushing will continue emitting events after the ack.
-        if (!this.resumeAcked) break;
-        if (event === 'agent:stream_start') {
-          if (session_id && data.message_id) {
-            store.dispatch(streamStart({
-              sessionId: session_id,
-              messageId: data.message_id,
-              role: data.role,
-              toolName: data.tool_name,
-            }));
-          }
-        } else if (event === 'agent:stream_delta') {
-          if (session_id && data.message_id) {
-            this.dispatchDelta(session_id, data.message_id, data.delta);
-          }
-        } else if (event === 'agent:stream_end') {
-          if (session_id && data.message_id) {
-            store.dispatch(streamEnd({
-              sessionId: session_id,
-              messageId: data.message_id,
-            }));
-          }
-        }
-        break;
-
-      case 'agent:approval_request':
-        if (session_id) {
-          store.dispatch(addApprovalRequest({
-            sessionId: session_id,
-            request: {
-              id: data.request_id,
-              session_id: session_id,
-              tool_name: data.tool_name,
-              tool_input: data.tool_input,
-              created_at: new Date().toISOString(),
-              sensitive_pattern: data.sensitive_pattern ?? null,
-              sensitive_label: data.sensitive_label ?? null,
-              sensitive_why: data.sensitive_why ?? null,
-            },
-          }));
-        }
-        break;
-
-      case 'agent:cost_update':
-        if (session_id) {
-          store.dispatch(updateSessionCost({
-            sessionId: session_id,
-            costUsd: data.cost_usd,
-          }));
-        }
-        break;
-
-      case 'agent:context_update':
-        if (session_id) {
-          store.dispatch(updateSessionContext({
-            sessionId: session_id,
-            inputTokens: data.input_tokens ?? 0,
-            outputTokens: data.output_tokens ?? 0,
-            cacheReadTokens: data.cache_read_tokens ?? 0,
-            cacheReadPct: data.cache_read_pct ?? 0,
-            ctxUsedPct: data.ctx_used_pct ?? 0,
-            contextWindow: typeof data.context_window === 'number' ? data.context_window : undefined,
-            frameworkOverheadTokens: typeof data.framework_overhead_tokens === 'number' ? data.framework_overhead_tokens : undefined,
-            activeMcps: Array.isArray(data.active_mcps) ? data.active_mcps : [],
-          }));
-        }
-        break;
-
-      case 'agent:context_overflow':
-        if (session_id) {
-          store.dispatch(setContextOverflow({
-            sessionId: session_id,
-            reason: data.reason ?? 'long_context_required',
-            message: data.message ?? 'Context full.',
-          }));
-        }
-        break;
-
-      case 'agent:provider_retrying':
-        // Mid-turn CLI backoff: the provider 500/429'd and the CLI is silently waiting; show the muted pill so the card doesn't read as dead (ENG-178).
-        if (session_id) {
-          store.dispatch(setProviderRetrying({
-            sessionId: session_id,
-            attempt: typeof data.attempt === 'number' ? data.attempt : null,
-            delayMs: typeof data.delay_ms === 'number' ? data.delay_ms : null,
-          }));
-        }
-        break;
-
-      case 'agent:rate_limited':
-        // Provider throttle that outlasted the silent backoff. Transient muted pill, not a card; auto-clears frontend-side.
-        if (session_id) {
-          store.dispatch(setRateLimited({
-            sessionId: session_id,
-            retryAfterS: typeof data.retry_after_s === 'number' ? data.retry_after_s : null,
-          }));
-        }
-        break;
-
-      case 'agent:context_recovered':
-        // The backend hit a context-overflow crash mid-turn, rebuilt from its local copy, and retried on its own. Transient muted pill so the recovery is visible without reading like an error.
-        if (session_id) {
-          store.dispatch(setContextRecovered({ sessionId: session_id }));
-        }
-        break;
-
-      case 'agent:app_deps_changed':
-        // A view-builder agent installed/changed deps this turn; the app card escalates its turn-finish reload from soft to a Vite restart so new deps actually load.
-        if (session_id) {
-          store.dispatch(setAppDepsChanged({ sessionId: session_id }));
-        }
-        break;
-
-      case 'agent:context_status':
-        // Auto-compaction collapsed older turns into a summary. Mirror compacted_through_msg_id locally so the renderer can drop a visible "N earlier turns summarized" chip into the transcript. Other reasons (cleared, etc.) flow through this same event but don't currently need a chip, ignore them for now.
-        if (session_id && data.reason === 'compacted') {
-          store.dispatch(recordCompaction({
-            sessionId: session_id,
-            throughMsgId: data.compacted_through_msg_id ?? null,
-          }));
-        }
-        break;
-
-      case 'agent:turn_label':
-        // Aux-LLM-generated verb-phrase for the current turn. Replaces the static "Thinking…" label until the turn ends, then the ThinkingBubble freezes to "Thought for Ns · M tokens".
-        if (session_id && data.label) {
-          store.dispatch(setTurnLabel({
-            sessionId: session_id,
-            turnId: data.turn_id || '',
-            label: data.label,
-          }));
-        }
-        break;
-
-      case 'agent:queued':
-        // Admission gate: this turn is waiting for a concurrency slot; shows a "queued" chip so it doesn't read as a hung "working".
-        if (session_id) store.dispatch(setQueued({ sessionId: session_id, queued: true }));
-        break;
-
-      case 'agent:admitted':
-        // Slot acquired; the turn is about to stream. Clears the queued chip.
-        if (session_id) store.dispatch(setQueued({ sessionId: session_id, queued: false }));
-        break;
-
-      case 'agent:auth_error':
-        // Re-uses the context_overflow card slot, both are "this session is blocked, here's what to do" cards. Reason field disambiguates.
-        if (session_id) {
-          store.dispatch(setContextOverflow({
-            sessionId: session_id,
-            reason: data.reason ?? 'auth_error',
-            message: data.message ?? 'Authentication failed.',
-          }));
-        }
-        break;
-
-      case 'agent:out_of_tokens':
-        // Reuses the context_overflow card slot, same "this session is blocked, here's what to do" shape. Reason field disambiguates from auth/overflow.
-        if (session_id) {
-          store.dispatch(setContextOverflow({
-            sessionId: session_id,
-            reason: 'out_of_tokens',
-            message: data.message ?? "You're out of tokens on this model.",
-          }));
-        }
-        break;
-
-      case 'agent:mcp_suggestions':
-        if (session_id) {
-          store.dispatch(setMcpSuggestions({
-            sessionId: session_id,
-            suggestions: Array.isArray(data.suggestions) ? data.suggestions : [],
-            isVague: !!data.is_vague,
-          }));
-        }
-        break;
-
-      case 'agent:branch_created':
-        if (session_id && data.branch) {
-          store.dispatch(addBranch({ sessionId: session_id, branch: data.branch }));
-          store.dispatch(setActiveBranch({ sessionId: session_id, branchId: data.active_branch_id }));
-        }
-        break;
-
-      case 'agent:branch_switched':
-        if (session_id) {
-          store.dispatch(setActiveBranch({ sessionId: session_id, branchId: data.active_branch_id }));
-        }
-        break;
-
-      case 'agent:name_updated':
-        if (session_id && data.name) {
-          store.dispatch(updateSessionName({ sessionId: session_id, name: data.name }));
-        }
-        break;
-
-      case 'agent:group_meta_updated':
-        if (session_id && data.group_id) {
-          store.dispatch(updateGroupMeta({
-            sessionId: session_id,
-            groupId: data.group_id,
-            name: data.name ?? '',
-            svg: data.svg ?? '',
-            isRefined: data.is_refined ?? false,
-          }));
-        }
-        break;
-
-      case 'agent:closed':
-        if (session_id) {
-          const closedStatus = data.status ?? 'stopped';
-          // Don't evict a chat the user is actively watching from a workflow card; let it settle into a normal completed chat they can continue or close themselves.
-          const watchedSidecar = Object.values(store.getState().workflows.openCards)
-            .some((oc) => oc.sidecarSessionId === session_id);
-          // The Run Monitor watches a run via its workflow id, not a sidecar: keep that run's session so the transcript survives completion.
-          const monWf = store.getState().dashboardLayout.workflowsMonitorId;
-          const watchedByMonitor = !!monWf
-            && (store.getState().workflows.runs[monWf] || []).some((r) => r.session_id === session_id);
-          store.dispatch(closeSessionFromWs({
-            id: session_id,
-            name: data.name ?? 'Untitled',
-            status: closedStatus,
-            model: data.model ?? '',
-            mode: data.mode ?? '',
-            created_at: data.created_at ?? new Date().toISOString(),
-            closed_at: data.closed_at ?? new Date().toISOString(),
-            cost_usd: data.cost_usd ?? 0,
-            dashboard_id: data.dashboard_id,
-            keepSession: watchedSidecar || watchedByMonitor,
-          }));
-          // Auto-delete browsers spawned by this agent when it finishes normally or errors out. We intentionally skip 'stopped', the user may want to inspect the browser after manually stopping. Mark for removal so BrowserCard renders a fade + Keep pill; the card itself runs the 3s timer to dispatch removeBrowserCard.
-          if (closedStatus === 'completed' || closedStatus === 'error') {
-            const browserCards = store.getState().dashboardLayout.browserCards;
-            for (const card of Object.values(browserCards)) {
-              if (card.spawned_by === session_id && !card.keep_open) {
-                store.dispatch(markBrowserCardEnding({
-                  browserId: card.browser_id, status: closedStatus,
-                }));
-              }
-            }
-          }
-        }
-        break;
-
-      case 'workflow:run':
-        if (data.run) {
-          const run = data.run;
-          store.dispatch(upsertRun(run));
-          // A manual run (the Run button OR the edit agent's RunWorkflowNow) should surface its live card the moment it starts. Fire once per run so the run's later tool-call updates don't keep re-pinning the monitor; scheduled runs stay quiet so they never hijack the canvas.
-          if (run.status === 'running' && run.triggered_by === 'manual' && run.id && !autoOpenedRunIds.has(run.id)) {
-            autoOpenedRunIds.add(run.id);
-            store.dispatch(openWorkflowMonitor({ workflowId: run.workflow_id, runId: run.id }));
-          }
-        }
-        break;
-
-      case 'workflow:updated':
-        if (data.workflow) {
-          store.dispatch(upsertWorkflow(data.workflow));
-        }
-        break;
-
-      case 'workflow:deleted':
-        if (data.workflow_id) {
-          store.dispatch(removeWorkflow(data.workflow_id));
-        }
-        break;
-
-      case 'workflow:notify':
-        if (data.workflow_id) {
-          notifyWorkflowRun({
-            workflowId: data.workflow_id,
-            workflowTitle: data.workflow_title || 'Workflow',
-            runId: data.run_id,
-            sessionId: data.session_id,
-            status: data.status,
-            tierKind: data.tier_kind,
-            fallback: data.fallback,
-          });
-        }
-        break;
-
-      case 'dashboard:browser_card_keep':
-        if (data.browser_id) {
-          store.dispatch(keepBrowserCardOpen(data.browser_id));
-        }
-        break;
-
-      case 'dashboard:browser_card_evict':
-        // A wedged card the backend is tearing down BEFORE it spawns a recovery card. Remove it now (no fade, no Keep pill) so its <webview> unmounts and stops starving the renderer while the fresh card mounts.
-        if (data.browser_id) {
-          store.dispatch(removeBrowserCard(data.browser_id));
-        }
-        break;
-
-      case 'dashboard:browser_card_added':
-        if (data.browser_card) {
-          // Tag with origin dashboard so the card renders only on the dashboard that spawned it, without this, a browser spawned by an agent on dashboard A leaks into whatever dashboard the user is currently viewing (the global browserCards dict + unfiltered render).
-          store.dispatch(addBrowserCardFromBackend({
-            ...data.browser_card,
-            dashboard_id: data.dashboard_id,
-          }));
-          const parentId = data.parent_session_id;
-          if (parentId) {
-            const layoutState = store.getState().dashboardLayout;
-            const browserCard = layoutState.browserCards[data.browser_card.browser_id];
-            if (browserCard) {
-              const exclude = { type: 'browser' as const, id: browserCard.browser_id };
-              const parentCard = layoutState.cards[parentId];
-              // Workflow chats have no standalone agent card: a run lives in the monitor (dock beside it), an edit/compose chat lives in the hub window (dock below it). Without this the browser keeps the backend's default spot, which overlaps the Workflows window.
-              const sess = store.getState().agents.sessions[parentId];
-              let pos: { x: number; y: number } | null = null;
-              let glowLabel = 'Use Browser';
-              if (parentCard) {
-                pos = placeBrowserBesideChat(layoutState, parentCard, parentId, browserCard.width, browserCard.height, browserCard.browser_id);
-                // A replacement browser buries its predecessor: the agent spins a fresh card when a tab dies, and the displaced spawned sibling must be torn down through the FULL path (a bare store delete gets resurrected by the backend layout sync as a free stacked window).
-                for (const old of Object.values(layoutState.browserCards)) {
-                  if (old.browser_id !== browserCard.browser_id && old.spawned_by === parentId && !old.keep_open) {
-                    void import('@/shared/browserTeardown').then(({ removeBrowserCardCleanly }) => removeBrowserCardCleanly(old.browser_id, store.dispatch));
-                  }
-                }
-                // Default home is INSIDE the chat: the card overlays the chat's dock slot while the
-                // chat is expanded; the beside-chat spot stays the undock/collapse fallback.
-                store.dispatch(setBrowserDocked({ browserId: browserCard.browser_id, dockedTo: parentId }));
-              } else if (sess?.workflow_run_id && layoutState.workflowsMonitorCard) {
-                pos = placeBesideCard(layoutState, layoutState.workflowsMonitorCard, browserCard.width, browserCard.height, undefined, exclude, WORKFLOW_CARD_GAP, true);
-              } else if (sess?.workflow_edit_id && layoutState.workflowsHub) {
-                pos = placeBelowCard(layoutState, layoutState.workflowsHub, browserCard.width, browserCard.height, undefined, exclude);
-                glowLabel = 'Browser';
-              }
-              if (pos) {
-                store.dispatch(setBrowserCardPosition({
-                  browserId: data.browser_card.browser_id,
-                  x: pos.x,
-                  y: pos.y,
-                }));
-                store.dispatch(setGlowingBrowserCards({
-                  browserIds: [data.browser_card.browser_id],
-                  sessionId: parentId,
-                  label: glowLabel,
-                }));
-              }
-            }
-          }
-        }
-        break;
-
-      case 'settings:changed':
-        // An agent wrote settings under us (not the user via the modal), so refetch now instead of waiting for the next window-focus. The slice's latestWriteId guard drops this if a newer user save is already in flight.
-        store.dispatch(fetchSettings());
-        break;
-    }
+    const notifyListeners = handleWsEvent(msg, {
+      resumeAcked: this.resumeAcked,
+      skipStreamEvents: this.skipStreamEvents,
+      dispatchDelta: (sessionId, messageId, delta) => this.dispatchDelta(sessionId, messageId, delta),
+    });
+    if (!notifyListeners) return;
 
     // Notify any custom listeners
     const handlers = this.listeners.get(event);
@@ -930,13 +361,13 @@ class WebSocketManager {
     // Queue if the socket isn't open OR resume hasn't been ack'd yet. The pre-ack gate prevents an outbound user message from racing the resume replay, the server might process the message before the replay finishes, leaving the slice's view of history incomplete.
     const open = this.ws?.readyState === WebSocket.OPEN;
     if (!open || !this.resumeAcked) {
-      this.outboundQueue.push({ event, data, client_msg_id: _genUuid() });
+      this.outboundQueue.push({ event, data, client_msg_id: genUuid() });
       return;
     }
     try {
       this.ws!.send(JSON.stringify({ event, data }));
     } catch {
-      this.outboundQueue.push({ event, data, client_msg_id: _genUuid() });
+      this.outboundQueue.push({ event, data, client_msg_id: genUuid() });
     }
   }
 
@@ -948,6 +379,7 @@ class WebSocketManager {
     this.send('agent:send_message', {
       session_id: sessionId,
       prompt,
+      idempotency_key: genUuid(),
       ...opts,
     });
   }
@@ -1004,20 +436,6 @@ import { WS_BASE } from '@/shared/config';
 })();
 
 export const dashboardWs = new WebSocketManager(`${WS_BASE}/ws/dashboard`, { skipStreamEvents: true });
-
-// Per-session high-water mark for the resume protocol. Survives across AgentChat mounts/unmounts so reopening a chat doesn't re-trigger a full replay from the server's ring buffer. Why this exists: AgentChat uses `key={session.id}` on the embedded instance inside AgentCard, so every expand/collapse remounts the component, which constructs a fresh WebSocketManager. Without this persistent map, each fresh manager starts at last_seq=0 and asks the server for the entire buffered history. The server faithfully replays it, the client renders the typewriter animation again, and the user sees their completed chat "type itself out" on every reopen. Lifetime: tied to the JS module load, which means the page tab. Lost on full app reload (intentional, that should re-hydrate from REST). On backend restart the buffers are wiped anyway, so a stale lastSeq pointing past the buffer top falls into the "fresh client" path on the server (last_seq>0 but no buffer) which short-circuits to a no-op replay. Safe.
-const _sessionLastSeq: Map<string, number> = new Map();
-
-// (session_id:seq) -> arrival time; entries older than the window are prunable. Bounded by event rate x window, not session count.
-const FRAME_DEDUPE_WINDOW_MS = 5_000;
-const _recentFrameTimes: Map<string, number> = new Map();
-
-/** Seed the resume cursor from a REST hydrate (GET /sessions returns event_seq), so the follow-up WS connect replays only what happened AFTER the snapshot instead of the whole ring buffer the client just received as JSON. Never lowers an existing high-water mark. */
-export function seedSessionSeq(sessionId: string, seq: number): void {
-  if (typeof seq !== 'number' || seq <= 0) return;
-  const cur = _sessionLastSeq.get(sessionId) ?? 0;
-  if (seq > cur) _sessionLastSeq.set(sessionId, seq);
-}
 
 export function createSessionWs(sessionId: string): WebSocketManager {
   return new WebSocketManager(`${WS_BASE}/ws/agents/${sessionId}`, { sessionId });

--- a/frontend/src/shared/ws/agentSessionEvents.ts
+++ b/frontend/src/shared/ws/agentSessionEvents.ts
@@ -1,0 +1,372 @@
+import { store } from '../state/store';
+import {
+  updateSession,
+  updateSessionName,
+  updateGroupMeta,
+  addMessage,
+  addApprovalRequest,
+  updateSessionStatus,
+  setSessionTestState,
+  updateSessionCost,
+  updateSessionContext,
+  setContextOverflow,
+  setRateLimited,
+  setContextRecovered,
+  setAppDepsChanged,
+  setMcpSuggestions,
+  addBranch,
+  setActiveBranch,
+  closeSessionFromWs,
+  trackAgentNotification,
+  recordCompaction,
+  setTurnLabel,
+  setQueued,
+  clearTurnLabel,
+  setProviderRetrying,
+} from '../state/agentsSlice';
+import { clearStreamingForSession } from '../state/streamingSlice';
+import { markBrowserCardEnding, fadeGlowingBrowserCards, clearGlowingBrowserCards, setGlowingBrowserCards } from '../state/dashboardLayoutSlice';
+import { displaySessionName } from '../state/sessionDisplay';
+import { notifyAgentCompletion } from '../notifications';
+import type { WSEvent } from './types';
+import type { WsEventHandlerResult } from './eventHandlerTypes';
+
+export function handleAgentSessionEvent(msg: WSEvent): WsEventHandlerResult {
+  const { event, session_id, data } = msg;
+
+  switch (event) {
+    case 'agent:test_state':
+      if (data.session_id && data.state) {
+        store.dispatch(setSessionTestState({ sessionId: data.session_id, state: data.state }));
+      }
+      return true;
+
+    case 'agent:status':
+      handleAgentStatus(session_id, data);
+      return true;
+
+    case 'agent:message':
+      if (session_id && data.message) {
+        store.dispatch(addMessage({ sessionId: session_id, message: data.message }));
+      }
+      return true;
+
+    case 'agent:approval_request':
+      if (session_id) {
+        store.dispatch(addApprovalRequest({
+          sessionId: session_id,
+          request: {
+            id: data.request_id,
+            session_id: session_id,
+            tool_name: data.tool_name,
+            tool_input: data.tool_input,
+            created_at: new Date().toISOString(),
+            sensitive_pattern: data.sensitive_pattern ?? null,
+            sensitive_label: data.sensitive_label ?? null,
+            sensitive_why: data.sensitive_why ?? null,
+          },
+        }));
+      }
+      return true;
+
+    case 'agent:cost_update':
+      if (session_id) {
+        store.dispatch(updateSessionCost({
+          sessionId: session_id,
+          costUsd: data.cost_usd,
+        }));
+      }
+      return true;
+
+    case 'agent:context_update':
+      if (session_id) {
+        store.dispatch(updateSessionContext({
+          sessionId: session_id,
+          inputTokens: data.input_tokens ?? 0,
+          outputTokens: data.output_tokens ?? 0,
+          cacheReadTokens: data.cache_read_tokens ?? 0,
+          cacheReadPct: data.cache_read_pct ?? 0,
+          ctxUsedPct: data.ctx_used_pct ?? 0,
+          contextWindow: typeof data.context_window === 'number' ? data.context_window : undefined,
+          frameworkOverheadTokens: typeof data.framework_overhead_tokens === 'number' ? data.framework_overhead_tokens : undefined,
+          activeMcps: Array.isArray(data.active_mcps) ? data.active_mcps : [],
+        }));
+      }
+      return true;
+
+    case 'agent:context_overflow':
+      if (session_id) {
+        store.dispatch(setContextOverflow({
+          sessionId: session_id,
+          reason: data.reason ?? 'long_context_required',
+          message: data.message ?? 'Context full.',
+        }));
+      }
+      return true;
+
+    case 'agent:rate_limited':
+      if (session_id) {
+        store.dispatch(setRateLimited({
+          sessionId: session_id,
+          retryAfterS: typeof data.retry_after_s === 'number' ? data.retry_after_s : null,
+        }));
+      }
+      return true;
+
+    case 'agent:context_recovered':
+      if (session_id) {
+        store.dispatch(setContextRecovered({ sessionId: session_id }));
+      }
+      return true;
+
+    case 'agent:app_deps_changed':
+      if (session_id) {
+        store.dispatch(setAppDepsChanged({ sessionId: session_id }));
+      }
+      return true;
+
+    case 'agent:context_status':
+      if (session_id && data.reason === 'compacted') {
+        store.dispatch(recordCompaction({
+          sessionId: session_id,
+          throughMsgId: data.compacted_through_msg_id ?? null,
+        }));
+      }
+      return true;
+
+    case 'agent:turn_label':
+      if (session_id && data.label) {
+        store.dispatch(setTurnLabel({
+          sessionId: session_id,
+          turnId: data.turn_id || '',
+          label: data.label,
+        }));
+      }
+      return true;
+
+    case 'agent:queued':
+      if (session_id) store.dispatch(setQueued({ sessionId: session_id, queued: true }));
+      return true;
+
+    case 'agent:admitted':
+      if (session_id) store.dispatch(setQueued({ sessionId: session_id, queued: false }));
+      return true;
+
+    case 'agent:provider_retrying':
+      // Mid-turn CLI backoff: the provider 500/429'd and the CLI is silently waiting; show the muted pill so the card doesn't read as dead.
+      if (session_id) {
+        store.dispatch(setProviderRetrying({
+          sessionId: session_id,
+          attempt: typeof data.attempt === 'number' ? data.attempt : null,
+          delayMs: typeof data.delay_ms === 'number' ? data.delay_ms : null,
+        }));
+      }
+      return true;
+
+    case 'agent:auth_error':
+      if (session_id) {
+        store.dispatch(setContextOverflow({
+          sessionId: session_id,
+          reason: data.reason ?? 'auth_error',
+          message: data.message ?? 'Authentication failed.',
+        }));
+      }
+      return true;
+
+    case 'agent:out_of_tokens':
+      if (session_id) {
+        store.dispatch(setContextOverflow({
+          sessionId: session_id,
+          reason: 'out_of_tokens',
+          message: data.message ?? "You're out of tokens on this model.",
+        }));
+      }
+      return true;
+
+    case 'agent:mcp_suggestions':
+      if (session_id) {
+        store.dispatch(setMcpSuggestions({
+          sessionId: session_id,
+          suggestions: Array.isArray(data.suggestions) ? data.suggestions : [],
+          isVague: !!data.is_vague,
+        }));
+      }
+      return true;
+
+    case 'agent:branch_created':
+      if (session_id && data.branch) {
+        store.dispatch(addBranch({ sessionId: session_id, branch: data.branch }));
+        store.dispatch(setActiveBranch({ sessionId: session_id, branchId: data.active_branch_id }));
+      }
+      return true;
+
+    case 'agent:branch_switched':
+      if (session_id) {
+        store.dispatch(setActiveBranch({ sessionId: session_id, branchId: data.active_branch_id }));
+      }
+      return true;
+
+    case 'agent:name_updated':
+      if (session_id && data.name) {
+        store.dispatch(updateSessionName({ sessionId: session_id, name: data.name }));
+      }
+      return true;
+
+    case 'agent:group_meta_updated':
+      if (session_id && data.group_id) {
+        store.dispatch(updateGroupMeta({
+          sessionId: session_id,
+          groupId: data.group_id,
+          name: data.name ?? '',
+          svg: data.svg ?? '',
+          isRefined: data.is_refined ?? false,
+        }));
+      }
+      return true;
+
+    case 'agent:closed':
+      handleAgentClosed(session_id, data);
+      return true;
+
+    default:
+      return null;
+  }
+}
+
+function handleAgentStatus(sessionId: string | undefined, data: Record<string, any>): void {
+  const prevSession = sessionId ? store.getState().agents.sessions[sessionId] : undefined;
+  const prevStatus = prevSession?.status;
+
+  if (data.session) {
+    store.dispatch(updateSession(data.session));
+  } else if (sessionId) {
+    store.dispatch(updateSessionStatus({ sessionId, status: data.status }));
+  }
+  if (data.status === 'running' && sessionId) {
+    store.dispatch(trackAgentNotification(sessionId));
+  }
+  // Native OS notification when an agent finishes while the user is elsewhere: workflows already had this; long chat tasks deserve the same.
+  if (data.status === 'completed' && sessionId && document.hidden) {
+    const p_sess2 = data.session ?? prevSession;
+    if (p_sess2 && !p_sess2.parent_session_id && p_sess2.mode !== 'browser-agent') {
+      void (window as any).openswarm?.notify?.({
+        title: 'Agent finished',
+        body: (p_sess2.name && p_sess2.name !== 'Untitled' ? p_sess2.name : 'Your task is done.').slice(0, 200),
+        deepLink: `openswarm://session/${sessionId}`,
+      });
+    }
+  }
+  // An AppAgent driving an app card announces itself only via this status event (no card_added like browsers), so light the app card here.
+  const p_sess = data.session;
+  if (p_sess && p_sess.mode === 'browser-agent' && typeof p_sess.browser_id === 'string' && p_sess.browser_id.startsWith('app:')
+      && (p_sess.status === 'running' || p_sess.status === 'waiting_approval')) {
+    store.dispatch(setGlowingBrowserCards({
+      browserIds: [p_sess.browser_id],
+      sessionId: p_sess.parent_session_id || p_sess.id,
+      label: 'Use App',
+    }));
+  }
+
+  const newStatus = data.status ?? data.session?.status;
+  const wasWorking = prevStatus === 'running' || prevStatus === 'waiting_approval';
+  if (sessionId && wasWorking && (newStatus === 'completed' || newStatus === 'stopped' || newStatus === 'error')) {
+    store.dispatch(fadeGlowingBrowserCards(sessionId));
+    setTimeout(() => store.dispatch(clearGlowingBrowserCards(sessionId)), 600);
+  }
+
+  const terminal = new Set(['completed', 'error']);
+  const nonTerminal = new Set(['running', 'waiting_approval', undefined, null, '']);
+  if (
+    sessionId &&
+    terminal.has(data.status) &&
+    nonTerminal.has(prevStatus as any) &&
+    data.session?.mode !== 'browser-agent' &&
+    data.session?.mode !== 'sub-agent' &&
+    data.session?.mode !== 'invoked-agent'
+  ) {
+    const sess = data.session ?? prevSession;
+    if (sess) {
+      const lastAssistant = [...(sess.messages || [])]
+        .reverse()
+        .find((m: any) => m.role === 'assistant' && typeof m.content === 'string');
+      notifyAgentCompletion({
+        sessionId,
+        sessionName: displaySessionName(sess.name),
+        dashboardId: sess.dashboard_id,
+        status: data.status as 'completed' | 'error',
+        bodyExcerpt: lastAssistant ? String(lastAssistant.content) : undefined,
+      });
+    }
+  }
+
+  if (sessionId && (data.status === 'completed' || data.status === 'error' || data.status === 'stopped')) {
+    store.dispatch(clearTurnLabel(sessionId));
+    if (data.status === 'stopped') {
+      promoteStoppedStream(sessionId);
+    }
+    store.dispatch(clearStreamingForSession(sessionId));
+  }
+
+  if (
+    sessionId &&
+    (data.status === 'completed' || data.status === 'error') &&
+    data.session?.mode !== 'browser-agent'
+  ) {
+    markSpawnedBrowsersEnding(sessionId, data.status);
+  }
+}
+
+function promoteStoppedStream(sessionId: string): void {
+  const entry = store.getState().streaming.bySession[sessionId];
+  if (!entry || entry.role !== 'assistant' || !entry.content) return;
+  const sess = store.getState().agents.sessions[sessionId];
+  if (sess?.messages?.some((m) => m.id === entry.id)) return;
+  store.dispatch(addMessage({
+    sessionId,
+    message: {
+      id: entry.id,
+      role: 'assistant',
+      content: entry.content,
+      timestamp: new Date().toISOString(),
+      branch_id: sess?.active_branch_id ?? 'main',
+      parent_id: null,
+    },
+  }));
+}
+
+function markSpawnedBrowsersEnding(sessionId: string, status: 'completed' | 'error'): void {
+  const browserCards = store.getState().dashboardLayout.browserCards;
+  for (const card of Object.values(browserCards)) {
+    if (card.spawned_by === sessionId && !card.keep_open) {
+      store.dispatch(markBrowserCardEnding({
+        browserId: card.browser_id,
+        status,
+      }));
+    }
+  }
+}
+
+function handleAgentClosed(sessionId: string | undefined, data: Record<string, any>): void {
+  if (!sessionId) return;
+  const closedStatus = data.status ?? 'stopped';
+  const watchedSidecar = Object.values(store.getState().workflows.openCards)
+    .some((oc) => oc.sidecarSessionId === sessionId);
+  const monitorWorkflowId = store.getState().dashboardLayout.workflowsMonitorId;
+  const watchedByMonitor = !!monitorWorkflowId
+    && (store.getState().workflows.runs[monitorWorkflowId] || []).some((r) => r.session_id === sessionId);
+  store.dispatch(closeSessionFromWs({
+    id: sessionId,
+    name: data.name ?? 'Untitled',
+    status: closedStatus,
+    model: data.model ?? '',
+    mode: data.mode ?? '',
+    created_at: data.created_at ?? new Date().toISOString(),
+    closed_at: data.closed_at ?? new Date().toISOString(),
+    cost_usd: data.cost_usd ?? 0,
+    dashboard_id: data.dashboard_id,
+    keepSession: watchedSidecar || watchedByMonitor,
+  }));
+  if (closedStatus === 'completed' || closedStatus === 'error') {
+    markSpawnedBrowsersEnding(sessionId, closedStatus);
+  }
+}

--- a/frontend/src/shared/ws/agentStreamEvents.ts
+++ b/frontend/src/shared/ws/agentStreamEvents.ts
@@ -1,0 +1,44 @@
+import { store } from '../state/store';
+import { streamStart, streamEnd } from '../state/streamingSlice';
+import type { WSEvent } from './types';
+import type { WsEventHandlerContext, WsEventHandlerResult } from './eventHandlerTypes';
+
+const STREAM_EVENTS = new Set(['agent:stream_start', 'agent:stream_delta', 'agent:stream_end']);
+
+export function handleAgentStreamEvent(msg: WSEvent, context: WsEventHandlerContext): WsEventHandlerResult {
+  const { event, session_id, data } = msg;
+  if (!STREAM_EVENTS.has(event)) return null;
+
+  if (context.skipStreamEvents) return false;
+
+  // Replay-skip guard. The WS resume protocol replays buffered events from the ring buffer with seq > last_seq.
+  // `resumeAcked` flips to true when server:hello arrives, which the server sends after replay completes.
+  if (!context.resumeAcked) return true;
+
+  if (event === 'agent:stream_start') {
+    if (session_id && data.message_id) {
+      store.dispatch(streamStart({
+        sessionId: session_id,
+        messageId: data.message_id,
+        role: data.role,
+        toolName: data.tool_name,
+      }));
+    }
+    return true;
+  }
+
+  if (event === 'agent:stream_delta') {
+    if (session_id && data.message_id) {
+      context.dispatchDelta(session_id, data.message_id, data.delta);
+    }
+    return true;
+  }
+
+  if (session_id && data.message_id) {
+    store.dispatch(streamEnd({
+      sessionId: session_id,
+      messageId: data.message_id,
+    }));
+  }
+  return true;
+}

--- a/frontend/src/shared/ws/dashboardBrowserEvents.ts
+++ b/frontend/src/shared/ws/dashboardBrowserEvents.ts
@@ -1,0 +1,87 @@
+import { store } from '../state/store';
+import {
+  addBrowserCardFromBackend,
+  keepBrowserCardOpen,
+  placeBesideCard,
+  placeBelowCard,
+  placeBrowserBesideChat,
+  setBrowserCardPosition,
+  setGlowingBrowserCards,
+  WORKFLOW_CARD_GAP,
+  removeBrowserCard,
+  setBrowserDocked,
+} from '../state/dashboardLayoutSlice';
+import type { WSEvent } from './types';
+import type { WsEventHandlerResult } from './eventHandlerTypes';
+
+export function handleDashboardBrowserEvent(msg: WSEvent): WsEventHandlerResult {
+  const { event, data } = msg;
+
+  switch (event) {
+    case 'dashboard:browser_card_keep':
+      if (data.browser_id) {
+        store.dispatch(keepBrowserCardOpen(data.browser_id));
+      }
+      return true;
+
+    case 'dashboard:browser_card_added':
+      if (data.browser_card) {
+        // Add first, then re-read layout so the collision-resolved placement sees the canonical card.
+        store.dispatch(addBrowserCardFromBackend({
+          ...data.browser_card,
+          dashboard_id: data.dashboard_id,
+        }));
+        const parentId = data.parent_session_id;
+        if (parentId) {
+          const layoutState = store.getState().dashboardLayout;
+          const browserCard = layoutState.browserCards[data.browser_card.browser_id];
+          if (browserCard) {
+            const exclude = { type: 'browser' as const, id: browserCard.browser_id };
+            const parentCard = layoutState.cards[parentId];
+            const sess = store.getState().agents.sessions[parentId];
+            let pos: { x: number; y: number } | null = null;
+            let glowLabel = 'Use Browser';
+            if (parentCard) {
+              pos = placeBrowserBesideChat(layoutState, parentCard, parentId, browserCard.width, browserCard.height, browserCard.browser_id);
+              // A replacement browser buries its predecessor: the agent spins a fresh card when a tab dies, and the displaced spawned sibling must go, not linger.
+              for (const old of Object.values(layoutState.browserCards)) {
+                if (old.browser_id !== browserCard.browser_id && old.spawned_by === parentId && !old.keep_open) {
+                  void import('@/shared/browserTeardown').then(({ removeBrowserCardCleanly }) => removeBrowserCardCleanly(old.browser_id, store.dispatch));
+                }
+              }
+              // Default home is INSIDE the chat: the card overlays the chat's dock slot while the chat is expanded; the beside-chat spot stays the undock/collapse fallback.
+              store.dispatch(setBrowserDocked({ browserId: browserCard.browser_id, dockedTo: parentId }));
+            } else if (sess?.workflow_run_id && layoutState.workflowsMonitorCard) {
+              pos = placeBesideCard(layoutState, layoutState.workflowsMonitorCard, browserCard.width, browserCard.height, undefined, exclude, WORKFLOW_CARD_GAP, true);
+            } else if (sess?.workflow_edit_id && layoutState.workflowsHub) {
+              pos = placeBelowCard(layoutState, layoutState.workflowsHub, browserCard.width, browserCard.height, undefined, exclude);
+              glowLabel = 'Browser';
+            }
+            if (pos) {
+              store.dispatch(setBrowserCardPosition({
+                browserId: data.browser_card.browser_id,
+                x: pos.x,
+                y: pos.y,
+              }));
+              store.dispatch(setGlowingBrowserCards({
+                browserIds: [data.browser_card.browser_id],
+                sessionId: parentId,
+                label: glowLabel,
+              }));
+            }
+          }
+        }
+      }
+      return true;
+
+    case 'dashboard:browser_card_evict':
+      // A wedged card the backend is tearing down BEFORE it spawns a recovery card. Remove it now (no fade, no Keep pill) so its <webview> unmounts first.
+      if (data.browser_id) {
+        store.dispatch(removeBrowserCard(data.browser_id));
+      }
+      return true;
+
+    default:
+      return null;
+  }
+}

--- a/frontend/src/shared/ws/eventHandlerTypes.ts
+++ b/frontend/src/shared/ws/eventHandlerTypes.ts
@@ -1,0 +1,7 @@
+export type WsEventHandlerContext = {
+  resumeAcked: boolean;
+  skipStreamEvents: boolean;
+  dispatchDelta: (sessionId: string, messageId: string, delta: string) => void;
+};
+
+export type WsEventHandlerResult = boolean | null;

--- a/frontend/src/shared/ws/eventHandlers.ts
+++ b/frontend/src/shared/ws/eventHandlers.ts
@@ -1,0 +1,30 @@
+import { handleAgentSessionEvent } from './agentSessionEvents';
+import { handleAgentStreamEvent } from './agentStreamEvents';
+import { handleDashboardBrowserEvent } from './dashboardBrowserEvents';
+import { handleOutputEvent } from './outputEvents';
+import { handleSettingsEvent } from './settingsEvents';
+import { handleWorkflowEvent } from './workflowEvents';
+import type { WSEvent } from './types';
+import type { WsEventHandlerContext } from './eventHandlerTypes';
+
+export function handleWsEvent(msg: WSEvent, context: WsEventHandlerContext): boolean {
+  const streamResult = handleAgentStreamEvent(msg, context);
+  if (streamResult !== null) return streamResult;
+
+  const agentResult = handleAgentSessionEvent(msg);
+  if (agentResult !== null) return agentResult;
+
+  const outputResult = handleOutputEvent(msg);
+  if (outputResult !== null) return outputResult;
+
+  const workflowResult = handleWorkflowEvent(msg);
+  if (workflowResult !== null) return workflowResult;
+
+  const dashboardResult = handleDashboardBrowserEvent(msg);
+  if (dashboardResult !== null) return dashboardResult;
+
+  const settingsResult = handleSettingsEvent(msg);
+  if (settingsResult !== null) return settingsResult;
+
+  return true;
+}

--- a/frontend/src/shared/ws/idempotency/WebSocketManager.idempotency.test.ts
+++ b/frontend/src/shared/ws/idempotency/WebSocketManager.idempotency.test.ts
@@ -1,0 +1,125 @@
+// Run: node --test (via scripts/run-tests.mjs)
+import assert from 'node:assert/strict';
+import { afterEach, before, beforeEach, mock, test } from 'node:test';
+import WebSocketManager from '../WebSocketManager';
+import { refreshAuthToken } from '../../config';
+
+// Seed the auth token the way the preload would, and stand in for the DOM bits the manager touches.
+const realGlobals = {
+  WebSocket: (globalThis as any).WebSocket,
+  requestAnimationFrame: (globalThis as any).requestAnimationFrame,
+};
+before(async () => {
+  (globalThis as any).window = { openswarm: { getAuthToken: async () => 'unit-token' }, dispatchEvent: () => true };
+  (globalThis as any).document = { body: { classList: { contains: () => false } } };
+  await refreshAuthToken();
+});
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  failNextSend = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+    if (this.failNextSend) {
+      this.failNextSend = false;
+      throw new Error('simulated transport failure');
+    }
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code: 1000 });
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(payload: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+type SentFrame = { event: string; data: Record<string, unknown> };
+
+function sentEvents(socket: FakeWebSocket): SentFrame[] {
+  return socket.sent.map((payload) => JSON.parse(payload));
+}
+
+function connectSession(sessionId: string): { manager: WebSocketManager; socket: FakeWebSocket } {
+  const manager = new WebSocketManager(`ws://unit/ws/agents/${sessionId}`, { sessionId });
+  manager.connect();
+  const socket = FakeWebSocket.instances.at(-1)!;
+  socket.open();
+  socket.receive({ event: 'server:hello', session_id: sessionId, data: {} });
+  return { manager, socket };
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  (globalThis as any).WebSocket = FakeWebSocket;
+  (globalThis as any).requestAnimationFrame = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  };
+});
+
+afterEach(() => {
+  (globalThis as any).WebSocket = realGlobals.WebSocket;
+  (globalThis as any).requestAnimationFrame = realGlobals.requestAnimationFrame;
+  mock.restoreAll();
+});
+
+test('logical WebSocket prompts receive distinct idempotency keys', () => {
+  const { manager, socket } = connectSession('session-idempotency-distinct');
+
+  manager.sendMessage('session-idempotency-distinct', 'first prompt');
+  manager.sendMessage('session-idempotency-distinct', 'second prompt');
+
+  const prompts = sentEvents(socket).filter((frame) => frame.event === 'agent:send_message');
+  assert.equal(prompts.length, 2);
+  assert.equal(typeof prompts[0].data.idempotency_key, 'string');
+  assert.equal(typeof prompts[1].data.idempotency_key, 'string');
+  assert.notEqual(prompts[0].data.idempotency_key, prompts[1].data.idempotency_key);
+
+  manager.disconnect();
+});
+
+test('WebSocket transport retry preserves the logical prompt idempotency key', () => {
+  const sessionId = 'session-idempotency-retry';
+  const { manager, socket: firstSocket } = connectSession(sessionId);
+  firstSocket.failNextSend = true;
+
+  manager.sendMessage(sessionId, 'retry this transport');
+  const attempted = sentEvents(firstSocket).find((frame) => frame.event === 'agent:send_message');
+  assert.ok(attempted);
+
+  firstSocket.close();
+  manager.connect();
+  const retrySocket = FakeWebSocket.instances.at(-1)!;
+  retrySocket.open();
+  retrySocket.receive({ event: 'server:hello', session_id: sessionId, data: {} });
+
+  const retried = sentEvents(retrySocket).find((frame) => frame.event === 'agent:send_message');
+  assert.ok(retried);
+  assert.equal(retried.data.idempotency_key, attempted.data.idempotency_key);
+  assert.equal(retried.data.prompt, 'retry this transport');
+
+  manager.disconnect();
+});

--- a/frontend/src/shared/ws/ids.ts
+++ b/frontend/src/shared/ws/ids.ts
@@ -1,0 +1,7 @@
+export function genUuid(): string {
+  // Avoid pulling in `crypto.randomUUID` for compat; this is a disambiguator, not a security boundary.
+  const a = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
+  const b = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
+  const c = Math.floor(Math.random() * 2 ** 32).toString(16).padStart(8, '0');
+  return `${a}${b}${c}`;
+}

--- a/frontend/src/shared/ws/outputEvents.ts
+++ b/frontend/src/shared/ws/outputEvents.ts
@@ -1,0 +1,44 @@
+import { store } from '../state/store';
+import { upsertOutput } from '../state/outputsSlice';
+import { setCardPosition } from '../state/dashboardLayoutSlice';
+import type { WSEvent } from './types';
+import type { WsEventHandlerResult } from './eventHandlerTypes';
+
+export function handleOutputEvent(msg: WSEvent): WsEventHandlerResult {
+  const { data } = msg;
+  switch (msg.event) {
+    case 'agent:output_upserted':
+      // Emitted when an Output row is created or updated. The reducer merges over existing rows.
+      if (data.output && data.output.id) {
+        store.dispatch(upsertOutput(data.output));
+      }
+      return true;
+
+    case 'apps_sdk:tool_grant_request':
+      // An app asked to use a connected MCP tool; AppToolGrantHost (global mount) owns the dialog.
+      window.dispatchEvent(new CustomEvent('openswarm:app-tool-grant', { detail: data }));
+      return true;
+
+    case 'apps_sdk:place_agent_card': {
+      // An app asked for its spawned agent at a specific canvas spot; the card is created async by the session lifecycle, so nudge it into place with a short bounded retry.
+      const sid = data.session_id as string;
+      const px = Number(data.x);
+      const py = Number(data.y);
+      if (!sid || !Number.isFinite(px) || !Number.isFinite(py)) return true;
+      let tries = 0;
+      const place = () => {
+        const exists = !!store.getState().dashboardLayout.cards[sid];
+        if (exists) {
+          store.dispatch(setCardPosition({ sessionId: sid, x: px, y: py }));
+          return;
+        }
+        if (++tries < 20) setTimeout(place, 300);
+      };
+      place();
+      return true;
+    }
+
+    default:
+      return null;
+  }
+}

--- a/frontend/src/shared/ws/resumeState.ts
+++ b/frontend/src/shared/ws/resumeState.ts
@@ -1,0 +1,18 @@
+const sessionLastSeq: Map<string, number> = new Map();
+
+export function getSessionLastSeq(sessionId: string): number {
+  return sessionLastSeq.get(sessionId) ?? 0;
+}
+
+export function setSessionLastSeq(sessionId: string, seq: number): void {
+  sessionLastSeq.set(sessionId, seq);
+}
+
+export function clearSessionLastSeq(sessionId: string): void {
+  sessionLastSeq.delete(sessionId);
+}
+
+/** Seed the resume cursor from a REST hydrate (GET /sessions returns event_seq), so the follow-up WS connect replays only what happened AFTER the snapshot instead of the whole ring buffer. */
+export function seedSessionSeq(sessionId: string, seq: number): void {
+  if (seq > getSessionLastSeq(sessionId)) sessionLastSeq.set(sessionId, seq);
+}

--- a/frontend/src/shared/ws/settingsEvents.ts
+++ b/frontend/src/shared/ws/settingsEvents.ts
@@ -1,0 +1,11 @@
+import { store } from '../state/store';
+import { fetchSettings } from '../state/settingsSlice';
+import type { WSEvent } from './types';
+import type { WsEventHandlerResult } from './eventHandlerTypes';
+
+export function handleSettingsEvent(msg: WSEvent): WsEventHandlerResult {
+  if (msg.event !== 'settings:changed') return null;
+  // An agent wrote settings under us, so refetch instead of waiting for window focus.
+  store.dispatch(fetchSettings());
+  return true;
+}

--- a/frontend/src/shared/ws/types.ts
+++ b/frontend/src/shared/ws/types.ts
@@ -1,0 +1,19 @@
+export type WSEvent = {
+  event: string;
+  session_id?: string;
+  data: Record<string, any>;
+  seq?: number;
+};
+
+export interface WSManagerOptions {
+  skipStreamEvents?: boolean;
+  // Session-scoped WSes opt into resume + connection-state dispatches by passing this. Dashboard WS doesn't.
+  sessionId?: string;
+}
+
+export interface QueuedFrame {
+  event: string;
+  data: Record<string, any>;
+  // Lets the future server-side dedup index match retries to originals. Today the server treats most events idempotently anyway.
+  client_msg_id: string;
+}

--- a/frontend/src/shared/ws/workflowEvents.ts
+++ b/frontend/src/shared/ws/workflowEvents.ts
@@ -1,0 +1,54 @@
+import { store } from '../state/store';
+import { openWorkflowMonitor } from '../state/dashboardLayoutSlice';
+import { upsertRun, upsertWorkflow, removeWorkflow } from '../state/workflowsSlice';
+import { notifyWorkflowRun } from '../notifications';
+import type { WSEvent } from './types';
+import type { WsEventHandlerResult } from './eventHandlerTypes';
+
+// Manual runs whose monitor card we've already popped open, so repeated workflow:run updates don't re-pin the monitor.
+const autoOpenedRunIds = new Set<string>();
+
+export function handleWorkflowEvent(msg: WSEvent): WsEventHandlerResult {
+  const { event, data } = msg;
+
+  switch (event) {
+    case 'workflow:run':
+      if (data.run) {
+        const run = data.run;
+        store.dispatch(upsertRun(run));
+        if (run.status === 'running' && run.triggered_by === 'manual' && run.id && !autoOpenedRunIds.has(run.id)) {
+          autoOpenedRunIds.add(run.id);
+          store.dispatch(openWorkflowMonitor({ workflowId: run.workflow_id, runId: run.id }));
+        }
+      }
+      return true;
+
+    case 'workflow:updated':
+      if (data.workflow) {
+        store.dispatch(upsertWorkflow(data.workflow));
+      }
+      return true;
+
+    case 'workflow:deleted':
+      if (data.workflow_id) {
+        store.dispatch(removeWorkflow(data.workflow_id));
+      }
+      return true;
+
+    case 'workflow:notify':
+      if (data.workflow_id) {
+        notifyWorkflowRun({
+          workflowId: data.workflow_id,
+          workflowTitle: data.workflow_title || 'Workflow',
+          runId: data.run_id,
+          sessionId: data.session_id,
+          status: data.status,
+          tierKind: data.tier_kind,
+          fallback: data.fallback,
+        });
+      }
+      return true;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
> **Draft, stacked on #147** (its import-safe `config.ts` is what lets these tests run under node:test; the extra commits in the diff disappear once #147 merges). First renderer-infra PR of the series; nothing hosted, no product features.

`shared/ws/WebSocketManager.ts` was 1,052 lines: the transport (connect, resume handshake, heartbeat, reconnect backoff, batched dispatch) and every server→client event family's store mutations in one switch. It is now the transport (472 lines) plus one module per family, each a pure `(event, data) → handled` function over the store:

| Module | Family |
|---|---|
| `agentSessionEvents.ts` | session status / message / branch / approval / queue events |
| `agentStreamEvents.ts` | stream start / delta / end |
| `dashboardBrowserEvents.ts` | browser card lifecycle |
| `outputEvents.ts` | app outputs (incl. the app-tool-grant DOM event) |
| `settingsEvents.ts`, `workflowEvents.ts` | as named |
| `eventHandlers.ts` / `eventHandlerTypes.ts` | the ordered handler chain |
| `resumeState.ts`, `ids.ts`, `types.ts` | resume bookkeeping, id helpers, the wire types |

**One behaviour change:** sends over a session socket carry a per-logical-prompt idempotency key that survives a transport retry (a resend after a failed send reuses the key; a new prompt gets a new one), so a backend that dedupes on the key never runs a prompt twice. Everything else is a move — the transport mechanisms (rAF/timer batching, drag dam, heartbeat, backoff, resume ack) are unchanged.

**Tests** (node:test, 8 cases): tokenized hello + queued-frame flush after `server:hello`; dashboard sockets skipping resume and emitting the reconnect notification; skipped stream events staying suppressed ahead of custom listeners; listener ordering/unsubscribe; replayed stream events dropped until resume ack; message append to an existing session; the two idempotency cases. They seed the auth token the way the preload would and stand in for the two DOM bits the manager reads (`requestAnimationFrame`, `document.body.classList`).

Proof: `tsc --noEmit` clean; `node scripts/run-tests.mjs` 151/151; packaged macOS app with this renderer: upstream smoke 5/5 + the characterization suite (#146) 19/19 — the chat/tool-ui and resilience specs drive this transport directly.

Not in this PR: the capability-overlay events of a card family that is not in this tree.