### PR TITLE
[E2E] run on macOS Intel + Windows, and make the suite's verdicts more honest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ name: E2E (packaged app, Windows + macOS Intel)
 
 on:
   push:
-    branches: [eric/lock]
+    branches: [eric/dev]
     paths: &build-paths
       - 'electron/**'
       - 'frontend/**'
@@ -38,7 +38,7 @@ on:
       - 'scripts/ci/**'
       - '.github/workflows/e2e.yml'
   pull_request:
-    branches: [main]
+    branches: [main, eric/dev]
     paths: *build-paths
   workflow_dispatch:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,14 +158,16 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
         run: npm ci
-      - name: GUI hand selftest (MCP)
-        shell: bash
-        working-directory: e2e
-        run: node mcp/selftest.js
       - name: Run E2E (Playwright)
         shell: bash
         working-directory: e2e
         run: npm test
+      # After the suite, not before: a timeout in this dev tool used to fail the job with no e2e verdict reported. always() so a red suite doesn't skip the check entirely.
+      - name: GUI hand selftest (MCP)
+        if: always()
+        shell: bash
+        working-directory: e2e
+        run: node mcp/selftest.js
       - name: Upload E2E results
         if: always()
         uses: actions/upload-artifact@v4
@@ -267,14 +269,16 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
         run: npm ci
-      - name: GUI hand selftest (MCP)
-        shell: bash
-        working-directory: e2e
-        run: node mcp/selftest.js
       - name: Run E2E (Playwright)
         shell: bash
         working-directory: e2e
         run: npm test
+      # After the suite, not before: a timeout in this dev tool used to fail the job with no e2e verdict reported. always() so a red suite doesn't skip the check entirely.
+      - name: GUI hand selftest (MCP)
+        if: always()
+        shell: bash
+        working-directory: e2e
+        run: node mcp/selftest.js
       - name: Installer cycle (clean runner)
         shell: pwsh
         run: node scripts/ci/verify-installer.js --destructive

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,6 @@
-name: E2E (packaged app, Windows)
+name: E2E (packaged app, Windows + macOS Intel)
 
-# Fast-feedback packaged-app gate, Windows-only. Split into parallel jobs so the
+# Fast-feedback packaged-app gate, Windows and macOS intel. Split into parallel jobs so the
 # push wall-clock stays well under ~10 min:
 #   gate        - cheap pure-node selftests (no build): mutation gate + preflight
 #                 Layers 1-5. Fails the "tests that test the tests" fast.
@@ -8,17 +8,21 @@ name: E2E (packaged app, Windows)
 #                 slow ~2min NSIS LZMA compression) and run the deterministic
 #                 verify-all gate against win-unpacked\OpenSwarm.exe.
 #   playwright  - build the unpacked app and run the renderer-level Playwright e2e.
+#   playwright-mac - the same suite on macos-15-intel, built with build-app.sh.
 #   installer   - full NSIS build + destructive install->verify->uninstall. The
 #                 heaviest leg, so it runs only on PR-to-main / dispatch (NOT on
 #                 routine pushes); release-windows.yml covers it on v* tags.
-# verify + playwright run concurrently; both reuse cached heavy build inputs
-# (bundled Python env, uv, MCP bundles, npm) so warm builds are fast - the build
-# script skips any input already on disk.
+# verify + playwright + playwright-mac run concurrently; they reuse cached heavy build
+# inputs (bundled Python env, uv, MCP bundles, npm) so warm builds are fast - the build
+# script skips any input already on disk. The mac leg caches only uv + MCP bundles: its
+# python-env stages under build-staging/, which build-app.sh wipes before every run.
 #
-# macOS legs were removed (runner starvation + untriageable mac-only failures);
-# re-add when a Mac maintainer can own them. Real Win10 coverage still needs the
-# SELF-HOSTED e2e-win10 job (repo var WIN10_SELF_HOSTED=true + a
-# [self-hosted, windows, win10] runner).
+# macOS legs were removed (runner starvation + untriageable mac-only failures). The Intel
+# leg is back as playwright-mac on macos-15-intel, the free runner intel-x64-verify already
+# uses: Rosetta on an arm64 host has no AVX, so real Intel silicon is the only place the x64
+# artifact is testable at all. arm64 stays out until someone can own it.
+# Real Win10 coverage still needs the SELF-HOSTED e2e-win10 job
+# (repo var WIN10_SELF_HOSTED=true + a [self-hosted, windows, win10] runner).
 
 on:
   push:
@@ -183,6 +187,77 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: e2e-traces
+          path: e2e/traces/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # macOS Intel leg: same suite, same specs, built with build-app.sh instead of the .ps1.
+  # Runs concurrently with the Windows legs so one run reports every OS verdict.
+  playwright-mac:
+    runs-on: macos-15-intel
+    # Longer than the Windows leg: this build compiles whisper.cpp from source and
+    # downloads a standalone CPython before electron-builder even starts.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1'
+          cache: npm
+          cache-dependency-path: |
+            electron/package-lock.json
+            frontend/package-lock.json
+            e2e/package-lock.json
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Cache uv binaries
+        uses: actions/cache@v4
+        with:
+          path: backend/uv-bin
+          key: uvbin-mac-${{ hashFiles('scripts/build-app.sh') }}
+      - name: Cache MCP bundles
+        uses: actions/cache@v4
+        with:
+          path: backend/mcp-bundles
+          key: mcpbundles-mac-${{ hashFiles('scripts/build-app.sh') }}
+      - name: Build packaged app
+        shell: bash
+        env:
+          # e2e never drives dictation, so skip the 190MB model download on every run.
+          OPENSWARM_SKIP_WHISPER_MODEL: '1'
+        run: bash scripts/build-app.sh
+      - name: Install e2e deps
+        shell: bash
+        working-directory: e2e
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        run: npm ci
+      - name: Run E2E (Playwright)
+        shell: bash
+        working-directory: e2e
+        run: npm test
+      # After the suite, not before: a timeout in this dev tool used to fail the job with no e2e verdict reported. always() so a red suite doesn't skip the check entirely.
+      - name: GUI hand selftest (MCP)
+        if: always()
+        shell: bash
+        working-directory: e2e
+        run: node mcp/selftest.js
+      # Artifact names must differ from the Windows leg: upload-artifact@v4 rejects two
+      # uploads sharing a name within one run.
+      - name: Upload E2E results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results-mac
+          path: e2e/results.json
+          if-no-files-found: ignore
+          retention-days: 14
+      - name: Upload E2E visibility traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-traces-mac
           path: e2e/traces/
           if-no-files-found: ignore
           retention-days: 14

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -53,6 +53,25 @@ function seedTestUserIfClean(): void {
     merged.user_id = 'e2e-fake-user';
     merged.user_email = 'e2e@openswarm.test';
   }
+
+  // On a genuinely fresh profile OnboardingV3 opens a full-screen welcome modal
+  // ("Welcome." + an ArrowRight icon, OnboardingV3Root IntroBeat)
+  // and nothing behind it is clickable, so every spec that wants to reach the app stalls on step one.
+  // useOnboardingV3Gate treats ANY onboarding_v3 value as "not a fresh install", which is what an e2e profile is.
+  //
+  // This deliberately makes first-run onboarding untestable here, and that gap is not
+  // closable from the test side: IntroBeat's button has no text, aria-label,
+  // data-onboarding or data-testid, so there is no stable way to drive it.
+  //
+  // TODO: first-run onboarding needs a spec of its own, and it cannot live in this
+  // suite -- every spec calling launchApp() arrives here already seeded past the modal.
+  // It also needs a genuinely fresh profile on EVERY run, because a packaged build cannot
+  // replay the flow: useOnboardingV3Gate's osw_force_onboarding replay hatch is gated off
+  // by NODE_ENV === 'production'. Blocked on giving IntroBeat's button an accessible name;
+  // that single change closes both the a11y hole and this coverage gap.
+  if (!merged.onboarding_v3) {
+    merged.onboarding_v3 = 'skipped';
+  }
   // Provider keys: read from env each launch so a key never has to live on disk
   // outside the per-user app-support dir (and so rotating just means a new shell).
   const envKeys: Array<[string, string]> = [

--- a/e2e/tests/deep-coverage.spec.ts
+++ b/e2e/tests/deep-coverage.spec.ts
@@ -60,7 +60,14 @@ test.describe('deep interactive coverage', () => {
 
   test.afterAll(async () => { await app?.close().catch(() => {}); });
 
-  test('home renders without crashing', async ({}, info) => {
+  test('home renders a usable dashboard', async ({}, info) => {
+    await expect(page.locator('[data-onboarding="canvas-controls"]'), 'canvas controls never mounted')
+      .toBeVisible({ timeout: TARGET_TIMEOUT_MS });
+    // Playwright matches accessible names by substring, so a
+    // bare 'Send' also matches the "Send an agent to the web" suggestion chip
+    // and `exact: true` rejects the ambiguity.
+    await expect(page.getByRole('button', { name: 'Send', exact: true }), 'composer Send button never mounted')
+      .toBeVisible({ timeout: TARGET_TIMEOUT_MS });
     await page.screenshot({ path: info.outputPath('home.png') });
     noNewCrashes('home render');
   });

--- a/e2e/tests/deep-coverage.spec.ts
+++ b/e2e/tests/deep-coverage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, ElectronApplication, Locator, Page } from '@playwright/test';
 import { launchApp, waitForMainWindow } from '../helpers/launch';
 import fs from 'fs';
 import os from 'os';
@@ -32,17 +32,24 @@ test.describe('deep interactive coverage', () => {
     expect(now, `renderer crashed during: ${label}`).toBe(baseline);
   };
 
-  // Strict by default: a missing target FAILS the step so absent buttons can't
-  // green a build. Pass { optional: true } only for surfaces that legitimately
-  // may not exist on a clean profile, and we still annotate the skip.
-  const safeClick = async (locator: ReturnType<Page['getByText']>, label: string, opts?: { optional?: boolean }) => {
-    const count = await locator.count();
-    if (count === 0) {
-      if (opts?.optional) { test.info().annotations.push({ type: 'skip', description: `${label}: optional target absent` }); return false; }
-      throw new Error(`${label}: required target not visible`);
-    }
+  // Strict, with no opt-out: a missing target FAILS the step so an absent button can
+  // never green a build.
+  //
+  // WAIT, don't sample. This used locator.count(), a point-in-time query with no
+  // auto-wait, so it reported 0 for surfaces that mount a moment later and threw
+  // "required target not visible" 27ms into a test. The app's own resolver waits 15s
+  // for exactly this reason (frontend Onboarding/selectors.ts waitForSelector), so
+  // match it.
+  const TARGET_TIMEOUT_MS = 15_000;
+
+  // A DOM dump of the running app found none of the targets the legacy tests below
+  // reach for. Skipped rather than deleted so the lost coverage stays visible in the
+  // report; see the rewritten tests at the bottom of this file for live equivalents.
+  const STALE_UI = 'targets an earlier UI generation; the selector is absent from the running app';
+  const safeClick = async (locator: Locator, label: string) => {
+    await expect(locator.first(), `${label}: required target never became visible`)
+      .toBeVisible({ timeout: TARGET_TIMEOUT_MS });
     await locator.first().click({ timeout: 5000 });
-    return true;
   };
 
   test.beforeAll(async () => {
@@ -58,7 +65,17 @@ test.describe('deep interactive coverage', () => {
     noNewCrashes('home render');
   });
 
+  // The body below still targets the OLD Onboarding panel's top-right "Continue" pill;
+  // OnboardingV3 replaced that surface with a full-screen "Welcome." card (OnboardingV3Root IntroBeat)
+  // whose only control is an ArrowRight icon carrying no text, aria-label, data-onboarding or data-testid
+  // so there is nothing stable to click. launch.ts now seeds onboarding_v3='skipped'
+  // so that modal cannot block the rest of this walkthrough, which also means first-run onboarding
+  // is not exercised here at all.
+  //
+  // TODO: give IntroBeat's button an accessible name, then rewrite this against it;
+  // ideally as its own fresh-profile spec, since this file runs seeded past onboarding.
   test('onboarding panel opens on Continue', async ({}, info) => {
+    test.skip(true, 'OnboardingV3 replaced the Continue pill; its arrow button has no accessible name to target');
     await safeClick(page.getByText(/^Continue/), 'Continue');
     await page.waitForTimeout(2000);
     await page.screenshot({ path: info.outputPath('onboarding-step1.png') });
@@ -66,6 +83,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('roadmap (See all todos) renders all 8 steps', async ({}, info) => {
+    test.skip(true, STALE_UI);
     await safeClick(page.getByText('See all todos'), 'See all todos');
     await page.waitForTimeout(1500);
     await page.screenshot({ path: info.outputPath('onboarding-roadmap.png') });
@@ -75,6 +93,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Settings opens and every tab renders', async ({}, info) => {
+    test.skip(true, STALE_UI);
     await safeClick(page.getByText('Settings', { exact: true }), 'Settings nav');
     await page.waitForTimeout(1500);
     for (const tab of ['General', 'Models', 'Usage', 'Commands']) {
@@ -91,6 +110,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Settings toggles flip + revert (effect verified)', async ({}, info) => {
+    test.skip(true, STALE_UI);
     await safeClick(page.getByText('Settings', { exact: true }), 'Settings nav for toggles');
     await page.waitForTimeout(1500);
     const toggles = page.locator('input[type="checkbox"], [role="switch"]');
@@ -112,6 +132,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Customization: Skills / Actions / Modes render', async ({}, info) => {
+    test.skip(true, STALE_UI);
     for (const screen of ['Skills', 'Actions', 'Modes']) {
       await safeClick(page.getByText(screen, { exact: true }), screen);
       await page.waitForTimeout(1500);
@@ -121,6 +142,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Modes editor (RichPromptEditor) opens without TSF crash', async ({}, info) => {
+    test.skip(true, STALE_UI);
     await safeClick(page.getByText('Modes', { exact: true }), 'Modes');
     await page.waitForTimeout(1200);
     // Modes list may be empty on a brand-new profile; this branch is the one
@@ -139,6 +161,7 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Dashboard canvas opens', async ({}, info) => {
+    test.skip(true, STALE_UI);
     // A clean CI profile has no "Getting Started" (or any) dashboard, so open an
     // existing one if present, else create one via the sidebar "+" so the canvas
     // actually mounts instead of failing on a missing seed dashboard.
@@ -159,7 +182,8 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('New Agent compose box opens (EditorSurface contentEditable mount)', async ({}, info) => {
-    await safeClick(page.getByRole('button', { name: 'New Agent' }) as any, 'New Agent');
+    test.skip(true, STALE_UI);
+    await safeClick(page.getByRole('button', { name: 'New Agent' }), 'New Agent');
     await page.waitForTimeout(2500);
     await page.screenshot({ path: info.outputPath('new-agent-compose.png') });
     noNewCrashes('New Agent compose mount');
@@ -168,14 +192,16 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Browser card mounts (webview path)', async ({}, info) => {
-    await safeClick(page.getByRole('button', { name: 'Browser' }) as any, 'Browser');
+    test.skip(true, STALE_UI);
+    await safeClick(page.getByRole('button', { name: 'Browser' }), 'Browser');
     await page.waitForTimeout(3000);
     await page.screenshot({ path: info.outputPath('browser-card.png') });
     noNewCrashes('Browser card mount (webview)');
   });
 
   test('History panel opens', async ({}, info) => {
-    await safeClick(page.getByRole('button', { name: 'History' }) as any, 'History');
+    test.skip(true, STALE_UI);
+    await safeClick(page.getByRole('button', { name: 'History' }), 'History');
     await page.waitForTimeout(1500);
     await page.screenshot({ path: info.outputPath('history.png') });
     noNewCrashes('History panel mount');
@@ -184,12 +210,76 @@ test.describe('deep interactive coverage', () => {
   });
 
   test('Add App picker opens', async ({}, info) => {
-    await safeClick(page.getByRole('button', { name: 'Add App' }) as any, 'Add App');
+    test.skip(true, STALE_UI);
+    await safeClick(page.getByRole('button', { name: 'Add App' }), 'Add App');
     await page.waitForTimeout(1500);
     await page.screenshot({ path: info.outputPath('add-app-picker.png') });
     noNewCrashes('Add App picker mount');
     await page.keyboard.press('Escape').catch(() => {});
     await page.waitForTimeout(500);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rewritten against surfaces the app actually renders today. The tests above
+  // were written for an earlier UI generation: a DOM dump of the running app found
+  // ZERO of their sixteen targets present (no sidebar nav, no Settings/Skills/
+  // Actions/Modes text, no New Agent / Browser / History / Add App buttons, and
+  // only 4 of ~25 data-onboarding values from frontend Onboarding/selectors.ts).
+  //
+  // Each test below asserts an observable STATE CHANGE, not "a screenshot was taken"
+  // and not "the renderer survived" -- so each one can name something the app could
+  // do wrong that would turn it red.
+  // ---------------------------------------------------------------------------
+
+  test('What\'s-new panel dismisses when Got it is clicked', async () => {
+    const panel = page.locator('[data-select-type="whats-new"]');
+    await expect(panel, 'what\'s-new panel should be on screen for a fresh profile').toBeVisible({ timeout: TARGET_TIMEOUT_MS });
+    await safeClick(page.getByRole('button', { name: 'Got it' }), 'Got it');
+    // The point of the button: the panel goes away and stays away.
+    await expect(panel, 'panel still visible after Got it').toBeHidden({ timeout: 10_000 });
+    noNewCrashes('whats-new dismiss');
+  });
+
+  test('canvas zoom controls change the zoom readout', async () => {
+    const controls = page.locator('[data-onboarding="canvas-controls"]');
+    await expect(controls, 'canvas control cluster missing').toBeVisible({ timeout: TARGET_TIMEOUT_MS });
+    const before = (await controls.innerText()).trim();
+    await safeClick(page.getByRole('button', { name: 'Zoom in' }), 'Zoom in');
+    // Zooming has to be observable somewhere. The cluster carries the % readout, so
+    // its text must differ; an inert button leaves it identical and fails here.
+    await expect
+      .poll(async () => (await controls.innerText()).trim(), { timeout: 10_000, message: 'zoom readout unchanged after Zoom in' })
+      .not.toBe(before);
+    noNewCrashes('canvas zoom in');
+  });
+
+  // Deliberately LAST of the live tests. This one currently fails, and in serial mode a
+  // failure buries everything after it -- so it sits where it can only cost itself.
+  //
+  // It is NOT failing on a stale selector. Playwright resolves the button, reports it
+  // "visible, enabled and stable", completes a scrollIntoView, and still reports
+  // "element is outside of the viewport" on every retry. The dashboard strip scrolls
+  // horizontally (see the Scroll spaces left/right controls), so the control is real,
+  // labelled, and unreachable by ordinary scrolling.
+  //
+  // TODO: decide which of these it is, then act.
+  //   a) APP BUG -- if the spaces strip scrolls by CSS transform rather than native
+  //      scrollTop/scrollLeft, the browser cannot bring the button into view and neither
+  //      can a keyboard user tabbing to it. Fix the strip, and this test goes green on
+  //      its own with no edit here.
+  //   b) TEST GAP -- if the strip IS natively scrollable, drive "Scroll spaces right"
+  //      until the button enters the viewport, then click. Assert the scroll happened so
+  //      the loop cannot silently spin forever.
+  test('New dashboard navigates to a different dashboard', async () => {
+    const before = page.url();
+    await safeClick(page.getByRole('button', { name: 'New dashboard' }), 'New dashboard');
+    // A new board means a new route. Asserting the URL CHANGED (not merely that it
+    // still looks like a dashboard URL) is what makes this fail if the button is inert.
+    await expect
+      .poll(() => page.url(), { timeout: 15_000, message: 'URL never changed after New dashboard' })
+      .not.toBe(before);
+    expect(page.url(), 'left the dashboard route entirely').toMatch(/\/dashboard\//);
+    noNewCrashes('new dashboard');
   });
 
   test('zero new renderer-gone-lines across the entire walkthrough', () => {

--- a/e2e/tests/deep-coverage.spec.ts
+++ b/e2e/tests/deep-coverage.spec.ts
@@ -60,13 +60,8 @@ test.describe('deep interactive coverage', () => {
 
   test.afterAll(async () => { await app?.close().catch(() => {}); });
 
-  test('home renders a usable dashboard', async ({}, info) => {
+  test('home renders the dashboard canvas shell', async ({}, info) => {
     await expect(page.locator('[data-onboarding="canvas-controls"]'), 'canvas controls never mounted')
-      .toBeVisible({ timeout: TARGET_TIMEOUT_MS });
-    // Playwright matches accessible names by substring, so a
-    // bare 'Send' also matches the "Send an agent to the web" suggestion chip
-    // and `exact: true` rejects the ambiguity.
-    await expect(page.getByRole('button', { name: 'Send', exact: true }), 'composer Send button never mounted')
       .toBeVisible({ timeout: TARGET_TIMEOUT_MS });
     await page.screenshot({ path: info.outputPath('home.png') });
     noNewCrashes('home render');

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -608,22 +608,25 @@ cd "$PROJECT_ROOT/electron"
 # npm ci: lockfile-exact, no drift. See frontend note above.
 npm ci
 
-# macOS mouse-clamp native addon: compile both arches into build-staging/mouseclamp/<arch>
-# so extraResources (mouseclamp/${arch}) is populated whichever target gets packed.
-# Cheap (~2s each); fails the build loudly if a slice can't compile rather than
-# silently shipping the crash. macOS-only.
+# macOS native addons: compile each into build-staging/<addon>/<arch> so
+# extraResources (<addon>/${arch}) is populated for whichever target gets packed.
+# Cheap (~2s each for mouseclamp/haptics/fn-watcher); fails the build loudly if a
+# slice can't compile rather than silently shipping the crash. macOS-only.
+#
+# Build only the arches this run packs (BUILD_ARCHS, top of file). electron-builder
+# resolves ${arch} to the packed arch, so the other slice is never read — building it
+# is wasted work and an extra failure surface: cross-building arm64 from an x86_64
+# host trips ggml's -mcpu=native (build-whisper.sh guards this for the x64 slice with
+# GGML_NATIVE=OFF, but the arm64 branch has no equivalent). Dual-arch publish runs
+# still build both, since that path sets BUILD_ARCHS=(arm64 x64).
 if [[ "$(uname)" == "Darwin" ]]; then
-    echo "Building mouse-clamp native addon (arm64 + x64)..."
-    bash scripts/build-mouseclamp.sh arm64
-    bash scripts/build-mouseclamp.sh x64
-    bash scripts/build-haptics.sh arm64
-    bash scripts/build-haptics.sh x64
-    echo "Building whisper-server for dictation (arm64 + x64)..."
-    bash scripts/build-whisper.sh arm64
-    bash scripts/build-whisper.sh x64
-    echo "Building fn-watcher for dictation's fn key (arm64 + x64)..."
-    bash scripts/build-fn-watcher.sh arm64
-    bash scripts/build-fn-watcher.sh x64
+    echo "Building macOS native addons (${BUILD_ARCHS[*]})..."
+    for A in "${BUILD_ARCHS[@]}"; do
+        bash scripts/build-mouseclamp.sh "$A"
+        bash scripts/build-haptics.sh "$A"
+        bash scripts/build-whisper.sh "$A"
+        bash scripts/build-fn-watcher.sh "$A"
+    done
 fi
 
 # Node's default ~4 GB heap OOMs while codesign'ing the .app on dual-arch


### PR DESCRIPTION
### What I'm doing

- Added a macOS Intel leg to the e2e workflow, 
- Reordered some of the build steps so a failed MCP selftest does not stop e2e suite from running
- Got both legs to actually report a verdict, and replaced the parts of `deep-coverage.spec.ts` that could not fail with tests that can
- Added trigger for e2e tests against the right branch 


### Testing & Deployment strategy

**Which OSes are green:** neither. Both now *report* identically though, which they didn't before.

*(passed / failed / skipped / did not run)*

| | Windows | macOS Intel |
|---|---|---|
| before | 16 / 3 / 16 / 34 | *did not exist* |
| after | 18 / 3 / 27 / 24 | 18 / 3 / 27 / 24 |

The 3️⃣  failed tests are red on purpose, not unfinished - reasoning documented in comments. 

- **Before:** [run 34160936083](https://github.com/chuyaguo2014/openswarm/actions/runs/34160936083) — sha `d2974920`, where `e2e/` was still byte-identical to `eric/dev`
- **After:** [run 34171626254](https://github.com/chuyaguo2014/openswarm/actions/runs/34171626254) — sha `951dc4ca`

**How many tests can fail now versus before:**

| | before | after |
|---|---|---|
| rendering a verdict | 19 | **21** |
| buried by serial cascade | 34 | **24** |
| skipped with a stated reason | 0 | 11 |
| `deep-coverage` tests asserting a state change | **0** | **4** |


To verify the baseline is correct yourself:

```
git diff d2974920 951dc4ca -- e2e/          # every suite change between the two runs
gh run download 34160936083 --repo chuyaguo2014/openswarm -n e2e-results-mac -D before/
gh run download 34171626254  --repo chuyaguo2014/openswarm -n e2e-results-mac -D after/
jq '.stats' before/results.json after/results.json
```

### Alternate approaches considered

- **Deleting the stale tests instead of skipping them.** Skipping keeps the lost coverage visible in the run report and in `results.json`; a deletion is invisible six months from now.
- **Rewriting all 13 `deep-coverage` tests against current UI.** The right end state, but the file targets a UI generation that no longer exists - that's a rewrite and needs someone who knows which surfaces are intended to be permanent.
- **Not seeding past onboarding, and driving the V3 modal instead.** Its only control is an `ArrowRight` icon with no accessible name - there is nothing stable to click.

### I'm leaving this for a future PR

Left several `TODO` in comments in the code; additionally, we should also consider:

1. **First-run onboarding is untestable rigth now.** `OnboardingV3Root`'s `IntroBeat` button has no text, `aria-label`, `data-onboarding`, or `data-testid`. That's also an accessibility defect - a screen reader announces nothing. 

2. **Serial mode still buries a lot.** One failure skips everything behind it. Splitting the specs, or accepting the cost of a fresh app per test, would make the suite report on all 72.

3. Go through the rest of the E2E tests like I did for `deep-coverage`. And also probably add more tests in general because the suite in general feels very light. 

### Additional issues found along the way:

- The MCP selftest times out on Windows only; it passes on the mac leg.
- the app build step can take up to 25 minutes for mac - maybe consider more caching to save time if possible?
- `build-whisper.sh`'s arm64 branch has no `GGML_NATIVE=OFF`, unlike the x64 branch. 
- `cmake` (and Homebrew `gettext`, for DMG packaging) are undocumented build prerequisites. The dmg was unnecessary for e2e build anyways on a map. A `--dir` flag on `build-app.sh` (mirroring `build-app-win.ps1 -DirOnly`), would let dev and CI skip DMG packaging entirely.

---

*Worked this through with Claude Code 🤖 *
